### PR TITLE
migration to populate new_product field and logo image in config

### DIFF
--- a/migrations/versions/schema/2024-10-24_757168fc0571_populate_new_product_fields.py
+++ b/migrations/versions/schema/2024-10-24_757168fc0571_populate_new_product_fields.py
@@ -1,0 +1,25 @@
+"""populate new_product fields.
+
+Revision ID: 757168fc0571
+Revises: 35a9b4add7a2
+Create Date: 2024-10-24 13:02:50.233499
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '757168fc0571'
+down_revision = '35a9b4add7a2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("""UPDATE products SET new_product=false"""))
+
+
+def downgrade() -> None:
+    pass

--- a/migrations/versions/schema/2024-10-24_757168fc0571_populate_new_product_fields.py
+++ b/migrations/versions/schema/2024-10-24_757168fc0571_populate_new_product_fields.py
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '757168fc0571'
-down_revision = '35a9b4add7a2'
+revision = "757168fc0571"
+down_revision = "35a9b4add7a2"
 branch_labels = None
 depends_on = None
 

--- a/server/schemas/shop.py
+++ b/server/schemas/shop.py
@@ -145,6 +145,7 @@ class ConfigurationHomepageSections(BoilerplateBaseModel):
 
 class ConfigurationV1(BoilerplateBaseModel):
     short_shop_name: str
+    logo: str
     main_banner: str
     alt1_banner: str | None = None
     alt2_banner: str | None = None

--- a/tests/unit_tests/api/test_shops.py
+++ b/tests/unit_tests/api/test_shops.py
@@ -179,6 +179,7 @@ def test_shop_create_config(test_client, shop):
             "main_banner": "string",
             "alt1_banner": "string",
             "alt2_banner": "string",
+            "logo": "string",
             "languages": {
                 "main": {
                     "language_name": "string",
@@ -281,6 +282,7 @@ def test_shop_update_config(test_client, shop_with_config):
             "main_banner": "string",
             "alt1_banner": "string",
             "alt2_banner": "string",
+            "logo": "string",
             "languages": {
                 "main": {
                     "language_name": "string",

--- a/tests/unit_tests/factories/shop.py
+++ b/tests/unit_tests/factories/shop.py
@@ -69,6 +69,7 @@ def make_shop(
             main_banner="string",
             alt1_banner="string",
             alt2_banner="string",
+            logo="string",
             contact=config_contact,
             homepage_sections=homepage_sections,
         )


### PR DESCRIPTION
adds migration to populate the new new_product field, defaults all to false.

also updates config to include link to a logo. Add this line to config on the same level as the banner images:

```
"logo": "51799a20-6a7c-4867-9545-fed56051a203/logo.png",
```