### PR TITLE
Fix available-attributes to only count visible products

### DIFF
--- a/server/api/endpoints/shop_endpoints/categories.py
+++ b/server/api/endpoints/shop_endpoints/categories.py
@@ -1,3 +1,4 @@
+import json
 from collections import defaultdict
 from http import HTTPStatus
 from typing import Any, List, Optional
@@ -15,6 +16,7 @@ from server.api.helpers import invalidateShopCache
 from server.crud import crud_shop
 from server.crud.crud_category import category_crud
 from server.crud.crud_product import product_crud
+from server.crud.crud_shop import shop_crud
 from server.db import db
 from server.db.models import (
     AttributeOptionTable,
@@ -172,8 +174,12 @@ def get_available_attributes(shop_id: UUID, category_id: UUID) -> list[Available
     if not category:
         raise_status(HTTPStatus.NOT_FOUND, f"Category with id {category_id} not found")
 
+    shop = shop_crud.get(shop_id)
+    if shop and isinstance(shop.config, str):
+        shop.config = json.loads(shop.config)
+
     # Single aggregation query: get attribute+option+count for all used options in this category
-    results = (
+    query = (
         db.session.query(
             AttributeTable.id.label("attribute_id"),
             AttributeTable.name.label("attribute_name"),
@@ -187,15 +193,19 @@ def get_available_attributes(shop_id: UUID, category_id: UUID) -> list[Available
         .join(AttributeOptionTable, AttributeOptionTable.id == ProductAttributeValueTable.option_id)
         .filter(ProductTable.shop_id == shop_id)
         .filter(ProductTable.category_id == category_id)
-        .group_by(
-            AttributeTable.id,
-            AttributeTable.name,
-            AttributeTable.unit,
-            AttributeOptionTable.id,
-            AttributeOptionTable.value_key,
-        )
-        .all()
+        .filter(ProductTable.price.isnot(None))
     )
+
+    if shop and shop.config.get("toggles", {}).get("enable_stock_on_products"):
+        query = query.filter(ProductTable.stock > 0)
+
+    results = query.group_by(
+        AttributeTable.id,
+        AttributeTable.name,
+        AttributeTable.unit,
+        AttributeOptionTable.id,
+        AttributeOptionTable.value_key,
+    ).all()
 
     if not results:
         return []

--- a/tests/unit_tests/api/test_available_attributes.py
+++ b/tests/unit_tests/api/test_available_attributes.py
@@ -1,6 +1,9 @@
 from http import HTTPStatus
 from uuid import uuid4
 
+from server.db import db
+from server.db.models import ProductTable, ShopTable
+
 
 def test_available_attributes_happy_path(test_client, shop_with_category_attributes):
     ids = shop_with_category_attributes
@@ -69,6 +72,103 @@ def test_available_attributes_empty_category(test_client, shop_with_category_att
     response = test_client.get(f"/shops/{ids['shop_id']}/categories/{empty_cat_id}/available-attributes")
     assert response.status_code == HTTPStatus.OK
     assert response.json() == []
+
+
+def test_available_attributes_excludes_products_without_price(test_client, shop_with_category_attributes):
+    """Products with price=None should not be counted in attribute options."""
+    ids = shop_with_category_attributes
+
+    # Set prod3 (the only product with size L and color BLUE) to have no price
+    prod3 = db.session.query(ProductTable).filter(ProductTable.category_id == ids["cat1_id"]).all()
+    # prod3 is the one with size L — find it via attribute values
+    from server.db.models import ProductAttributeValueTable
+
+    prod_with_l = (
+        db.session.query(ProductAttributeValueTable.product_id)
+        .filter(ProductAttributeValueTable.option_id == ids["size_l_id"])
+        .scalar()
+    )
+    product = db.session.query(ProductTable).get(prod_with_l)
+    product.price = None
+    db.session.commit()
+
+    response = test_client.get(f"/shops/{ids['shop_id']}/categories/{ids['cat1_id']}/available-attributes")
+    assert response.status_code == HTTPStatus.OK
+
+    data = response.json()
+    attrs_by_name = {a["name"]: a for a in data}
+
+    # Size L and color BLUE should be gone (only prod3 had them)
+    size_opts = {o["value_key"]: o for o in attrs_by_name["size"]["options"]}
+    assert "L" not in size_opts
+    assert size_opts["S"]["product_count"] == 2
+    assert size_opts["M"]["product_count"] == 1
+
+    color_opts = {o["value_key"]: o for o in attrs_by_name["color"]["options"]}
+    assert "BLUE" not in color_opts
+    assert color_opts["RED"]["product_count"] == 2
+
+
+def test_available_attributes_excludes_out_of_stock_when_enabled(test_client, shop_with_category_attributes):
+    """When enable_stock_on_products is on, products with stock<=0 should not be counted."""
+    ids = shop_with_category_attributes
+
+    # Enable stock toggle on the shop
+    shop = db.session.query(ShopTable).get(ids["shop_id"])
+    shop.config = {"toggles": {"enable_stock_on_products": True}}
+    db.session.commit()
+
+    # Set prod3 (size L, color BLUE) to stock=0
+    from server.db.models import ProductAttributeValueTable
+
+    prod_with_l = (
+        db.session.query(ProductAttributeValueTable.product_id)
+        .filter(ProductAttributeValueTable.option_id == ids["size_l_id"])
+        .scalar()
+    )
+    product = db.session.query(ProductTable).get(prod_with_l)
+    product.stock = 0
+    db.session.commit()
+
+    response = test_client.get(f"/shops/{ids['shop_id']}/categories/{ids['cat1_id']}/available-attributes")
+    assert response.status_code == HTTPStatus.OK
+
+    data = response.json()
+    attrs_by_name = {a["name"]: a for a in data}
+
+    size_opts = {o["value_key"]: o for o in attrs_by_name["size"]["options"]}
+    assert "L" not in size_opts
+
+    color_opts = {o["value_key"]: o for o in attrs_by_name["color"]["options"]}
+    assert "BLUE" not in color_opts
+
+
+def test_available_attributes_includes_out_of_stock_when_toggle_disabled(test_client, shop_with_category_attributes):
+    """When enable_stock_on_products is off, products with stock=0 should still be counted."""
+    ids = shop_with_category_attributes
+
+    # Set prod3 stock to 0 but don't enable the toggle (shop has no config)
+    from server.db.models import ProductAttributeValueTable
+
+    prod_with_l = (
+        db.session.query(ProductAttributeValueTable.product_id)
+        .filter(ProductAttributeValueTable.option_id == ids["size_l_id"])
+        .scalar()
+    )
+    product = db.session.query(ProductTable).get(prod_with_l)
+    product.stock = 0
+    db.session.commit()
+
+    response = test_client.get(f"/shops/{ids['shop_id']}/categories/{ids['cat1_id']}/available-attributes")
+    assert response.status_code == HTTPStatus.OK
+
+    data = response.json()
+    attrs_by_name = {a["name"]: a for a in data}
+
+    # L should still be present since stock toggle is off
+    size_opts = {o["value_key"]: o for o in attrs_by_name["size"]["options"]}
+    assert "L" in size_opts
+    assert size_opts["L"]["product_count"] == 1
 
 
 def test_available_attributes_nonexistent_category(test_client, shop_with_category_attributes):


### PR DESCRIPTION
## Summary

- Exclude products without a price (`price IS NULL`) from attribute option counts in the `/shops/{shop_id}/categories/{category_id}/available-attributes` endpoint
- When `enable_stock_on_products` is toggled on in shop config, also exclude out-of-stock products (`stock <= 0`)
- This aligns the endpoint with the prices endpoint behavior, so filter counts reflect only products actually visible in the shop

## Test plan

- [x] Existing tests pass (backwards compatible — products with price and stock are unaffected)
- [x] New test: products without a price are excluded from counts
- [x] New test: out-of-stock products excluded when stock toggle is enabled
- [x] New test: out-of-stock products still counted when stock toggle is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)