### PR TITLE
Add launch script for apprunner

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+pip3 install -r requirements/base.txt
+python3 -m uvicorn server.main:app --port 8000 --host 0.0.0.0


### PR DESCRIPTION
Needed to replace pre-run / start_command in your setup with a script since terraform does not have an option to configure it 🤔

Once we are fully switched over, we should clean up a lot of the apprunner/deployment related files.