### PR TITLE
fixed translation database bug in create method

### DIFF
--- a/server/crud/base.py
+++ b/server/crud/base.py
@@ -184,19 +184,23 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         except:
             pass
 
-        db_obj = self.model(**{**obj_in_data, 'shop_id': shop_id})
-        db.session.add(db_obj)
-        db.session.commit()
-        db.session.refresh(db_obj)
+        try:
+            db_obj = self.model(**{**obj_in_data, 'shop_id': shop_id})
+            db.session.add(db_obj)
+            db.session.flush()
 
-        if translation_data:
-            translation_name = db_obj.__class__.__name__.split("Table")[0]
-            translation_model = globals().get(translation_name + "Translation", None)
-            translation_data[translation_name.lower() + "_id"] = db_obj.id
-            translation = translation_model(**translation_data)
-            db.session.add(translation)
-            db.session.commit()
-            db.session.refresh(translation)
+            if translation_data:
+                translation_name = db_obj.__class__.__name__.split("Table")[0]
+                translation_model = globals().get(translation_name + "Translation", None)
+                translation_data[translation_name.lower() + "_id"] = db_obj.id
+                translation = translation_model(**translation_data)
+                db.session.add(translation)
+                db.session.commit()
+                db.session.refresh(db_obj)
+                db.session.refresh(translation)
+        except:
+            db.session.rollback()
+            raise
 
         return db_obj
 


### PR DESCRIPTION
Due to this bug, products/categories/tags would be added to the database, even if an error occured with the translation object, resulting in products/categories/tags without any translation. This also caused the tables in the frontend to not show anything.

This commit fixes that by introducing a rollback should an error occur in the translation object.