### PR TITLE
removed amount field on products-to-tags schema

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ uvicorn[standard]~=0.29.0
 itsdangerous
 pydantic-forms
 pydantic-settings~=2.4.0
-python-multipart
+python-multipart==0.0.12
 wheel
 stripe==10.7.0
 phonenumbers==8.13.45

--- a/server/schemas/product_to_tag.py
+++ b/server/schemas/product_to_tag.py
@@ -21,7 +21,6 @@ class ProductToTagBase(BoilerplateBaseModel):
     product_id: UUID
     tag_id: UUID
     shop_id: UUID
-    amount: int
 
 
 # Properties to receive via API on creation


### PR DESCRIPTION
Removes leftover 'amount' field on products-to-tags schema, was already removed from db model.