### PR TITLE
Disable MAIL_TEST_ENDPOINT_ENABLED in App Runner

### DIFF
--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -21,7 +21,7 @@ run:
     - name: SHOP_MAIL_ENABLED
       value: "true"
     - name: MAIL_TEST_ENDPOINT_ENABLED
-      value: "true"
+      value: "false"
   secrets:
     - name: DATABASE_URI
       value-from: "arn:aws:ssm:eu-central-1:987457788157:parameter/pricelist-backend/DATABASE_URI"


### PR DESCRIPTION
## Summary
- Flips `MAIL_TEST_ENDPOINT_ENABLED` to `"false"` in `apprunner.yaml` now that Mailgun delivery is verified, closing the unauthenticated `/mail-test` route.

## Test plan
- [ ] CI green
- [ ] After deploy, confirm `POST /mail-test/send-order-confirmation` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)