### PR TITLE
Gate /admin/accounts on Cognito Admins group

### DIFF
--- a/server/api/endpoints/admin_accounts.py
+++ b/server/api/endpoints/admin_accounts.py
@@ -12,10 +12,11 @@
 # limitations under the License.
 """Cross-shop admin endpoints for investigating accounts and Stripe state.
 
-Mounted at ``/admin/accounts``. All handlers require a superuser
-(``Depends(deps.get_current_active_superuser)``). The shop-scoped
-``/shops/{shop_id}/accounts`` routes remain the standard read/write
-path for end-user shops; this router exists so a superuser can:
+Mounted at ``/admin/accounts``. All handlers require membership of the
+Cognito ``Admins`` group (M2M tokens are trusted) via
+``Depends(admin_required)``. The shop-scoped ``/shops/{shop_id}/accounts``
+routes remain the standard read/write path for end-user shops; this
+router exists so an admin can:
 
 * see accounts across every shop in one place,
 * identify accounts that are missing a Stripe linkage,
@@ -35,18 +36,18 @@ from sqlalchemy import or_
 from sqlalchemy.orm import joinedload
 from starlette.responses import Response
 
-from server.api import deps
 from server.api.deps import common_parameters
 from server.api.error_handling import raise_status
 from server.crud.crud_account import account_crud
 from server.db import db
-from server.db.models import Account, UserTable
+from server.db.models import Account
 from server.schemas.admin_account import (
     AdminAccountSchema,
     LinkStripeBody,
     SyncStripeResponse,
     build_admin_account,
 )
+from server.security import admin_required
 from server.services import stripe_client
 from server.services.stripe_client import StripeCustomerMissing, StripeNotConfigured
 
@@ -73,7 +74,7 @@ def _require_linked_shop(account: Account) -> None:
 @router.get(
     "",
     response_model=List[AdminAccountSchema],
-    responses={HTTPStatus.FORBIDDEN.value: {"description": "Not a superuser"}},
+    responses={HTTPStatus.FORBIDDEN.value: {"description": "Not a member of the Admins group"}},
 )
 def list_accounts(
     response: Response,
@@ -83,7 +84,7 @@ def list_accounts(
         description="If true, only accounts without a stripe_customer_id; if false, only those with one.",
     ),
     common: dict = Depends(common_parameters),
-    current_user: UserTable = Depends(deps.get_current_active_superuser),
+    _: object = Depends(admin_required),
 ) -> List[AdminAccountSchema]:
     query = db.session.query(Account).options(joinedload(Account.shop))
 
@@ -118,13 +119,13 @@ def list_accounts(
     "/{id}",
     response_model=AdminAccountSchema,
     responses={
-        HTTPStatus.FORBIDDEN.value: {"description": "Not a superuser"},
+        HTTPStatus.FORBIDDEN.value: {"description": "Not a member of the Admins group"},
         HTTPStatus.NOT_FOUND.value: {"description": "Account not found"},
     },
 )
 def get_account(
     id: UUID,
-    current_user: UserTable = Depends(deps.get_current_active_superuser),
+    _: object = Depends(admin_required),
 ) -> AdminAccountSchema:
     account = _load_account_or_404(id)
     return build_admin_account(account)
@@ -133,7 +134,7 @@ def get_account(
 @router.get(
     "/{id}/stripe-customer",
     responses={
-        HTTPStatus.FORBIDDEN.value: {"description": "Not a superuser"},
+        HTTPStatus.FORBIDDEN.value: {"description": "Not a member of the Admins group"},
         HTTPStatus.NOT_FOUND.value: {"description": "Account not found"},
         HTTPStatus.BAD_REQUEST.value: {"description": "Account or shop not configured for Stripe"},
         HTTPStatus.BAD_GATEWAY.value: {"description": "Stripe API error"},
@@ -141,7 +142,7 @@ def get_account(
 )
 def get_stripe_customer(
     id: UUID,
-    current_user: UserTable = Depends(deps.get_current_active_superuser),
+    _: object = Depends(admin_required),
 ) -> dict:
     """Read-through: fetch the Stripe customer for this account.
 
@@ -175,7 +176,7 @@ def get_stripe_customer(
     "/{id}/sync-stripe",
     response_model=SyncStripeResponse,
     responses={
-        HTTPStatus.FORBIDDEN.value: {"description": "Not a superuser"},
+        HTTPStatus.FORBIDDEN.value: {"description": "Not a member of the Admins group"},
         HTTPStatus.NOT_FOUND.value: {"description": "Account not found"},
         HTTPStatus.BAD_REQUEST.value: {"description": "Account or shop not configured for Stripe"},
         HTTPStatus.BAD_GATEWAY.value: {"description": "Stripe API error"},
@@ -183,7 +184,7 @@ def get_stripe_customer(
 )
 def sync_stripe(
     id: UUID,
-    current_user: UserTable = Depends(deps.get_current_active_superuser),
+    _: object = Depends(admin_required),
 ) -> SyncStripeResponse:
     """Pull the Stripe customer snapshot and persist it on the account.
 
@@ -231,14 +232,14 @@ def sync_stripe(
     "/{id}/link-stripe",
     response_model=AdminAccountSchema,
     responses={
-        HTTPStatus.FORBIDDEN.value: {"description": "Not a superuser"},
+        HTTPStatus.FORBIDDEN.value: {"description": "Not a member of the Admins group"},
         HTTPStatus.NOT_FOUND.value: {"description": "Account not found"},
     },
 )
 def link_stripe(
     id: UUID,
     body: LinkStripeBody = Body(...),
-    current_user: UserTable = Depends(deps.get_current_active_superuser),
+    _: object = Depends(admin_required),
 ) -> AdminAccountSchema:
     """Manually associate a Stripe customer id with an account.
 

--- a/server/security.py
+++ b/server/security.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from datetime import datetime, timedelta
-from typing import Any, Optional, Union
+from typing import Any, List, Optional, Union
 
 from fastapi import HTTPException
 from fastapi.param_functions import Depends
@@ -27,6 +27,8 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 logger = get_logger(__name__)
 
+ADMIN_GROUP = "Admins"
+
 
 class CustomCognitoToken(BaseModel):
     origin_jti: Optional[str] = None
@@ -41,6 +43,9 @@ class CustomCognitoToken(BaseModel):
     jti: str
     client_id: str
     username: str | None = None
+    cognito_groups: List[str] = Field(default_factory=list, alias="cognito:groups")
+
+    model_config = {"populate_by_name": True}
 
 
 cognito_eu = CognitoAuth(settings=CognitoSettings.from_global_settings(auth_settings), custom_model=CustomCognitoToken)
@@ -56,6 +61,17 @@ def auth_required(token: CognitoToken = Depends(cognito_eu.auth_required)):
         return token
 
     raise HTTPException(status_code=401, detail="Invalid OAuth2 scope")
+
+
+def admin_required(token: CognitoToken = Depends(auth_required)):
+    # M2M tokens (already validated by auth_required) are trusted as admin.
+    if token.client_id != app_settings.AWS_COGNITO_CLIENT_ID:
+        return token
+
+    if ADMIN_GROUP in getattr(token, "cognito_groups", []):
+        return token
+
+    raise HTTPException(status_code=403, detail=f"User is not a member of the '{ADMIN_GROUP}' group")
 
 
 def create_access_token(subject: Union[str, Any], expires_delta: Optional[timedelta] = None) -> str:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -10,7 +10,6 @@ from alembic.config import Config
 from fastapi import HTTPException
 from fastapi.applications import FastAPI
 from fastapi.testclient import TestClient
-from fastapi_cognito import CognitoToken
 from sqlalchemy import create_engine, make_url, text
 from sqlalchemy.orm import scoped_session, sessionmaker
 from starlette.middleware.cors import CORSMiddleware
@@ -31,7 +30,7 @@ from server.db.database import (
 )
 from server.db.models import ProductTable, UserTable
 from server.exception_handlers.generic_exception_handlers import problem_detail_handler
-from server.security import auth_required
+from server.security import CustomCognitoToken, auth_required
 from server.settings import app_settings
 from tests.unit_tests.factories.account import make_account
 from tests.unit_tests.factories.attribute import make_attribute, make_attribute_with_translation, make_option, make_pav
@@ -194,9 +193,13 @@ def fastapi_app(database, db_uri):
     # app.add_exception_handler(FormException, form_error_handler)
     app.add_exception_handler(ProblemDetailException, problem_detail_handler)
 
-    def get_current_active_superuser_override() -> CognitoToken:
-        CognitoToken(
-            client_id="1234",
+    def get_current_active_superuser_override() -> CustomCognitoToken:
+        # Return a token with the ``Admins`` Cognito group so the
+        # ``admin_required`` dependency lets requests through in tests.
+        # Use the configured client id so it's treated as a user token,
+        # not M2M, by ``admin_required``.
+        return CustomCognitoToken(
+            client_id=app_settings.AWS_COGNITO_CLIENT_ID,
             sub="5678",
             token_use="access",
             scope="openid profile email",
@@ -206,6 +209,7 @@ def fastapi_app(database, db_uri):
             iat=9727169594,
             jti="jti",
             username="5678",
+            **{"cognito:groups": ["Admins"]},
         )
 
     app.dependency_overrides[auth_required] = get_current_active_superuser_override


### PR DESCRIPTION
## Summary
- `/admin/accounts` returned 403 to users in the Cognito `Admins` group because the router gated on the legacy DB-role `is_superuser` check (`server/db/models.py` only matches a role literally named `"admin"`), which is not how admin status is determined for this API.
- Added `cognito_groups` (alias `cognito:groups`) to `CustomCognitoToken` and a new `admin_required` dependency in `server/security.py` that validates the JWT via `auth_required`, then requires `"Admins"` in `cognito:groups`. M2M tokens (validated by their `/api` scope in `auth_required`) are trusted as admin.
- Swapped the five `Depends(deps.get_current_active_superuser)` calls in `server/api/endpoints/admin_accounts.py` for `Depends(admin_required)`, and updated the module docstring + 403 response descriptions to match.
- Updated the test fixture in `tests/unit_tests/conftest.py` so the `auth_required` override actually returns a `CustomCognitoToken` carrying `cognito:groups=["Admins"]`, letting the new gate pass in tests.

## Notes
- Other endpoints that still rely on `deps.get_current_active_superuser` (`licenses.py`, `users.py`) were left as-is — out of scope for this fix.
- The legacy `get_current_active_superuser` dep and the `RoleTable`/`UserTable.is_superuser` machinery are untouched.

## Test plan
- [x] `PYTHONPATH=. pytest tests/unit_tests` — 127 passed
- [x] `isort . && black .` — clean
- [ ] Hit `GET /admin/accounts?limit=1` in a deployed environment with a Cognito user in the `Admins` group → expect 200
- [ ] Hit the same endpoint with a Cognito user NOT in `Admins` → expect 403 with detail "User is not a member of the 'Admins' group"
- [ ] Hit the same endpoint with a valid M2M token (`scope` ending in `/api`) → expect 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)