### PR TITLE
set product modified_at on update

### DIFF
--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import Any, List, Optional
 from uuid import UUID
@@ -113,6 +114,8 @@ def update(*, product_id: UUID, shop_id: UUID, item_in: ProductUpdate) -> Any:
     logger.info("Updating product", data=product)
     if not product:
         raise HTTPException(status_code=404, detail="Product not found")
+
+    item_in.modified_at = datetime.now(timezone.utc)
 
     product = product_crud.update(
         db_obj=product,


### PR DESCRIPTION
Should be noted that I originally fixed this by updating the Product database model, altering the modified_at field to match the created_at and completed_at fields found in the order table, but with an (server_)onupdate included. This worked to an extent, but not for any of the fields in the translation object; modifying those did not trigger the onupdate, since it doesn't work on "child objects", i.e. tables with a one-to-one relation.

Hence why this PR fixes the issue by setting it in the Product Update endpoint, and keeps the modified_at field present in the ProductUpdate schema. The frontend simply has it's modified_at removed from the payload, and even if it is present, the backend will overwrite it