### PR TITLE
Add MCP server, CLI tool, and fix CI pipeline

### DIFF
--- a/.github/workflows/run-linting-tests.yml
+++ b/.github/workflows/run-linting-tests.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: [3.11]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,5 @@ dmypy.json
 .DS_Store
 
 #stage
-pricelist_prod.psql
+*.psql
 config.env
-shop.psql

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,11 @@ PYTHONPATH=. alembic revision --autogenerate -m "Description"
 
 # Create data migration (DML)
 PYTHONPATH=. alembic revision --message "Description"
+
+# CLI (requires running API server)
+python cli.py shops list
+python cli.py products list <shop-id>
+python cli.py --help
 ```
 
 Line length: **120** (configured in `pyproject.toml` for both black and isort).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ShopVirge Backend — a FastAPI REST API for managing shop data (products, categories, orders, attributes) with PostgreSQL. Python 3.10+, targets 3.11 in CI/Docker.
+
+## Common Commands
+
+All commands require `PYTHONPATH=.` prefix.
+
+```bash
+# Install dependencies
+pip install -r requirements/all.txt
+
+# Run dev server (hot reload)
+PYTHONPATH=. uvicorn server.main:app --reload --port 8080
+
+# Run all tests
+PYTHONPATH=. pytest tests/unit_tests
+
+# Run a single test file
+PYTHONPATH=. pytest tests/unit_tests/api/test_shops.py
+
+# Run a single test
+PYTHONPATH=. pytest tests/unit_tests/api/test_shops.py::test_get_shops -v
+
+# Run tests with coverage
+PYTHONPATH=. pytest --cov-branch --cov=server tests/unit_tests
+
+# Lint (check only, as CI runs it)
+isort -c .
+black --check .
+
+# Format
+isort .
+black .
+
+# Apply all DB migrations
+PYTHONPATH=. alembic upgrade heads
+
+# Create schema migration (DDL)
+PYTHONPATH=. alembic revision --autogenerate -m "Description"
+
+# Create data migration (DML)
+PYTHONPATH=. alembic revision --message "Description"
+```
+
+Line length: **120** (configured in `pyproject.toml` for both black and isort).
+
+## Architecture
+
+**Three-layer pattern:** API endpoints → CRUD classes → SQLAlchemy models
+
+### Key directories
+- `server/api/endpoints/` — top-level endpoints (login, users, health, images, etc.)
+- `server/api/endpoints/shop_endpoints/` — shop-scoped endpoints (`/shops/{shop_id}/...`)
+- `server/crud/` — CRUD layer; each model has a `crud_<model>.py` with a `CRUDBase` subclass
+- `server/db/models.py` — all SQLAlchemy ORM models (single file)
+- `server/schemas/` — Pydantic request/response models
+- `server/api/api.py` — central router that registers all sub-routers
+- `server/api/deps.py` — FastAPI dependency injection (auth, pagination via `common_parameters`)
+- `server/settings.py` — all config via `pydantic-settings` (`AppSettings`, `AuthSetting`, `MailSettings`)
+- `migrations/versions/schema/` — DDL migrations; `migrations/versions/general/` — data migrations
+
+### Important patterns
+
+**Shop isolation:** Most resources carry a `shop_id` FK. Endpoints are scoped as `/shops/{shop_id}/...` and queries always filter by shop.
+
+**Translation tables:** Content models (Product, Category, Tag, Attribute) use separate `*TranslationTable` with `main_name`, `alt1_name`, `alt2_name` for multi-language support. CRUD operations handle creating/updating/deleting translations alongside the main model.
+
+**CRUDBase generic:** `server/crud/base.py` provides `CRUDBase[ModelType, CreateSchemaType, UpdateSchemaType]` with standard methods (`get`, `get_multi`, `get_multi_by_shop_id`, `create`, `create_by_shop_id`, `update`, `delete`, `delete_by_shop_id`). Per-model CRUD classes extend this.
+
+**Database session:** `DBSessionMiddleware` creates a scoped session per request. The `db` proxy object in `server/db/__init__.py` wraps the actual `Database`, allowing late initialization and test overrides.
+
+**Transactional context manager:** Use `transactional(db, logger)` from `server.db.database` for atomic operations:
+```python
+from server.db import transactional
+from structlog import get_logger
+logger = get_logger(__name__)
+with transactional(db, logger):
+    # atomic operations here
+```
+
+**Pagination/filtering/sorting:** List endpoints use the `common_parameters` dependency. Filter format: `key:value`. Sort format: `col:ASC` or `col:DESC`. Responses include `Content-Range` header.
+
+**Error handling:** `ProblemDetailException` and `raise_status()` in `server/api/error_handling.py` for RFC 7807-style error responses.
+
+**Dual auth:**
+- **AWS Cognito JWT** (primary, most endpoints): via `auth_required` dependency in `server/security.py`
+- **Local JWT** (legacy login endpoint): OAuth2 password flow via `/login/access-token`, decoded in `server/api/deps.py`
+- Roles: `admin` (superuser) and `employee` checked via `is_superuser`/`is_employee` properties on `UserTable`
+
+## Naming Conventions
+
+- SQLAlchemy models: `PascalCase` with `Table` suffix (e.g., `ProductTable`, `CategoryTable`) — some legacy models omit it (`Account`, `License`)
+- CRUD classes: `CRUD<ModelName>`, instances: `<model_name>_crud`
+- Pydantic schemas: `PascalCase` without `Table` suffix
+- API JSON fields: `snake_case`
+
+## Testing
+
+- Tests in `tests/unit_tests/` using pytest with FastAPI `TestClient`
+- Fixtures and factories in `tests/unit_tests/conftest.py` and `tests/unit_tests/factories/`
+- Each test session creates a clean database by running all migrations
+- Cognito auth is overridden in tests with a fake `CognitoToken`
+- Requires a `shop-test` PostgreSQL database (default: `postgresql://shop:shop@localhost/shop-test`)
+
+## Database Setup
+
+PostgreSQL required with UUID extension:
+```bash
+createuser -sP shop          # password: shop
+createdb shop -O shop
+createdb shop-test -O shop   # for tests
+```
+
+## Configuration
+
+All config via environment variables (see `server/settings.py`). FastAPI auto-loads `.env` file. Key vars: `DATABASE_URI`, `SESSION_SECRET`, `TESTING`, `AWS_COGNITO_*`, `S3_BUCKET_*`.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,443 @@
+"""
+CLI for the ShopVirge Backend API.
+
+Provides command-line access to shops, products, categories, tags,
+attributes, and orders.
+
+Usage:
+    # Start the API server first:
+    PYTHONPATH=. uvicorn server.main:app --reload --port 8080
+
+    # Then use the CLI:
+    python cli.py shops list
+    python cli.py shops get <shop-id>
+    python cli.py products list <shop-id>
+    python cli.py orders list
+
+Environment variables:
+    SHOP_API_BASE_URL  - Base URL of the running API (default: http://localhost:8080)
+    SHOP_API_TOKEN     - Optional JWT token for authenticated endpoints
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Optional, Union
+
+import httpx
+import typer
+
+API_BASE_URL = os.environ.get("SHOP_API_BASE_URL", "http://localhost:8080")
+API_TOKEN = os.environ.get("SHOP_API_TOKEN", "")
+
+app = typer.Typer(help="ShopVirge Backend CLI")
+shops_app = typer.Typer(help="Manage shops")
+products_app = typer.Typer(help="Manage products")
+categories_app = typer.Typer(help="Manage categories")
+tags_app = typer.Typer(help="Manage tags")
+attributes_app = typer.Typer(help="Manage attributes")
+orders_app = typer.Typer(help="Manage orders")
+health_app = typer.Typer(help="Health checks")
+
+app.add_typer(shops_app, name="shops")
+app.add_typer(products_app, name="products")
+app.add_typer(categories_app, name="categories")
+app.add_typer(tags_app, name="tags")
+app.add_typer(attributes_app, name="attributes")
+app.add_typer(orders_app, name="orders")
+app.add_typer(health_app, name="health")
+
+
+# --- HTTP helper ---
+
+
+def _headers() -> dict:
+    headers = {}
+    if API_TOKEN:
+        headers["Authorization"] = f"Bearer {API_TOKEN}"
+    return headers
+
+
+def _api(method: str, path: str, params: Optional[dict] = None, json_body: Optional[dict] = None):
+    """Make an HTTP request to the ShopVirge API and return parsed JSON."""
+    url = f"{API_BASE_URL}/api{path}"
+    if params:
+        params = {k: v for k, v in params.items() if v is not None}
+
+    try:
+        response = httpx.request(method, url, params=params, json=json_body, headers=_headers(), timeout=30.0)
+    except httpx.ConnectError:
+        typer.echo(f"Error: Cannot connect to API at {API_BASE_URL}. Is the server running?", err=True)
+        raise typer.Exit(1)
+    except httpx.TimeoutException:
+        typer.echo(f"Error: Request timed out: {method} {url}", err=True)
+        raise typer.Exit(1)
+
+    if response.status_code == 204:
+        return {"status": "deleted"}
+
+    try:
+        data = response.json()
+    except Exception:
+        data = response.text
+
+    if response.status_code >= 400:
+        typer.echo(f"Error {response.status_code}: {json.dumps(data, indent=2, default=str)}", err=True)
+        raise typer.Exit(1)
+
+    return data
+
+
+def _print(data):
+    """Pretty-print JSON data."""
+    typer.echo(json.dumps(data, indent=2, default=str))
+
+
+# =============================================================================
+# HEALTH
+# =============================================================================
+
+
+@health_app.command("check")
+def health_check():
+    """Check if the API is running."""
+    _print(_api("GET", "/health/"))
+
+
+# =============================================================================
+# SHOPS
+# =============================================================================
+
+
+@shops_app.command("list")
+def shops_list(
+    skip: int = typer.Option(0, help="Number of records to skip"),
+    limit: int = typer.Option(20, help="Max records to return"),
+):
+    """List all shops."""
+    _print(_api("GET", "/shops/", params={"skip": skip, "limit": limit}))
+
+
+@shops_app.command("get")
+def shops_get(shop_id: str = typer.Argument(..., help="Shop UUID")):
+    """Get details of a specific shop."""
+    _print(_api("GET", f"/shops/{shop_id}"))
+
+
+@shops_app.command("create")
+def shops_create(
+    name: str = typer.Option(..., help="Shop name"),
+    description: str = typer.Option(..., help="Shop description"),
+    vat_standard: float = typer.Option(21.0, help="Standard VAT rate"),
+    vat_lower_1: float = typer.Option(9.0, help="Lower VAT rate 1"),
+    vat_lower_2: float = typer.Option(0.0, help="Lower VAT rate 2"),
+    vat_lower_3: float = typer.Option(0.0, help="Lower VAT rate 3"),
+    vat_special: float = typer.Option(0.0, help="Special VAT rate"),
+    vat_zero: float = typer.Option(0.0, help="Zero VAT rate"),
+):
+    """Create a new shop."""
+    body = {
+        "name": name,
+        "description": description,
+        "vat_standard": vat_standard,
+        "vat_lower_1": vat_lower_1,
+        "vat_lower_2": vat_lower_2,
+        "vat_lower_3": vat_lower_3,
+        "vat_special": vat_special,
+        "vat_zero": vat_zero,
+    }
+    _print(_api("POST", "/shops/", json_body=body))
+
+
+@shops_app.command("update")
+def shops_update(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    name: str = typer.Option(..., help="Shop name"),
+    description: str = typer.Option(..., help="Shop description"),
+    vat_standard: float = typer.Option(21.0, help="Standard VAT rate"),
+    vat_lower_1: float = typer.Option(9.0, help="Lower VAT rate 1"),
+    vat_lower_2: float = typer.Option(0.0, help="Lower VAT rate 2"),
+    vat_lower_3: float = typer.Option(0.0, help="Lower VAT rate 3"),
+    vat_special: float = typer.Option(0.0, help="Special VAT rate"),
+    vat_zero: float = typer.Option(0.0, help="Zero VAT rate"),
+):
+    """Update an existing shop."""
+    body = {
+        "name": name,
+        "description": description,
+        "vat_standard": vat_standard,
+        "vat_lower_1": vat_lower_1,
+        "vat_lower_2": vat_lower_2,
+        "vat_lower_3": vat_lower_3,
+        "vat_special": vat_special,
+        "vat_zero": vat_zero,
+    }
+    _print(_api("PUT", f"/shops/{shop_id}", json_body=body))
+
+
+@shops_app.command("delete")
+def shops_delete(shop_id: str = typer.Argument(..., help="Shop UUID")):
+    """Delete a shop."""
+    _print(_api("DELETE", f"/shops/{shop_id}"))
+
+
+# =============================================================================
+# PRODUCTS
+# =============================================================================
+
+
+@products_app.command("list")
+def products_list(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    skip: int = typer.Option(0, help="Number of records to skip"),
+    limit: int = typer.Option(20, help="Max records to return"),
+):
+    """List products for a shop."""
+    _print(_api("GET", f"/shops/{shop_id}/products/", params={"skip": skip, "limit": limit}))
+
+
+@products_app.command("get")
+def products_get(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    product_id: str = typer.Argument(..., help="Product UUID"),
+):
+    """Get details of a specific product."""
+    _print(_api("GET", f"/shops/{shop_id}/products/{product_id}"))
+
+
+@products_app.command("create")
+def products_create(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    category_id: str = typer.Option(..., help="Category UUID"),
+    main_name: str = typer.Option(..., help="Product name (main language)"),
+    main_description: str = typer.Option(..., help="Product description (main language)"),
+    main_description_short: str = typer.Option(..., help="Short description (main language)"),
+    price: Optional[float] = typer.Option(None, help="Product price"),
+    tax_category: str = typer.Option("vat_standard", help="Tax category"),
+    stock: int = typer.Option(1, help="Stock count"),
+    featured: bool = typer.Option(False, help="Mark as featured"),
+    shippable: bool = typer.Option(False, help="Product is shippable"),
+):
+    """Create a new product in a shop."""
+    body = {
+        "shop_id": shop_id,
+        "category_id": category_id,
+        "price": price,
+        "tax_category": tax_category,
+        "stock": stock,
+        "featured": featured,
+        "shippable": shippable,
+        "max_one": False,
+        "new_product": False,
+        "translation": {
+            "main_name": main_name,
+            "main_description": main_description,
+            "main_description_short": main_description_short,
+        },
+    }
+    _print(_api("POST", f"/shops/{shop_id}/products/", json_body=body))
+
+
+@products_app.command("delete")
+def products_delete(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    product_id: str = typer.Argument(..., help="Product UUID"),
+):
+    """Delete a product from a shop."""
+    _print(_api("DELETE", f"/shops/{shop_id}/products/{product_id}"))
+
+
+# =============================================================================
+# CATEGORIES
+# =============================================================================
+
+
+@categories_app.command("list")
+def categories_list(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    skip: int = typer.Option(0, help="Number of records to skip"),
+    limit: int = typer.Option(20, help="Max records to return"),
+):
+    """List categories for a shop."""
+    _print(_api("GET", f"/shops/{shop_id}/categories/", params={"skip": skip, "limit": limit}))
+
+
+@categories_app.command("get")
+def categories_get(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    category_id: str = typer.Argument(..., help="Category UUID"),
+):
+    """Get details of a specific category."""
+    _print(_api("GET", f"/shops/{shop_id}/categories/{category_id}"))
+
+
+@categories_app.command("create")
+def categories_create(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    main_name: str = typer.Option(..., help="Category name (main language)"),
+    main_description: str = typer.Option(..., help="Category description (main language)"),
+    color: str = typer.Option("#000000", help="Category color (hex)"),
+    order_number: Optional[int] = typer.Option(None, help="Display order"),
+):
+    """Create a new category in a shop."""
+    body = {
+        "shop_id": shop_id,
+        "color": color,
+        "order_number": order_number,
+        "translation": {
+            "main_name": main_name,
+            "main_description": main_description,
+        },
+    }
+    _print(_api("POST", f"/shops/{shop_id}/categories/", json_body=body))
+
+
+@categories_app.command("delete")
+def categories_delete(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    category_id: str = typer.Argument(..., help="Category UUID"),
+):
+    """Delete a category from a shop."""
+    _print(_api("DELETE", f"/shops/{shop_id}/categories/{category_id}"))
+
+
+# =============================================================================
+# TAGS
+# =============================================================================
+
+
+@tags_app.command("list")
+def tags_list(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    skip: int = typer.Option(0, help="Number of records to skip"),
+    limit: int = typer.Option(20, help="Max records to return"),
+):
+    """List tags for a shop."""
+    _print(_api("GET", f"/shops/{shop_id}/tags/", params={"skip": skip, "limit": limit}))
+
+
+@tags_app.command("create")
+def tags_create(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    name: str = typer.Option(..., help="Tag name (internal)"),
+    main_name: str = typer.Option(..., help="Tag display name (main language)"),
+):
+    """Create a new tag in a shop."""
+    body = {
+        "shop_id": shop_id,
+        "name": name,
+        "translation": {"main_name": main_name},
+    }
+    _print(_api("POST", f"/shops/{shop_id}/tags/", json_body=body))
+
+
+@tags_app.command("delete")
+def tags_delete(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    tag_id: str = typer.Argument(..., help="Tag UUID"),
+):
+    """Delete a tag from a shop."""
+    _print(_api("DELETE", f"/shops/{shop_id}/tags/{tag_id}"))
+
+
+# =============================================================================
+# ATTRIBUTES
+# =============================================================================
+
+
+@attributes_app.command("list")
+def attributes_list(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    skip: int = typer.Option(0, help="Number of records to skip"),
+    limit: int = typer.Option(20, help="Max records to return"),
+):
+    """List attributes for a shop."""
+    _print(_api("GET", f"/shops/{shop_id}/attributes/", params={"skip": skip, "limit": limit}))
+
+
+@attributes_app.command("list-with-options")
+def attributes_list_with_options(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    skip: int = typer.Option(0, help="Number of records to skip"),
+    limit: int = typer.Option(20, help="Max records to return"),
+):
+    """List attributes with their options for a shop."""
+    _print(_api("GET", f"/shops/{shop_id}/attributes/with-options", params={"skip": skip, "limit": limit}))
+
+
+@attributes_app.command("create")
+def attributes_create(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    name: str = typer.Option(..., help="Attribute name (e.g. 'Size', 'Color')"),
+    unit: Optional[str] = typer.Option(None, help="Unit (e.g. 'ml', 'cm')"),
+):
+    """Create a new attribute for a shop."""
+    body = {"name": name, "unit": unit}
+    _print(_api("POST", f"/shops/{shop_id}/attributes/", json_body=body))
+
+
+@attributes_app.command("delete")
+def attributes_delete(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    attribute_id: str = typer.Argument(..., help="Attribute UUID"),
+):
+    """Delete an attribute from a shop."""
+    _print(_api("DELETE", f"/shops/{shop_id}/attributes/{attribute_id}"))
+
+
+@attributes_app.command("add-option")
+def attributes_add_option(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    attribute_id: str = typer.Argument(..., help="Attribute UUID"),
+    value: str = typer.Option(..., help="Option value (e.g. 'Red', 'XL')"),
+):
+    """Add an option to an attribute."""
+    body = {"value_key": value}
+    _print(_api("POST", f"/shops/{shop_id}/attributes/{attribute_id}/options/", json_body=body))
+
+
+@attributes_app.command("list-options")
+def attributes_list_options(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    attribute_id: str = typer.Argument(..., help="Attribute UUID"),
+    skip: int = typer.Option(0, help="Number of records to skip"),
+    limit: int = typer.Option(20, help="Max records to return"),
+):
+    """List options for a specific attribute."""
+    _print(_api("GET", f"/shops/{shop_id}/attributes/{attribute_id}/options/", params={"skip": skip, "limit": limit}))
+
+
+@attributes_app.command("delete-option")
+def attributes_delete_option(
+    shop_id: str = typer.Argument(..., help="Shop UUID"),
+    attribute_id: str = typer.Argument(..., help="Attribute UUID"),
+    option_id: str = typer.Argument(..., help="Option UUID"),
+):
+    """Delete an attribute option."""
+    _print(_api("DELETE", f"/shops/{shop_id}/attributes/{attribute_id}/options/{option_id}"))
+
+
+# =============================================================================
+# ORDERS
+# =============================================================================
+
+
+@orders_app.command("list")
+def orders_list(
+    skip: int = typer.Option(0, help="Number of records to skip"),
+    limit: int = typer.Option(20, help="Max records to return"),
+):
+    """List all orders."""
+    _print(_api("GET", "/orders/", params={"skip": skip, "limit": limit}))
+
+
+@orders_app.command("get")
+def orders_get(order_id: str = typer.Argument(..., help="Order UUID")):
+    """Get details of a specific order."""
+    _print(_api("GET", f"/orders/{order_id}"))
+
+
+if __name__ == "__main__":
+    app()

--- a/cli.py
+++ b/cli.py
@@ -62,7 +62,7 @@ def _headers() -> dict:
 
 def _api(method: str, path: str, params: Optional[dict] = None, json_body: Optional[dict] = None):
     """Make an HTTP request to the ShopVirge API and return parsed JSON."""
-    url = f"{API_BASE_URL}/api{path}"
+    url = f"{API_BASE_URL}{path}"
     if params:
         params = {k: v for k, v in params.items() if v is not None}
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,501 @@
+"""
+MCP Server for the ShopVirge Backend API.
+
+Exposes the key CRUD operations of the ShopVirge FastAPI backend as MCP tools,
+allowing AI assistants (Claude Desktop, Claude Code, etc.) to interact with
+shop data via natural language.
+
+Usage:
+    # Start the API server first:
+    PYTHONPATH=. uvicorn server.main:app --reload --port 8080
+
+    # Run the MCP server (stdio transport):
+    python mcp_server.py
+
+    # Or test interactively with the MCP inspector:
+    mcp dev mcp_server.py
+
+Environment variables:
+    SHOP_API_BASE_URL  - Base URL of the running API (default: http://localhost:8080)
+    SHOP_API_TOKEN     - Optional JWT token for authenticated endpoints
+"""
+
+import json
+import os
+from typing import Any, Optional
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+# --- Configuration ---
+
+API_BASE_URL = os.environ.get("SHOP_API_BASE_URL", "http://localhost:8080")
+API_TOKEN = os.environ.get("SHOP_API_TOKEN", "")
+
+mcp = FastMCP(
+    "ShopVirge Backend",
+    instructions=(
+        "MCP server for the ShopVirge shop management API. "
+        "Use these tools to manage shops, products, categories, tags, attributes, and orders. "
+        "Most endpoints require a shop_id (UUID). Use list_shops first to discover available shops."
+    ),
+)
+
+# --- HTTP helper ---
+
+
+async def _api_request(
+    method: str,
+    path: str,
+    params: dict[str, Any] | None = None,
+    json_body: dict[str, Any] | None = None,
+) -> str:
+    """Make an HTTP request to the ShopVirge API and return the response as a formatted string."""
+    headers: dict[str, str] = {}
+    if API_TOKEN:
+        headers["Authorization"] = f"Bearer {API_TOKEN}"
+
+    url = f"{API_BASE_URL}/api{path}"
+
+    # Remove None values from params
+    if params:
+        params = {k: v for k, v in params.items() if v is not None}
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            response = await client.request(method, url, params=params, json=json_body, headers=headers)
+        except httpx.ConnectError:
+            return json.dumps({"error": f"Cannot connect to API at {API_BASE_URL}. Is the server running?"})
+        except httpx.TimeoutException:
+            return json.dumps({"error": f"Request timed out: {method} {url}"})
+
+    if response.status_code == 204:
+        return json.dumps({"status": "deleted", "message": "Resource deleted successfully"})
+
+    try:
+        data = response.json()
+    except Exception:
+        data = response.text
+
+    if response.status_code >= 400:
+        return json.dumps({"error": True, "status_code": response.status_code, "detail": data}, default=str)
+
+    return json.dumps(data, default=str)
+
+
+# =============================================================================
+# SHOP TOOLS
+# =============================================================================
+
+
+@mcp.tool()
+async def list_shops(skip: int = 0, limit: int = 20) -> str:
+    """List all shops. Returns shop IDs, names, and descriptions. Use skip/limit for pagination."""
+    return await _api_request("GET", "/shops/", params={"skip": skip, "limit": limit})
+
+
+@mcp.tool()
+async def get_shop(shop_id: str) -> str:
+    """Get detailed information about a specific shop by its UUID, including prices and configuration."""
+    return await _api_request("GET", f"/shops/{shop_id}")
+
+
+@mcp.tool()
+async def create_shop(
+    name: str,
+    description: str,
+    vat_standard: float = 21.0,
+    vat_lower_1: float = 9.0,
+    vat_lower_2: float = 0.0,
+    vat_lower_3: float = 0.0,
+    vat_special: float = 0.0,
+    vat_zero: float = 0.0,
+    internal_url: Optional[str] = None,
+    external_url: Optional[str] = None,
+) -> str:
+    """Create a new shop. Requires admin authentication. Returns the created shop."""
+    body = {
+        "name": name,
+        "description": description,
+        "vat_standard": vat_standard,
+        "vat_lower_1": vat_lower_1,
+        "vat_lower_2": vat_lower_2,
+        "vat_lower_3": vat_lower_3,
+        "vat_special": vat_special,
+        "vat_zero": vat_zero,
+        "internal_url": internal_url,
+        "external_url": external_url,
+    }
+    return await _api_request("POST", "/shops/", json_body=body)
+
+
+@mcp.tool()
+async def update_shop(
+    shop_id: str,
+    name: str,
+    description: str,
+    vat_standard: float = 21.0,
+    vat_lower_1: float = 9.0,
+    vat_lower_2: float = 0.0,
+    vat_lower_3: float = 0.0,
+    vat_special: float = 0.0,
+    vat_zero: float = 0.0,
+    internal_url: Optional[str] = None,
+    external_url: Optional[str] = None,
+) -> str:
+    """Update an existing shop. Requires admin authentication."""
+    body = {
+        "name": name,
+        "description": description,
+        "vat_standard": vat_standard,
+        "vat_lower_1": vat_lower_1,
+        "vat_lower_2": vat_lower_2,
+        "vat_lower_3": vat_lower_3,
+        "vat_special": vat_special,
+        "vat_zero": vat_zero,
+        "internal_url": internal_url,
+        "external_url": external_url,
+    }
+    return await _api_request("PUT", f"/shops/{shop_id}", json_body=body)
+
+
+@mcp.tool()
+async def delete_shop(shop_id: str) -> str:
+    """Delete a shop by its UUID. Requires admin authentication. This is irreversible."""
+    return await _api_request("DELETE", f"/shops/{shop_id}")
+
+
+# =============================================================================
+# PRODUCT TOOLS
+# =============================================================================
+
+
+@mcp.tool()
+async def list_products(shop_id: str, skip: int = 0, limit: int = 20) -> str:
+    """List products for a shop. Returns product IDs, names, prices, and category info."""
+    return await _api_request("GET", f"/shops/{shop_id}/products/", params={"skip": skip, "limit": limit})
+
+
+@mcp.tool()
+async def get_product(shop_id: str, product_id: str) -> str:
+    """Get detailed product information including translations, prices, and images."""
+    return await _api_request("GET", f"/shops/{shop_id}/products/{product_id}")
+
+
+@mcp.tool()
+async def create_product(
+    shop_id: str,
+    category_id: str,
+    main_name: str,
+    main_description: str,
+    main_description_short: str,
+    price: Optional[float] = None,
+    tax_category: str = "vat_standard",
+    max_one: bool = False,
+    shippable: bool = False,
+    featured: bool = False,
+    new_product: bool = False,
+    digital: Optional[str] = None,
+    discounted_price: Optional[float] = None,
+    stock: int = 1,
+    order_number: Optional[int] = None,
+    alt1_name: Optional[str] = None,
+    alt1_description: Optional[str] = None,
+    alt1_description_short: Optional[str] = None,
+    alt2_name: Optional[str] = None,
+    alt2_description: Optional[str] = None,
+    alt2_description_short: Optional[str] = None,
+) -> str:
+    """Create a new product in a shop. Requires a category_id and translation fields (main_name, main_description, main_description_short). Optionally provide alt1_*/alt2_* for multi-language support."""
+    body = {
+        "shop_id": shop_id,
+        "category_id": category_id,
+        "price": price,
+        "tax_category": tax_category,
+        "max_one": max_one,
+        "shippable": shippable,
+        "featured": featured,
+        "new_product": new_product,
+        "digital": digital,
+        "discounted_price": discounted_price,
+        "stock": stock,
+        "order_number": order_number,
+        "translation": {
+            "main_name": main_name,
+            "main_description": main_description,
+            "main_description_short": main_description_short,
+            "alt1_name": alt1_name,
+            "alt1_description": alt1_description,
+            "alt1_description_short": alt1_description_short,
+            "alt2_name": alt2_name,
+            "alt2_description": alt2_description,
+            "alt2_description_short": alt2_description_short,
+        },
+    }
+    return await _api_request("POST", f"/shops/{shop_id}/products/", json_body=body)
+
+
+@mcp.tool()
+async def update_product(
+    shop_id: str,
+    product_id: str,
+    category_id: str,
+    main_name: str,
+    main_description: str,
+    main_description_short: str,
+    price: Optional[float] = None,
+    tax_category: str = "vat_standard",
+    max_one: bool = False,
+    shippable: bool = False,
+    featured: bool = False,
+    new_product: bool = False,
+    digital: Optional[str] = None,
+    discounted_price: Optional[float] = None,
+    stock: int = 1,
+    order_number: Optional[int] = None,
+    alt1_name: Optional[str] = None,
+    alt1_description: Optional[str] = None,
+    alt1_description_short: Optional[str] = None,
+    alt2_name: Optional[str] = None,
+    alt2_description: Optional[str] = None,
+    alt2_description_short: Optional[str] = None,
+) -> str:
+    """Update an existing product. All main translation fields are required."""
+    body = {
+        "shop_id": shop_id,
+        "category_id": category_id,
+        "price": price,
+        "tax_category": tax_category,
+        "max_one": max_one,
+        "shippable": shippable,
+        "featured": featured,
+        "new_product": new_product,
+        "digital": digital,
+        "discounted_price": discounted_price,
+        "stock": stock,
+        "order_number": order_number,
+        "translation": {
+            "main_name": main_name,
+            "main_description": main_description,
+            "main_description_short": main_description_short,
+            "alt1_name": alt1_name,
+            "alt1_description": alt1_description,
+            "alt1_description_short": alt1_description_short,
+            "alt2_name": alt2_name,
+            "alt2_description": alt2_description,
+            "alt2_description_short": alt2_description_short,
+        },
+    }
+    return await _api_request("PUT", f"/shops/{shop_id}/products/{product_id}", json_body=body)
+
+
+@mcp.tool()
+async def delete_product(shop_id: str, product_id: str) -> str:
+    """Delete a product from a shop. This is irreversible."""
+    return await _api_request("DELETE", f"/shops/{shop_id}/products/{product_id}")
+
+
+# =============================================================================
+# CATEGORY TOOLS
+# =============================================================================
+
+
+@mcp.tool()
+async def list_categories(shop_id: str, skip: int = 0, limit: int = 20) -> str:
+    """List categories for a shop. Categories organize products."""
+    return await _api_request("GET", f"/shops/{shop_id}/categories/", params={"skip": skip, "limit": limit})
+
+
+@mcp.tool()
+async def get_category(shop_id: str, category_id: str) -> str:
+    """Get detailed information about a specific category."""
+    return await _api_request("GET", f"/shops/{shop_id}/categories/{category_id}")
+
+
+@mcp.tool()
+async def create_category(
+    shop_id: str,
+    main_name: str,
+    main_description: str,
+    color: str = "#000000",
+    icon: Optional[str] = None,
+    order_number: Optional[int] = None,
+    alt1_name: Optional[str] = None,
+    alt1_description: Optional[str] = None,
+    alt2_name: Optional[str] = None,
+    alt2_description: Optional[str] = None,
+) -> str:
+    """Create a new category in a shop. Provide main_name and main_description at minimum."""
+    body = {
+        "shop_id": shop_id,
+        "color": color,
+        "icon": icon,
+        "order_number": order_number,
+        "translation": {
+            "main_name": main_name,
+            "main_description": main_description,
+            "alt1_name": alt1_name,
+            "alt1_description": alt1_description,
+            "alt2_name": alt2_name,
+            "alt2_description": alt2_description,
+        },
+    }
+    return await _api_request("POST", f"/shops/{shop_id}/categories/", json_body=body)
+
+
+@mcp.tool()
+async def delete_category(shop_id: str, category_id: str) -> str:
+    """Delete a category from a shop. This is irreversible."""
+    return await _api_request("DELETE", f"/shops/{shop_id}/categories/{category_id}")
+
+
+# =============================================================================
+# TAG TOOLS
+# =============================================================================
+
+
+@mcp.tool()
+async def list_tags(shop_id: str, skip: int = 0, limit: int = 20) -> str:
+    """List tags for a shop. Tags can be attached to products for filtering."""
+    return await _api_request("GET", f"/shops/{shop_id}/tags/", params={"skip": skip, "limit": limit})
+
+
+@mcp.tool()
+async def create_tag(
+    shop_id: str,
+    name: str,
+    main_name: str,
+    alt1_name: Optional[str] = None,
+    alt2_name: Optional[str] = None,
+) -> str:
+    """Create a new tag in a shop. Tags are used to label and filter products."""
+    body = {
+        "shop_id": shop_id,
+        "name": name,
+        "translation": {
+            "main_name": main_name,
+            "alt1_name": alt1_name,
+            "alt2_name": alt2_name,
+        },
+    }
+    return await _api_request("POST", f"/shops/{shop_id}/tags/", json_body=body)
+
+
+@mcp.tool()
+async def delete_tag(shop_id: str, tag_id: str) -> str:
+    """Delete a tag from a shop. This is irreversible."""
+    return await _api_request("DELETE", f"/shops/{shop_id}/tags/{tag_id}")
+
+
+# =============================================================================
+# ATTRIBUTE TOOLS
+# =============================================================================
+
+
+@mcp.tool()
+async def list_attributes(shop_id: str, skip: int = 0, limit: int = 20) -> str:
+    """List attributes for a shop. Attributes define product characteristics (e.g. size, color)."""
+    return await _api_request("GET", f"/shops/{shop_id}/attributes/", params={"skip": skip, "limit": limit})
+
+
+@mcp.tool()
+async def list_attributes_with_options(shop_id: str, skip: int = 0, limit: int = 20) -> str:
+    """List attributes with their options for a shop. Shows each attribute and its available option values."""
+    return await _api_request(
+        "GET", f"/shops/{shop_id}/attributes/with-options", params={"skip": skip, "limit": limit}
+    )
+
+
+@mcp.tool()
+async def create_attribute(shop_id: str, name: str, unit: Optional[str] = None) -> str:
+    """Create a new attribute for a shop (e.g. 'Size', 'Color'). Optionally specify a unit (e.g. 'ml', 'cm')."""
+    body = {"name": name, "unit": unit}
+    return await _api_request("POST", f"/shops/{shop_id}/attributes/", json_body=body)
+
+
+@mcp.tool()
+async def delete_attribute(shop_id: str, attribute_id: str) -> str:
+    """Delete an attribute from a shop. This is irreversible."""
+    return await _api_request("DELETE", f"/shops/{shop_id}/attributes/{attribute_id}")
+
+
+# =============================================================================
+# ATTRIBUTE OPTION TOOLS
+# =============================================================================
+
+
+@mcp.tool()
+async def list_attribute_options(shop_id: str, attribute_id: str, skip: int = 0, limit: int = 20) -> str:
+    """List options for a specific attribute (e.g. for a 'Size' attribute: 'S', 'M', 'L')."""
+    return await _api_request(
+        "GET", f"/shops/{shop_id}/attributes/{attribute_id}/options/", params={"skip": skip, "limit": limit}
+    )
+
+
+@mcp.tool()
+async def create_attribute_option(shop_id: str, attribute_id: str, value_key: str) -> str:
+    """Create a new option for an attribute. The value_key is the option value (e.g. 'Red', 'XL')."""
+    body = {"value_key": value_key}
+    return await _api_request("POST", f"/shops/{shop_id}/attributes/{attribute_id}/options/", json_body=body)
+
+
+@mcp.tool()
+async def delete_attribute_option(shop_id: str, attribute_id: str, option_id: str) -> str:
+    """Delete an attribute option. This is irreversible."""
+    return await _api_request("DELETE", f"/shops/{shop_id}/attributes/{attribute_id}/options/{option_id}")
+
+
+# =============================================================================
+# ORDER TOOLS
+# =============================================================================
+
+
+@mcp.tool()
+async def list_orders(skip: int = 0, limit: int = 20) -> str:
+    """List all orders across all shops. Requires admin authentication."""
+    return await _api_request("GET", "/orders/", params={"skip": skip, "limit": limit})
+
+
+@mcp.tool()
+async def get_order(order_id: str) -> str:
+    """Get detailed information about a specific order by its UUID."""
+    return await _api_request("GET", f"/orders/{order_id}")
+
+
+@mcp.tool()
+async def create_order(
+    shop_id: str,
+    order_info: list[dict],
+    account_id: Optional[str] = None,
+    account_name: Optional[str] = None,
+    total: Optional[float] = None,
+    notes: Optional[str] = None,
+    status: Optional[str] = None,
+    customer_order_id: Optional[int] = None,
+) -> str:
+    """Create a new order. order_info is a list of items, each with: description, price, product_id, product_name, quantity. Provide either account_id (existing account) or account_name (creates new)."""
+    body: dict[str, Any] = {
+        "shop_id": shop_id,
+        "order_info": order_info,
+    }
+    if account_id is not None:
+        body["account_id"] = account_id
+    if account_name is not None:
+        body["account_name"] = account_name
+    if total is not None:
+        body["total"] = total
+    if notes is not None:
+        body["notes"] = notes
+    if status is not None:
+        body["status"] = status
+    if customer_order_id is not None:
+        body["customer_order_id"] = customer_order_id
+    return await _api_request("POST", "/orders/", json_body=body)
+
+
+# =============================================================================
+# Entry point
+# =============================================================================
+
+if __name__ == "__main__":
+    mcp.run()

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -401,9 +401,7 @@ async def list_attributes(shop_id: str, skip: int = 0, limit: int = 20) -> str:
 @mcp.tool()
 async def list_attributes_with_options(shop_id: str, skip: int = 0, limit: int = 20) -> str:
     """List attributes with their options for a shop. Shows each attribute and its available option values."""
-    return await _api_request(
-        "GET", f"/shops/{shop_id}/attributes/with-options", params={"skip": skip, "limit": limit}
-    )
+    return await _api_request("GET", f"/shops/{shop_id}/attributes/with-options", params={"skip": skip, "limit": limit})
 
 
 @mcp.tool()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ gunicorn~=20.0.4
 more-itertools==10.2.0
 passlib[bcrypt]==1.7.4
 psycopg2-binary==2.9.9
-pydantic[email]==2.7.1
+pydantic[email]>=2.9.0,<3.0.0
 pyjwt==2.1.0  # Todo: Not sure if we need this one
 python-jose[cryptography]==3.2.0
 python-rapidjson==1.17
@@ -25,14 +25,13 @@ structlog
 uvicorn[standard]~=0.29.0
 itsdangerous
 pydantic-forms
-pydantic-settings~=2.4.0
+pydantic-settings>=2.4.0
 python-multipart==0.0.12
 wheel
 stripe==10.7.0
 phonenumbers==8.13.45
 pydantic_extra_types==2.9.0
 httpx>=0.27.0
-mcp[cli]>=1.0.0
 sentry-sdk~=2.28.0
 html2text==2024.2.26
 Jinja2==3.1.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,8 @@ wheel
 stripe==10.7.0
 phonenumbers==8.13.45
 pydantic_extra_types==2.9.0
-httpx
+httpx>=0.27.0
+mcp[cli]>=1.0.0
 sentry-sdk~=2.28.0
 html2text==2024.2.26
 Jinja2==3.1.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,3 +5,4 @@ pydocstyle==3.0.0
 watchdog
 typer==0.7.0  # added to speed up
 click==8.1.8
+mcp[cli]>=1.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,6 +3,7 @@ apache-license-check
 black
 isort
 pytest
+pytest-asyncio
 pytest-cov
 pytest-xdist
 pytest_benchmark

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -1,0 +1,201 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from cli import app
+
+runner = CliRunner()
+
+
+def test_cli_help():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "ShopVirge Backend CLI" in result.output
+
+
+def test_cli_shops_help():
+    result = runner.invoke(app, ["shops", "--help"])
+    assert result.exit_code == 0
+    assert "list" in result.output
+    assert "get" in result.output
+    assert "create" in result.output
+    assert "delete" in result.output
+
+
+def test_cli_products_help():
+    result = runner.invoke(app, ["products", "--help"])
+    assert result.exit_code == 0
+    assert "list" in result.output
+    assert "get" in result.output
+    assert "create" in result.output
+    assert "delete" in result.output
+
+
+def test_cli_categories_help():
+    result = runner.invoke(app, ["categories", "--help"])
+    assert result.exit_code == 0
+    assert "list" in result.output
+    assert "create" in result.output
+
+
+def test_cli_tags_help():
+    result = runner.invoke(app, ["tags", "--help"])
+    assert result.exit_code == 0
+    assert "list" in result.output
+    assert "create" in result.output
+
+
+def test_cli_attributes_help():
+    result = runner.invoke(app, ["attributes", "--help"])
+    assert result.exit_code == 0
+    assert "list" in result.output
+    assert "create" in result.output
+    assert "add-option" in result.output
+    assert "list-options" in result.output
+
+
+def test_cli_orders_help():
+    result = runner.invoke(app, ["orders", "--help"])
+    assert result.exit_code == 0
+    assert "list" in result.output
+    assert "get" in result.output
+
+
+@patch("cli.httpx.request")
+def test_cli_shops_list(mock_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [{"id": "abc-123", "name": "Test Shop"}]
+    mock_request.return_value = mock_response
+
+    result = runner.invoke(app, ["shops", "list"])
+    assert result.exit_code == 0
+    assert "Test Shop" in result.output
+    assert "abc-123" in result.output
+    mock_request.assert_called_once()
+
+
+@patch("cli.httpx.request")
+def test_cli_shops_get(mock_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"id": "abc-123", "name": "Test Shop", "description": "A test shop"}
+    mock_request.return_value = mock_response
+
+    result = runner.invoke(app, ["shops", "get", "abc-123"])
+    assert result.exit_code == 0
+    assert "Test Shop" in result.output
+
+
+@patch("cli.httpx.request")
+def test_cli_shops_create(mock_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"id": "new-123", "name": "New Shop"}
+    mock_request.return_value = mock_response
+
+    result = runner.invoke(app, ["shops", "create", "--name", "New Shop", "--description", "Desc"])
+    assert result.exit_code == 0
+    assert "New Shop" in result.output
+
+
+@patch("cli.httpx.request")
+def test_cli_shops_delete(mock_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 204
+    mock_request.return_value = mock_response
+
+    result = runner.invoke(app, ["shops", "delete", "abc-123"])
+    assert result.exit_code == 0
+    assert "deleted" in result.output
+
+
+@patch("cli.httpx.request")
+def test_cli_products_list(mock_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [{"id": "prod-1", "name": "Widget"}]
+    mock_request.return_value = mock_response
+
+    result = runner.invoke(app, ["products", "list", "shop-123"])
+    assert result.exit_code == 0
+    assert "Widget" in result.output
+
+
+@patch("cli.httpx.request")
+def test_cli_orders_list(mock_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [{"id": "order-1", "total": 42.0}]
+    mock_request.return_value = mock_response
+
+    result = runner.invoke(app, ["orders", "list"])
+    assert result.exit_code == 0
+    assert "order-1" in result.output
+
+
+@patch("cli.httpx.request")
+def test_cli_health_check(mock_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": "ok"}
+    mock_request.return_value = mock_response
+
+    result = runner.invoke(app, ["health", "check"])
+    assert result.exit_code == 0
+    assert "ok" in result.output
+
+
+@patch("cli.httpx.request")
+def test_cli_api_error(mock_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.json.return_value = {"detail": "Not found"}
+    mock_request.return_value = mock_response
+
+    result = runner.invoke(app, ["shops", "get", "nonexistent"])
+    assert result.exit_code == 1
+
+
+@patch("cli.httpx.request", side_effect=httpx.ConnectError("Connection refused"))
+def test_cli_connection_error(mock_request):
+    result = runner.invoke(app, ["shops", "list"])
+    assert result.exit_code == 1
+    assert "Cannot connect" in result.output
+
+
+@patch("cli.httpx.request", side_effect=httpx.TimeoutException("timed out"))
+def test_cli_timeout_error(mock_request):
+    result = runner.invoke(app, ["shops", "list"])
+    assert result.exit_code == 1
+    assert "timed out" in result.output
+
+
+@patch("cli.httpx.request")
+def test_cli_auth_header(mock_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = []
+    mock_request.return_value = mock_response
+
+    with patch("cli.API_TOKEN", "my-secret-token"):
+        runner.invoke(app, ["shops", "list"])
+
+    call_kwargs = mock_request.call_args
+    assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer my-secret-token"
+
+
+@patch("cli.httpx.request")
+def test_cli_no_auth_header_when_no_token(mock_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = []
+    mock_request.return_value = mock_response
+
+    with patch("cli.API_TOKEN", ""):
+        runner.invoke(app, ["shops", "list"])
+
+    call_kwargs = mock_request.call_args
+    assert "Authorization" not in call_kwargs.kwargs["headers"]

--- a/tests/unit_tests/test_mcp_server.py
+++ b/tests/unit_tests/test_mcp_server.py
@@ -1,0 +1,148 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from mcp_server import _api_request
+
+
+@pytest.mark.asyncio
+async def test_api_request_get():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [{"id": "abc", "name": "Shop"}]
+
+    with patch("mcp_server.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await _api_request("GET", "/shops/")
+
+    data = json.loads(result)
+    assert data == [{"id": "abc", "name": "Shop"}]
+
+
+@pytest.mark.asyncio
+async def test_api_request_post_with_body():
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"id": "new-123", "name": "New Shop"}
+
+    with patch("mcp_server.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await _api_request("POST", "/shops/", json_body={"name": "New Shop"})
+
+    data = json.loads(result)
+    assert data["name"] == "New Shop"
+    mock_client.request.assert_called_once()
+    call_kwargs = mock_client.request.call_args
+    assert call_kwargs.kwargs["json"] == {"name": "New Shop"}
+
+
+@pytest.mark.asyncio
+async def test_api_request_delete_204():
+    mock_response = MagicMock()
+    mock_response.status_code = 204
+
+    with patch("mcp_server.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await _api_request("DELETE", "/shops/abc-123")
+
+    data = json.loads(result)
+    assert data["status"] == "deleted"
+
+
+@pytest.mark.asyncio
+async def test_api_request_error_response():
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.json.return_value = {"detail": "Not found"}
+
+    with patch("mcp_server.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await _api_request("GET", "/shops/nonexistent")
+
+    data = json.loads(result)
+    assert data["error"] is True
+    assert data["status_code"] == 404
+
+
+@pytest.mark.asyncio
+async def test_api_request_connection_error():
+    with patch("mcp_server.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.request.side_effect = httpx.ConnectError("Connection refused")
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await _api_request("GET", "/shops/")
+
+    data = json.loads(result)
+    assert "error" in data
+    assert "Cannot connect" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_api_request_timeout():
+    with patch("mcp_server.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.request.side_effect = httpx.TimeoutException("timed out")
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await _api_request("GET", "/shops/")
+
+    data = json.loads(result)
+    assert "error" in data
+    assert "timed out" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_api_request_strips_none_params():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = []
+
+    with patch("mcp_server.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await _api_request("GET", "/shops/", params={"skip": 0, "limit": 20, "filter": None})
+
+    call_kwargs = mock_client.request.call_args
+    assert call_kwargs.kwargs["params"] == {"skip": 0, "limit": 20}
+
+
+@pytest.mark.asyncio
+async def test_api_request_auth_header():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = []
+
+    with patch("mcp_server.httpx.AsyncClient") as mock_client_cls, patch("mcp_server.API_TOKEN", "test-token"):
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await _api_request("GET", "/shops/")
+
+    call_kwargs = mock_client.request.call_args
+    assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer test-token"

--- a/tests/unit_tests/test_mcp_server.py
+++ b/tests/unit_tests/test_mcp_server.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+mcp_available = pytest.importorskip("mcp", reason="mcp not installed")
 from mcp_server import _api_request
 
 


### PR DESCRIPTION
## Summary
- Add MCP server (`mcp_server.py`) exposing 27 ShopVirge API tools for AI assistants (Claude Desktop, Claude Code)
- Add typer-based CLI (`cli.py`) for interacting with the backend API from the command line (shops, products, categories, tags, attributes, orders)
- Fix CI pipeline dependency conflict: update `pydantic[email]` from `==2.7.1` to `>=2.9.0,<3.0.0` to resolve incompatibility with `pydantic-forms` and `pydantic_extra_types`
- Move `mcp[cli]` from `base.txt` to `dev.txt` (only needed for standalone MCP server)
- Update GitHub Actions from v2 to v4/v5
- Add `CLAUDE.md` with project conventions and common commands
- Replace individual `.psql` gitignore entries with `*.psql` wildcard

NOTE: Bumped pydantic, 2.7 -> 2.9. We should test this properly or take time to deploy it carefully (have time for a rollback if needed)

## Test plan
- [x] All 43 unit tests pass
- [x] Linting (isort, black) passes in CI
- [x] CI pipeline (both linting and unit test jobs) passes on branch
- [ ] Do a smoke test locally with GUI/editor -> to see if the pydantic stuff causes problems.
- [ ] Verify CLI works against running dev server (`python cli.py shops list`)
- [ ] Verify MCP server works with `mcp dev mcp_server.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)