### PR TITLE
Add order confirmation emails on completion

### DIFF
--- a/server/api/endpoints/shop_endpoints/orders.py
+++ b/server/api/endpoints/shop_endpoints/orders.py
@@ -21,11 +21,13 @@ from server.crud.crud_order import order_crud
 from server.crud.crud_product import product_crud
 from server.crud.crud_shop import shop_crud
 from server.db.models import Account, OrderTable, ShopTable, UserTable
+from server.mail import send_order_confirmation_emails
 from server.schemas import ProductUpdate
 from server.schemas.account import AccountCreate
 from server.schemas.order import OrderBase, OrderCreate, OrderCreated, OrderSchema, OrderUpdate, OrderUpdated
 from server.schemas.product import ProductTranslationBase
 from server.security import auth_required
+from server.settings import mail_settings
 from server.utils.discord.discord import post_discord_order_complete
 
 logger = structlog.get_logger(__name__)
@@ -391,10 +393,12 @@ def patch(
             )
             product_crud.update(db_obj=product, obj_in=new_product)
 
+    # Fetch account once for Discord and email notifications
+    account = account_crud.get(updated_order.account_id) if updated_order.account_id else None
+
     try:
         shop = load(ShopTable, updated_order.shop_id)
-        if shop.discord_webhook is not None:
-            account = account_crud.get(updated_order.account_id)
+        if shop.discord_webhook is not None and account:
             post_discord_order_complete(
                 f"New order from {account.name}",
                 botname=shop.name,
@@ -402,9 +406,15 @@ def patch(
                 order=updated_order,
                 email=account.name,
             )
-
     except Exception as e:
         logger.error("Failed to post to Discord: ", error=str(e))
+
+    # Send order confirmation emails
+    if mail_settings.SHOP_MAIL_ENABLED and item_in.status == "complete" and account:
+        try:
+            send_order_confirmation_emails(order=order, shop=shop, account=account)
+        except Exception as e:
+            logger.error("Failed to send order confirmation email", error=str(e))
 
     invalidateCompletedOrdersCache(updated_order.id)
     return updated_order

--- a/server/mail.py
+++ b/server/mail.py
@@ -105,7 +105,12 @@ def send_mail(
     if mail_settings.MAIL_ENABLED:
         logger.debug("Sending an email", message=message)
         mailer = SMTP(host=mail_settings.MAIL_SERVER, port=mail_settings.MAIL_PORT)
+        if mail_settings.MAIL_STARTTLS:
+            mailer.starttls()
+        if mail_settings.MAIL_SMTP_USERNAME and mail_settings.MAIL_SMTP_PASSWORD:
+            mailer.login(user=mail_settings.MAIL_SMTP_USERNAME, password=mail_settings.MAIL_SMTP_PASSWORD)
         mailer.send_message(message)
+        mailer.quit()
     return message
 
 
@@ -363,46 +368,173 @@ def shop_product_summary(product: ProductBase, extra_content: str | None = None)
     )
 
 
-# @generate_product_summary.register
-# def other_product_summary(subscription: OtherProvisioning, extra_content: str | None = None) -> str:
-#     """Create and return an ConfirmationMail for :class:`~products.product_types.other.OtherProvisioning`.
-#
-#     Args:
-#         model: OtherProvisioning
-#         extra_content: Optional str to add extra text above the summary
-#         kwargs: Extra arguments, only to be signature compatible
-#
-#     Returns: HTML string
-#     """
-#
-#     # Todo BEV-3979: resolve the items from live system: contact and representative info should be
-#     # resolved in the ET. That will enable us to re-send the confirmation mail at all times.
-#
-#     # Setup labels to translate fields
-#     labels = {
-#         # section headers
-#         "title": "Titel",
-#         "company": "Bedrijfsinformatie",
-#         # data fields
-#         "company_name": "Bedrijfsnaam",
-#     }
-#     # Map domain model data to labels
-#     data = {
-#         "company_name": subscription.other.company.chamber_of_commerce_name,
-#     }
-#
-#     # Group data in to sections
-#     section_fields = {
-#         "company": ["company_name"],
-#     }
-#     sections = ["company"]
-#
-#     template = get_template_for_product_summary("other_summary.html.j2")
-#     return template.render(
-#         subscription=subscription.model_dump(),
-#         sections=sections,
-#         section_fields=section_fields,
-#         data=data,
-#         labels=labels,
-#         extra_content=extra_content,
-#     )
+def _map_language(language_name: str) -> str:
+    """Map a language name from shop config to a template folder code."""
+    mapping = {
+        "nederlands": "NL",
+        "dutch": "NL",
+        "nl": "NL",
+        "english": "EN",
+        "en": "EN",
+        "engels": "EN",
+        "deutsch": "DE",
+        "german": "DE",
+        "de": "DE",
+    }
+    return mapping.get(language_name.lower().strip(), "NL")
+
+
+def _compute_order_lines_for_email(order_info: list[dict], shop: Any) -> list[dict]:
+    """Build enriched order line dicts with VAT and attribute info for email templates."""
+    from server.crud.crud_product import product_crud
+
+    lines = []
+    for item in order_info:
+        product = product_crud.get_id_by_shop_id(shop.id, item["product_id"])
+
+        # Determine VAT rate from product's tax_category mapped to shop column
+        vat_rate = shop.vat_standard
+        if product and product.tax_category:
+            vat_rate = getattr(shop, product.tax_category, shop.vat_standard)
+
+        price_ex = item["price"]
+        price_inc = round(price_ex * (1 + vat_rate / 100), 2)
+
+        # Collect product attributes
+        attributes = []
+        if product and hasattr(product, "attribute_values") and product.attribute_values:
+            for av in product.attribute_values:
+                attr_name = av.attribute.name
+                if av.attribute.translation and av.attribute.translation.main_name:
+                    attr_name = av.attribute.translation.main_name
+                attr_value = av.option.value_key if av.option else ""
+                attr_unit = av.attribute.unit or ""
+                attributes.append({"name": attr_name, "value": attr_value, "unit": attr_unit})
+
+        lines.append(
+            {
+                "product_name": item.get("product_name", "Unknown product"),
+                "description": item.get("description"),
+                "attributes": attributes,
+                "quantity": item.get("quantity", 1),
+                "price_ex_btw": price_ex,
+                "price_inc_btw": price_inc,
+                "btw_rate": vat_rate,
+                "line_total_ex_btw": round(price_ex * item.get("quantity", 1), 2),
+                "line_total_inc_btw": round(price_inc * item.get("quantity", 1), 2),
+            }
+        )
+    return lines
+
+
+def send_order_confirmation_emails(order: Any, shop: Any, account: Any) -> None:
+    """Send order confirmation emails to both customer and shop owner.
+
+    Args:
+        order: OrderTable instance with order_info, customer_order_id, completed_at
+        shop: ShopTable instance with config (contact, legal, languages) and VAT rates
+        account: Account instance with name (customer email) and details (optional business info)
+    """
+    try:
+        config = shop.config
+        contact = config.get("contact", {})
+        legal = config.get("legal") or {}
+
+        # Determine language from shop config
+        language = "NL"
+        languages_config = config.get("languages", {})
+        main_lang = languages_config.get("main", {})
+        if main_lang.get("language_name"):
+            language = _map_language(main_lang["language_name"])
+
+        # Build order lines with VAT and attribute data
+        order_lines = _compute_order_lines_for_email(order.order_info, shop)
+
+        # Compute totals
+        total_ex_btw = round(sum(line["line_total_ex_btw"] for line in order_lines), 2)
+        total_inc_btw = round(sum(line["line_total_inc_btw"] for line in order_lines), 2)
+        total_btw = round(total_inc_btw - total_ex_btw, 2)
+
+        # Extract business info from account details
+        account_details = account.details or {} if account.details else {}
+        customer_company_name = account_details.get("company_name")
+        customer_btw_number = account_details.get("btw_number")
+
+        # Format completion date
+        completed_at_str = ""
+        if order.completed_at:
+            completed_at_str = order.completed_at.strftime("%d-%m-%Y %H:%M")
+
+        # Common template variables
+        template_vars = {
+            "customer_order_id": order.customer_order_id,
+            "customer_email": account.name,
+            "order_lines": order_lines,
+            "total_ex_btw": total_ex_btw,
+            "total_inc_btw": total_inc_btw,
+            "total_btw": total_btw,
+            "shop_name": shop.name,
+            "shop_company": contact.get("company", shop.name),
+            "shop_address": contact.get("address", ""),
+            "shop_zip_code": contact.get("zip_code", ""),
+            "shop_city": contact.get("city", ""),
+            "shop_phone": contact.get("phone", ""),
+            "shop_email": contact.get("email", ""),
+            "kvk_number": legal.get("kvk_number"),
+            "btw_number": legal.get("btw_number"),
+            "customer_company_name": customer_company_name,
+            "customer_btw_number": customer_btw_number,
+            "completed_at": completed_at_str,
+        }
+
+        env = template_environment(loader)
+        lang_folder = language.lower()
+
+        # Send customer email
+        customer_template = env.get_template(f"{lang_folder}/mail_order_confirmation_customer.html.j2")
+        customer_body = customer_template.render(**template_vars)
+
+        subject_prefix_customer = {
+            "NL": f"Orderbevestiging #{order.customer_order_id} - {shop.name}",
+            "EN": f"Order confirmation #{order.customer_order_id} - {shop.name}",
+        }
+
+        customer_mail: ConfirmationMail = {
+            "message": customer_body,
+            "subject": subject_prefix_customer.get(language, subject_prefix_customer["NL"]),
+            "to": [{"email": account.name, "name": account.name}],
+            "cc": [],
+            "bcc": BCC,
+            "language": language,
+            "images": IMAGES_SHOP_VIRGE,
+        }
+        send_mail(customer_mail)
+        logger.info("Sent order confirmation to customer", order_id=str(order.id), customer=account.name)
+
+        # Send shop owner email
+        owner_email = contact.get("email")
+        if owner_email:
+            owner_template = env.get_template(f"{lang_folder}/mail_order_confirmation_owner.html.j2")
+            owner_body = owner_template.render(**template_vars)
+
+            subject_prefix_owner = {
+                "NL": f"Nieuwe bestelling #{order.customer_order_id} - {shop.name}",
+                "EN": f"New order #{order.customer_order_id} - {shop.name}",
+            }
+
+            owner_mail: ConfirmationMail = {
+                "message": owner_body,
+                "subject": subject_prefix_owner.get(language, subject_prefix_owner["NL"]),
+                "to": [{"email": owner_email, "name": contact.get("company", shop.name)}],
+                "cc": [],
+                "bcc": BCC,
+                "language": language,
+                "images": IMAGES_SHOP_VIRGE,
+            }
+            send_mail(owner_mail)
+            logger.info("Sent order notification to shop owner", order_id=str(order.id), owner=owner_email)
+        else:
+            logger.warning("No shop owner email configured, skipping owner notification", shop_id=str(shop.id))
+
+    except Exception as e:
+        logger.error("Failed to send order confirmation emails", error=str(e), order_id=str(order.id))

--- a/server/mail_templates/en/mail_order_confirmation_customer.html.j2
+++ b/server/mail_templates/en/mail_order_confirmation_customer.html.j2
@@ -1,0 +1,92 @@
+{% set title = 'Order confirmation #' ~ customer_order_id %}
+{% set welcome_text = 'Order confirmation #' ~ customer_order_id %}
+
+{% import 'macros.html.j2' as m %}
+{% extends "default_layout.html.j2" %}
+
+{% block content %}
+<div>
+    <p>Dear customer,</p>
+
+    <p>Thank you for your order at <strong>{{ shop_name }}</strong>. Below you will find a summary of your order.</p>
+
+    {% if customer_company_name %}
+    <table style="width: 100%; margin-bottom: 20px;">
+        <tr>
+            <td style="width: 40%; font-weight: bold;">Company name:</td>
+            <td>{{ customer_company_name }}</td>
+        </tr>
+        {% if customer_btw_number %}
+        <tr>
+            <td style="width: 40%; font-weight: bold;">VAT number:</td>
+            <td>{{ customer_btw_number }}</td>
+        </tr>
+        {% endif %}
+    </table>
+    {% endif %}
+
+    <table style="width: 100%; border-collapse: collapse; margin-top: 20px;">
+        <thead>
+            <tr style="background-color: #f5f5f5; border-bottom: 2px solid #ddd;">
+                <th style="text-align: left; padding: 10px;">Product</th>
+                <th style="text-align: right; padding: 10px;">Qty</th>
+                <th style="text-align: right; padding: 10px;">Price ex VAT</th>
+                <th style="text-align: right; padding: 10px;">VAT %</th>
+                <th style="text-align: right; padding: 10px;">Price inc VAT</th>
+                <th style="text-align: right; padding: 10px;">Total</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for line in order_lines %}
+            <tr style="border-bottom: 1px solid #eee;">
+                <td style="padding: 10px;">
+                    <strong>{{ line.product_name }}</strong>
+                    {% if line.description %}
+                    <br><small style="color: #666;">{{ line.description }}</small>
+                    {% endif %}
+                    {% if line.attributes %}
+                    <br>
+                    {% for attr in line.attributes %}
+                    <small style="color: #666;">{{ attr.name }}: {{ attr.value }}{% if attr.unit %} {{ attr.unit }}{% endif %}{% if not loop.last %}, {% endif %}</small>
+                    {% endfor %}
+                    {% endif %}
+                </td>
+                <td style="text-align: right; padding: 10px;">{{ line.quantity }}</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(line.btw_rate) }}%</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.line_total_inc_btw) }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+        <tfoot>
+            <tr style="border-top: 2px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">Total ex VAT:</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_ex_btw) }}</td>
+            </tr>
+            <tr>
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">VAT:</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_btw) }}</td>
+            </tr>
+            <tr style="border-top: 1px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">Total inc VAT:</td>
+                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro; {{ "%.2f"|format(total_inc_btw) }}</td>
+            </tr>
+        </tfoot>
+    </table>
+
+    <p style="margin-top: 30px;">Order date: {{ completed_at }}</p>
+
+    <hr style="margin-top: 30px; border: none; border-top: 1px solid #ccc;">
+
+    <p style="font-size: 12px; color: #888; margin-top: 20px;">
+        <strong>{{ shop_company }}</strong><br>
+        {{ shop_address }}<br>
+        {{ shop_zip_code }} {{ shop_city }}<br>
+        {% if shop_phone %}Phone: {{ shop_phone }}<br>{% endif %}
+        {% if shop_email %}Email: {{ shop_email }}<br>{% endif %}
+        {% if kvk_number %}CoC: {{ kvk_number }}<br>{% endif %}
+        {% if btw_number %}VAT: {{ btw_number }}{% endif %}
+    </p>
+</div>
+{% endblock %}

--- a/server/mail_templates/en/mail_order_confirmation_owner.html.j2
+++ b/server/mail_templates/en/mail_order_confirmation_owner.html.j2
@@ -1,0 +1,88 @@
+{% set title = 'New order #' ~ customer_order_id %}
+{% set welcome_text = 'New order #' ~ customer_order_id %}
+
+{% import 'macros.html.j2' as m %}
+{% extends "default_layout.html.j2" %}
+
+{% block content %}
+<div>
+    <p>Dear {{ shop_company }},</p>
+
+    <p>A new order has been placed in your shop <strong>{{ shop_name }}</strong>.</p>
+
+    <table style="width: 100%; margin-bottom: 20px; background-color: #f9f9f9; padding: 10px;">
+        <tr>
+            <td style="width: 40%; font-weight: bold; padding: 5px;">Customer email:</td>
+            <td style="padding: 5px;">{{ customer_email }}</td>
+        </tr>
+        <tr>
+            <td style="width: 40%; font-weight: bold; padding: 5px;">Order number:</td>
+            <td style="padding: 5px;">#{{ customer_order_id }}</td>
+        </tr>
+        {% if customer_company_name %}
+        <tr>
+            <td style="width: 40%; font-weight: bold; padding: 5px;">Company name:</td>
+            <td style="padding: 5px;">{{ customer_company_name }}</td>
+        </tr>
+        {% endif %}
+        {% if customer_btw_number %}
+        <tr>
+            <td style="width: 40%; font-weight: bold; padding: 5px;">Customer VAT number:</td>
+            <td style="padding: 5px;">{{ customer_btw_number }}</td>
+        </tr>
+        {% endif %}
+    </table>
+
+    <table style="width: 100%; border-collapse: collapse; margin-top: 20px;">
+        <thead>
+            <tr style="background-color: #f5f5f5; border-bottom: 2px solid #ddd;">
+                <th style="text-align: left; padding: 10px;">Product</th>
+                <th style="text-align: right; padding: 10px;">Qty</th>
+                <th style="text-align: right; padding: 10px;">Price ex VAT</th>
+                <th style="text-align: right; padding: 10px;">VAT %</th>
+                <th style="text-align: right; padding: 10px;">Price inc VAT</th>
+                <th style="text-align: right; padding: 10px;">Total</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for line in order_lines %}
+            <tr style="border-bottom: 1px solid #eee;">
+                <td style="padding: 10px;">
+                    <strong>{{ line.product_name }}</strong>
+                    {% if line.description %}
+                    <br><small style="color: #666;">{{ line.description }}</small>
+                    {% endif %}
+                    {% if line.attributes %}
+                    <br>
+                    {% for attr in line.attributes %}
+                    <small style="color: #666;">{{ attr.name }}: {{ attr.value }}{% if attr.unit %} {{ attr.unit }}{% endif %}{% if not loop.last %}, {% endif %}</small>
+                    {% endfor %}
+                    {% endif %}
+                </td>
+                <td style="text-align: right; padding: 10px;">{{ line.quantity }}</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(line.btw_rate) }}%</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.line_total_inc_btw) }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+        <tfoot>
+            <tr style="border-top: 2px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">Total ex VAT:</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_ex_btw) }}</td>
+            </tr>
+            <tr>
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">VAT:</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_btw) }}</td>
+            </tr>
+            <tr style="border-top: 1px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">Total inc VAT:</td>
+                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro; {{ "%.2f"|format(total_inc_btw) }}</td>
+            </tr>
+        </tfoot>
+    </table>
+
+    <p style="margin-top: 30px;">Order date: {{ completed_at }}</p>
+</div>
+{% endblock %}

--- a/server/mail_templates/nl/mail_order_confirmation_customer.html.j2
+++ b/server/mail_templates/nl/mail_order_confirmation_customer.html.j2
@@ -1,0 +1,92 @@
+{% set title = 'Orderbevestiging #' ~ customer_order_id %}
+{% set welcome_text = 'Orderbevestiging #' ~ customer_order_id %}
+
+{% import 'macros.html.j2' as m %}
+{% extends "default_layout.html.j2" %}
+
+{% block content %}
+<div>
+    <p>Beste klant,</p>
+
+    <p>Bedankt voor je bestelling bij <strong>{{ shop_name }}</strong>. Hieronder vind je een overzicht van je bestelling.</p>
+
+    {% if customer_company_name %}
+    <table style="width: 100%; margin-bottom: 20px;">
+        <tr>
+            <td style="width: 40%; font-weight: bold;">Bedrijfsnaam:</td>
+            <td>{{ customer_company_name }}</td>
+        </tr>
+        {% if customer_btw_number %}
+        <tr>
+            <td style="width: 40%; font-weight: bold;">BTW-nummer:</td>
+            <td>{{ customer_btw_number }}</td>
+        </tr>
+        {% endif %}
+    </table>
+    {% endif %}
+
+    <table style="width: 100%; border-collapse: collapse; margin-top: 20px;">
+        <thead>
+            <tr style="background-color: #f5f5f5; border-bottom: 2px solid #ddd;">
+                <th style="text-align: left; padding: 10px;">Product</th>
+                <th style="text-align: right; padding: 10px;">Aantal</th>
+                <th style="text-align: right; padding: 10px;">Prijs ex BTW</th>
+                <th style="text-align: right; padding: 10px;">BTW %</th>
+                <th style="text-align: right; padding: 10px;">Prijs inc BTW</th>
+                <th style="text-align: right; padding: 10px;">Totaal</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for line in order_lines %}
+            <tr style="border-bottom: 1px solid #eee;">
+                <td style="padding: 10px;">
+                    <strong>{{ line.product_name }}</strong>
+                    {% if line.description %}
+                    <br><small style="color: #666;">{{ line.description }}</small>
+                    {% endif %}
+                    {% if line.attributes %}
+                    <br>
+                    {% for attr in line.attributes %}
+                    <small style="color: #666;">{{ attr.name }}: {{ attr.value }}{% if attr.unit %} {{ attr.unit }}{% endif %}{% if not loop.last %}, {% endif %}</small>
+                    {% endfor %}
+                    {% endif %}
+                </td>
+                <td style="text-align: right; padding: 10px;">{{ line.quantity }}</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(line.btw_rate) }}%</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.line_total_inc_btw) }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+        <tfoot>
+            <tr style="border-top: 2px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">Totaal ex BTW:</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_ex_btw) }}</td>
+            </tr>
+            <tr>
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">BTW:</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_btw) }}</td>
+            </tr>
+            <tr style="border-top: 1px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">Totaal inc BTW:</td>
+                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro; {{ "%.2f"|format(total_inc_btw) }}</td>
+            </tr>
+        </tfoot>
+    </table>
+
+    <p style="margin-top: 30px;">Besteldatum: {{ completed_at }}</p>
+
+    <hr style="margin-top: 30px; border: none; border-top: 1px solid #ccc;">
+
+    <p style="font-size: 12px; color: #888; margin-top: 20px;">
+        <strong>{{ shop_company }}</strong><br>
+        {{ shop_address }}<br>
+        {{ shop_zip_code }} {{ shop_city }}<br>
+        {% if shop_phone %}Tel: {{ shop_phone }}<br>{% endif %}
+        {% if shop_email %}E-mail: {{ shop_email }}<br>{% endif %}
+        {% if kvk_number %}KVK: {{ kvk_number }}<br>{% endif %}
+        {% if btw_number %}BTW: {{ btw_number }}{% endif %}
+    </p>
+</div>
+{% endblock %}

--- a/server/mail_templates/nl/mail_order_confirmation_owner.html.j2
+++ b/server/mail_templates/nl/mail_order_confirmation_owner.html.j2
@@ -1,0 +1,88 @@
+{% set title = 'Nieuwe bestelling #' ~ customer_order_id %}
+{% set welcome_text = 'Nieuwe bestelling #' ~ customer_order_id %}
+
+{% import 'macros.html.j2' as m %}
+{% extends "default_layout.html.j2" %}
+
+{% block content %}
+<div>
+    <p>Beste {{ shop_company }},</p>
+
+    <p>Er is een nieuwe bestelling geplaatst in je shop <strong>{{ shop_name }}</strong>.</p>
+
+    <table style="width: 100%; margin-bottom: 20px; background-color: #f9f9f9; padding: 10px;">
+        <tr>
+            <td style="width: 40%; font-weight: bold; padding: 5px;">Klant e-mail:</td>
+            <td style="padding: 5px;">{{ customer_email }}</td>
+        </tr>
+        <tr>
+            <td style="width: 40%; font-weight: bold; padding: 5px;">Bestelnummer:</td>
+            <td style="padding: 5px;">#{{ customer_order_id }}</td>
+        </tr>
+        {% if customer_company_name %}
+        <tr>
+            <td style="width: 40%; font-weight: bold; padding: 5px;">Bedrijfsnaam:</td>
+            <td style="padding: 5px;">{{ customer_company_name }}</td>
+        </tr>
+        {% endif %}
+        {% if customer_btw_number %}
+        <tr>
+            <td style="width: 40%; font-weight: bold; padding: 5px;">BTW-nummer klant:</td>
+            <td style="padding: 5px;">{{ customer_btw_number }}</td>
+        </tr>
+        {% endif %}
+    </table>
+
+    <table style="width: 100%; border-collapse: collapse; margin-top: 20px;">
+        <thead>
+            <tr style="background-color: #f5f5f5; border-bottom: 2px solid #ddd;">
+                <th style="text-align: left; padding: 10px;">Product</th>
+                <th style="text-align: right; padding: 10px;">Aantal</th>
+                <th style="text-align: right; padding: 10px;">Prijs ex BTW</th>
+                <th style="text-align: right; padding: 10px;">BTW %</th>
+                <th style="text-align: right; padding: 10px;">Prijs inc BTW</th>
+                <th style="text-align: right; padding: 10px;">Totaal</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for line in order_lines %}
+            <tr style="border-bottom: 1px solid #eee;">
+                <td style="padding: 10px;">
+                    <strong>{{ line.product_name }}</strong>
+                    {% if line.description %}
+                    <br><small style="color: #666;">{{ line.description }}</small>
+                    {% endif %}
+                    {% if line.attributes %}
+                    <br>
+                    {% for attr in line.attributes %}
+                    <small style="color: #666;">{{ attr.name }}: {{ attr.value }}{% if attr.unit %} {{ attr.unit }}{% endif %}{% if not loop.last %}, {% endif %}</small>
+                    {% endfor %}
+                    {% endif %}
+                </td>
+                <td style="text-align: right; padding: 10px;">{{ line.quantity }}</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(line.btw_rate) }}%</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.line_total_inc_btw) }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+        <tfoot>
+            <tr style="border-top: 2px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">Totaal ex BTW:</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_ex_btw) }}</td>
+            </tr>
+            <tr>
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">BTW:</td>
+                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_btw) }}</td>
+            </tr>
+            <tr style="border-top: 1px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">Totaal inc BTW:</td>
+                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro; {{ "%.2f"|format(total_inc_btw) }}</td>
+            </tr>
+        </tfoot>
+    </table>
+
+    <p style="margin-top: 30px;">Besteldatum: {{ completed_at }}</p>
+</div>
+{% endblock %}

--- a/server/settings.py
+++ b/server/settings.py
@@ -206,6 +206,8 @@ class MailSettings(BaseSettings):
     MAIL_SERVER: str = "localhost"
     MAIL_PORT: int = 1025  # default to Mailhog, see Readme for setup instructions
     MAIL_STARTTLS: bool = False
+    MAIL_SMTP_USERNAME: str = ""
+    MAIL_SMTP_PASSWORD: str = ""
     MAIL_INFO_NAME: str = "More info"
     MAIL_INFO_LINK: str = "https://shop.pricelist.info"
 

--- a/server/utils/types.py
+++ b/server/utils/types.py
@@ -1,11 +1,12 @@
 from enum import Enum
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from pydantic import EmailStr
 
 
 class MailType(str, Enum):
     INFO = "INFO"
+    ORDER_CONFIRMATION = "ORDER_CONFIRMATION"
 
 
 class InlineImage(TypedDict):
@@ -32,4 +33,5 @@ class ConfirmationMail(TypedDict):
     to: list[MailAddress]
     cc: list[MailAddress]
     bcc: list[MailAddress]
-    sender: MailAddress
+    sender: NotRequired[MailAddress]
+    images: NotRequired[list[InlineImage]]


### PR DESCRIPTION
## Summary
- Send bilingual (NL/EN) order confirmation emails to **customer** and **shop owner** when an order is marked complete
- Each email includes: product name, attributes, quantity, price ex BTW, BTW %, price inc BTW, line totals, and grand totals
- Business purchase support: shows customer company name and VAT number (from `Account.details`) when present
- Legal footer with shop company name, address, KVK number, and BTW number from shop config
- SMTP STARTTLS + authentication support (matching wfo-backend-formatics)
- Guarded by `SHOP_MAIL_ENABLED` setting so it can be toggled per environment

### Files changed
- `server/settings.py` — added `MAIL_SMTP_USERNAME` and `MAIL_SMTP_PASSWORD`
- `server/utils/types.py` — added `ORDER_CONFIRMATION` mail type, fixed `ConfirmationMail` TypedDict
- `server/mail.py` — STARTTLS/auth in `send_mail()`, new `send_order_confirmation_emails()` with VAT computation and attribute lookup
- `server/api/endpoints/shop_endpoints/orders.py` — wired email sending into PATCH endpoint on order completion
- 4 new Jinja2 email templates (NL/EN × customer/owner)

### Known follow-ups
- Frontend: no UI yet for collecting customer business info (company name / VAT nr) during checkout
- No bank account / IBAN field in shop config (may be needed for legal compliance)
- No formal invoice numbering (uses `customer_order_id` as reference)

## Test plan
- [ ] Start Mailhog (`docker run -p 1025:1025 -p 8025:8025 mailhog/mailhog`)
- [ ] Set `SHOP_MAIL_ENABLED=True` and `MAIL_ENABLED=True`
- [ ] Ensure test shop has `config.contact.email` and `config.legal` populated
- [ ] Create an order and PATCH it to status "complete"
- [ ] Verify customer email in Mailhog: order lines, attributes, BTW calculations, legal footer
- [ ] Verify owner email in Mailhog: customer email shown, same order details
- [ ] Test with `SHOP_MAIL_ENABLED=False` — no emails should be sent
- [ ] Run `PYTHONPATH=. pytest tests/unit_tests` — all 97 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)