### PR TITLE
expanded upon pydantic forms using test endpoint

### DIFF
--- a/server/api/api.py
+++ b/server/api/api.py
@@ -26,6 +26,7 @@ from server.api.endpoints import (
     login,
     sentry_test,
     shops,
+    test_forms,
     users,
 )
 from server.api.endpoints.shop_endpoints import (
@@ -143,6 +144,11 @@ api_router.include_router(
     sentry_test.router,
     prefix="/sentry",
     tags=["sentry"],
+)
+api_router.include_router(
+    test_forms.router,
+    prefix="/test-forms",
+    tags=["test-forms"],
 )
 
 # api_router.include_router(

--- a/server/api/endpoints/shop_endpoints/info_request.py
+++ b/server/api/endpoints/shop_endpoints/info_request.py
@@ -1,12 +1,11 @@
 from http import HTTPStatus
-from typing import Annotated, Any, ClassVar
+from typing import Any, ClassVar
 from uuid import UUID
 
 import structlog
 from fastapi import APIRouter, HTTPException
-from fastapi.exceptions import RequestValidationError
 from fastapi.param_functions import Body
-from pydantic import ConfigDict, EmailStr, ValidationError
+from pydantic import ConfigDict, EmailStr
 from pydantic_forms.core import FormPage
 from pydantic_forms.core import FormPage as PydanticFormsFormPage
 from pydantic_forms.core import post_form

--- a/server/api/endpoints/test_forms.py
+++ b/server/api/endpoints/test_forms.py
@@ -5,6 +5,7 @@ import structlog
 from annotated_types import Ge, Le, MultipleOf, Predicate
 from fastapi import APIRouter
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic_extra_types.phone_numbers import PhoneNumber
 from pydantic_forms.core import FormPage
 from pydantic_forms.core import FormPage as PydanticFormsFormPage
 from pydantic_forms.core import post_form
@@ -42,9 +43,11 @@ class ListChoices(Choice):
     _4 = ("4", "Option 4")
     _5 = ("5", "Option 5")
     _6 = ("6", "Option 6")
+    _7 = ("7", "Option 7")
+    _8 = ("8", "Option 8")
 
 
-TestString = Annotated[str, Field(min_length=2, max_length=10)]
+TestString = Annotated[str, Field(min_length=2, max_length=50)]
 
 
 class Education(BaseModel):
@@ -67,14 +70,15 @@ async def form(form_data: list[dict] = []):
             email: EmailStr
             number: int
             check: bool
-            # textList: unique_conlist(TestString, min_items=1, max_items=5)
-            # numberList: TestExampleNumberList
             select: ListChoices
+            radio: ListChoices
+            multi: ListChoices
+            phone: PhoneNumber
+            textarea: TestString
 
         form_data_email = yield TestForm
 
         class SecondForm(FormPage):
-            # todo; check if it works without a title.
             discover_date: datetime
             people: list[Person]
             singular_person: Person

--- a/server/api/endpoints/test_forms.py
+++ b/server/api/endpoints/test_forms.py
@@ -1,9 +1,10 @@
+from datetime import datetime
 from typing import Annotated, ClassVar
 
 import structlog
-from annotated_types import Predicate
+from annotated_types import Ge, Le, MultipleOf, Predicate
 from fastapi import APIRouter
-from pydantic import ConfigDict, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 from pydantic_forms.core import FormPage
 from pydantic_forms.core import FormPage as PydanticFormsFormPage
 from pydantic_forms.core import post_form
@@ -46,6 +47,11 @@ class ListChoices(Choice):
 TestString = Annotated[str, Field(min_length=2, max_length=10)]
 
 
+class Education(BaseModel):
+    degree: str
+    years: int | None
+
+
 class Person(BaseModel):
     name: str
     age: Annotated[int, Ge(18), Le(99), MultipleOf(multiple_of=3)]
@@ -70,11 +76,11 @@ async def form(form_data: list[dict] = []):
         class SecondForm(FormPage):
             # todo; check if it works without a title.
             discover_date: datetime
-            names: list[str]
-            persons: list[Person]
+            people: list[Person]
+            singular_person: Person
 
         form_second = yield SecondForm
 
-        return form_data_email.model_dump()
+        return form_data_email.model_dump() | form_second.model_dump()
 
     post_form(form_generator, state={}, user_inputs=form_data)

--- a/server/api/endpoints/test_forms.py
+++ b/server/api/endpoints/test_forms.py
@@ -1,0 +1,66 @@
+from typing import Annotated, ClassVar
+
+import structlog
+from annotated_types import Predicate
+from fastapi import APIRouter
+from pydantic import ConfigDict, EmailStr, Field
+from pydantic_forms.core import FormPage
+from pydantic_forms.core import FormPage as PydanticFormsFormPage
+from pydantic_forms.core import post_form
+from pydantic_forms.types import JSON, State
+from pydantic_forms.validators import Choice, unique_conlist
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+class FormPage(PydanticFormsFormPage):
+    meta__: ClassVar[JSON] = {"hasNext": True}
+
+
+class SubmitFormPage(FormPage):
+    meta__: ClassVar[JSON] = {"hasNext": False}
+
+
+def example_list_validation(val: int) -> bool:
+    return True
+
+
+TestExampleNumberList = Annotated[
+    unique_conlist(int, min_items=2, max_items=5),
+    Predicate(example_list_validation),
+]
+
+
+class ListChoices(Choice):
+    _0 = ("0", "Option 0")
+    _1 = ("1", "Option 1")
+    _2 = ("2", "Option 2")
+    _3 = ("3", "Option 3")
+    _4 = ("4", "Option 4")
+    _5 = ("5", "Option 5")
+    _6 = ("6", "Option 6")
+
+
+TestString = Annotated[str, Field(min_length=2, max_length=10)]
+
+
+@router.post("/")
+async def form(form_data: list[dict] = []):
+    def form_generator(state: State):
+        class TestForm(FormPage):
+            model_config = ConfigDict(title="Form Title Page 1")
+
+            email: EmailStr
+            number: int
+            check: bool
+            # textList: unique_conlist(TestString, min_items=1, max_items=5)
+            # numberList: TestExampleNumberList
+            select: ListChoices
+
+        form_data_email = yield TestForm
+
+        return form_data_email.model_dump()
+
+    post_form(form_generator, state={}, user_inputs=form_data)

--- a/tests/unit_tests/api/test_authentication.py
+++ b/tests/unit_tests/api/test_authentication.py
@@ -18,6 +18,7 @@ EXCLUDED_ENDPOINTS = [
     {"path": "/shops/{shop_id}/stripe/subscription", "name": "create_subscription_intent", "method": "POST"},
     {"path": "/info-request/", "name": "create_info_request", "method": "POST"},
     {"path": "/sentry/", "name": "trigger_error", "method": "GET"},
+    {"path": "/test-forms/", "name": "form", "method": "POST"},
 ]
 
 


### PR DESCRIPTION
Expands upon previous pydantic forms implementation. New endpoint created for testing forms. Includes Number, Enum (Select in frontend), and boolean fields, as well as numberlist and textlist (currently commented since no frontend styling is available yet).