### PR TITLE
Fix double-VAT in order mail and localize completed_at for NL

### DIFF
--- a/docs/api/email-notifications.md
+++ b/docs/api/email-notifications.md
@@ -45,6 +45,22 @@ sequenceDiagram
 
 The call site wraps the send in try/except and logs failures rather than aborting the request — a delivery error must not undo a successful order completion.
 
+## Price and VAT convention
+
+`order_info[*].price` is **VAT-inclusive** — it matches the catalog price the customer sees in the shop. `_compute_order_lines_for_email` treats it as the ground truth and derives the ex-VAT figures by dividing out the applicable rate:
+
+```
+price_inc_btw     = item["price"]
+price_ex_btw      = round(price_inc_btw / (1 + vat_rate/100), 2)
+line_total_inc    = round(price_inc_btw * quantity, 2)
+line_total_ex     = round(line_total_inc / (1 + vat_rate/100), 2)
+```
+
+The VAT rate comes from the product's `tax_category` (e.g. `vat_standard`, `vat_lower_1`), resolved against the shop's per-category rates (`shop.vat_standard`, `shop.vat_lower_1`, …). If the product has no `tax_category`, `shop.vat_standard` is used.
+
+!!! warning
+    Do **not** re-order this math to `price_ex = item["price"]; price_inc = price_ex * (1 + rate/100)`. That double-counts VAT — the displayed "Totaal inc BTW" would no longer match the amount the customer actually paid. See `test_compute_order_lines_treats_stored_price_as_vat_inclusive` in `tests/unit_tests/test_mail.py`.
+
 ## Local smoke-testing (Mailpit)
 
 A disabled-by-default endpoint lets you exercise the full render + SMTP path against a local Mailpit instance without creating a real order.
@@ -57,6 +73,10 @@ The endpoint builds synthetic shop/order/account objects in memory and calls `se
 
 !!! warning
     Never enable `MAIL_TEST_ENDPOINT_ENABLED` in production. The route is unauthenticated; anyone who can reach the backend can trigger outbound mail.
+
+## Completion date timezone
+
+`order.completed_at` is stored as a naive UTC timestamp (PostgreSQL `DateTime` column without `timezone=True`). For NL mails the renderer converts it to `Europe/Amsterdam` so the date shown to the customer matches their local clock; other languages currently render the UTC value as-is. Add new conversions in `send_order_confirmation_emails` when introducing another locale.
 
 ## Language selection
 

--- a/server/mail.py
+++ b/server/mail.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from email.encoders import encode_base64
 from email.mime.base import MIMEBase
 from email.mime.image import MIMEImage
@@ -9,6 +9,7 @@ from functools import singledispatch
 from itertools import filterfalse
 from smtplib import SMTP
 from typing import Any, Callable, NoReturn
+from zoneinfo import ZoneInfo
 
 import html2text
 import jinja2
@@ -394,8 +395,16 @@ def _compute_order_lines_for_email(order_info: list[dict], shop: Any) -> list[di
         if product and product.tax_category:
             vat_rate = getattr(shop, product.tax_category, shop.vat_standard)
 
-        price_ex = item["price"]
-        price_inc = round(price_ex * (1 + vat_rate / 100), 2)
+        # order_info prices are VAT-inclusive (they match the catalog price the
+        # customer sees in the shop). Derive the ex-VAT figures by dividing out
+        # the rate, and keep the inc-VAT line total as the authoritative value
+        # so shown totals match what the customer paid.
+        quantity = item.get("quantity", 1)
+        price_inc = item["price"]
+        vat_divisor = 1 + vat_rate / 100
+        price_ex = round(price_inc / vat_divisor, 2)
+        line_total_inc = round(price_inc * quantity, 2)
+        line_total_ex = round(line_total_inc / vat_divisor, 2)
 
         # Collect product attributes
         attributes = []
@@ -413,12 +422,12 @@ def _compute_order_lines_for_email(order_info: list[dict], shop: Any) -> list[di
                 "product_name": item.get("product_name", "Unknown product"),
                 "description": item.get("description"),
                 "attributes": attributes,
-                "quantity": item.get("quantity", 1),
+                "quantity": quantity,
                 "price_ex_btw": price_ex,
                 "price_inc_btw": price_inc,
                 "btw_rate": vat_rate,
-                "line_total_ex_btw": round(price_ex * item.get("quantity", 1), 2),
-                "line_total_inc_btw": round(price_inc * item.get("quantity", 1), 2),
+                "line_total_ex_btw": line_total_ex,
+                "line_total_inc_btw": line_total_inc,
             }
         )
     return lines
@@ -457,10 +466,17 @@ def send_order_confirmation_emails(order: Any, shop: Any, account: Any) -> None:
         customer_company_name = account_details.get("company_name")
         customer_btw_number = account_details.get("btw_number")
 
-        # Format completion date
+        # Format completion date. `completed_at` is stored as a naive UTC timestamp
+        # (DateTime column without timezone=True); for NL mails we render it in
+        # Europe/Amsterdam so the date shown to customers matches their local clock.
         completed_at_str = ""
         if order.completed_at:
-            completed_at_str = order.completed_at.strftime("%d-%m-%Y %H:%M")
+            completed_at_dt = order.completed_at
+            if completed_at_dt.tzinfo is None:
+                completed_at_dt = completed_at_dt.replace(tzinfo=timezone.utc)
+            if language == "NL":
+                completed_at_dt = completed_at_dt.astimezone(ZoneInfo("Europe/Amsterdam"))
+            completed_at_str = completed_at_dt.strftime("%d-%m-%Y %H:%M")
 
         # Common template variables
         template_vars = {

--- a/tests/unit_tests/test_mail.py
+++ b/tests/unit_tests/test_mail.py
@@ -5,7 +5,7 @@ import pytest
 
 from server.db import db
 from server.db.models import OrderTable, ShopTable
-from server.mail import send_order_confirmation_emails
+from server.mail import _compute_order_lines_for_email, send_order_confirmation_emails
 from tests.unit_tests.factories.account import make_account
 from tests.unit_tests.factories.categories import make_category
 from tests.unit_tests.factories.product import make_product
@@ -115,3 +115,69 @@ def test_send_order_confirmation_emails_swallows_render_errors(shop_with_config,
 
     send_order_confirmation_emails(order=broken_order, shop=shop, account=account)
     assert smtp_cls.call_count == 0
+
+
+def test_compute_order_lines_treats_stored_price_as_vat_inclusive(completed_order, shop_with_config):
+    """Stored order_info price includes VAT — ex-VAT must divide out the rate, not add it on top.
+
+    The first order line is Widget A at price 10.00 x 2, VAT 21% (shop.vat_standard).
+    After the fix, price_inc_btw == 10.00 (as stored), price_ex_btw == 10.00 / 1.21 ≈ 8.26,
+    and line_total_inc_btw == 20.00. Prior to the fix, price_inc_btw came out as 12.10
+    because ex was treated as the ground truth and VAT was stacked on top.
+    """
+    order = db.session.get(OrderTable, completed_order)
+    shop = db.session.get(ShopTable, shop_with_config)
+
+    lines = _compute_order_lines_for_email(order.order_info, shop)
+
+    widget_a = next(line for line in lines if line["product_name"] == "Widget A")
+    assert widget_a["btw_rate"] == shop.vat_standard
+    assert widget_a["price_inc_btw"] == 10.0, "stored price must be surfaced as the inc-VAT price"
+    assert widget_a["price_ex_btw"] == round(10.0 / 1.21, 2)
+    assert widget_a["line_total_inc_btw"] == 20.0
+    assert widget_a["line_total_ex_btw"] == round(20.0 / 1.21, 2)
+
+    widget_b = next(line for line in lines if line["product_name"] == "Widget B")
+    assert widget_b["price_inc_btw"] == 5.0
+    assert widget_b["price_ex_btw"] == round(5.0 / 1.21, 2)
+    assert widget_b["line_total_inc_btw"] == 5.0
+
+
+def test_customer_mail_shows_completed_at_in_europe_amsterdam_for_nl(completed_order, shop_with_config, mock_smtp):
+    """NL mails render order.completed_at in Europe/Amsterdam, not UTC.
+
+    The fixture sets completed_at = 2026-04-23 12:00 UTC. In late April the
+    Netherlands is on CEST (UTC+2), so the rendered date string must read 14:00,
+    not 12:00. Without conversion the mail would show the customer a time two
+    hours behind the moment they actually placed the order.
+    """
+    _, smtp_instance = mock_smtp
+    order = db.session.get(OrderTable, completed_order)
+    shop = db.session.get(ShopTable, shop_with_config)
+
+    send_order_confirmation_emails(order=order, shop=shop, account=order.account)
+
+    customer_call = next(
+        call for call in smtp_instance.send_message.call_args_list if call.args[0]["To"] == "customer@example.com"
+    )
+    message = customer_call.args[0]
+    html_parts = [part for part in message.walk() if part.get_content_type() == "text/html"]
+    assert html_parts, "no HTML part in customer mail"
+    html_body = html_parts[0].get_payload(decode=True).decode("utf-8")
+
+    assert "23-04-2026 14:00" in html_body, "expected Amsterdam-local time in NL mail body"
+    assert "23-04-2026 12:00" not in html_body, "UTC value must not leak into NL mail"
+
+
+def test_compute_order_lines_zero_vat_is_lossless(completed_order, shop_with_config):
+    """With a 0% VAT rate, ex and inc figures must be identical (no division by zero fragility)."""
+    shop = db.session.get(ShopTable, shop_with_config)
+    shop.vat_standard = 0.0
+    db.session.commit()
+
+    order = db.session.get(OrderTable, completed_order)
+    lines = _compute_order_lines_for_email(order.order_info, shop)
+
+    for line in lines:
+        assert line["price_ex_btw"] == line["price_inc_btw"]
+        assert line["line_total_ex_btw"] == line["line_total_inc_btw"]


### PR DESCRIPTION
## Summary
- Treat `order_info[*].price` as VAT-inclusive (matches the catalog price the customer sees); derive ex-VAT by dividing the rate out instead of stacking it on top. Old behavior inflated the customer-facing "Totaal inc BTW" above the amount actually paid.
- Convert `order.completed_at` (naive UTC) to `Europe/Amsterdam` for NL mails so the Besteldatum shows the customer's local clock.
- Lock both behaviors with unit tests and document the conventions in `docs/api/email-notifications.md`.

## Test plan
- [x] `pytest tests/unit_tests/test_mail.py` — all 6 green locally
- [x] Full suite (133 passed) locally
- [ ] CI green
- [ ] Trigger a real order mail and verify the inc total matches what Stripe charged, and that Besteldatum reads Amsterdam-local time

🤖 Generated with [Claude Code](https://claude.com/claude-code)