### PR TITLE
Migrate monetary float to Decimal with backward-compatible API (#114)

### DIFF
--- a/migrations/versions/schema/2026-05-07_762f0ee89e95_money_columns_to_numeric.py
+++ b/migrations/versions/schema/2026-05-07_762f0ee89e95_money_columns_to_numeric.py
@@ -1,0 +1,77 @@
+"""Convert monetary Float columns to Numeric.
+
+Revision ID: 762f0ee89e95
+Revises: 8037ea701b64
+Create Date: 2026-05-07 22:30:00.000000
+
+Float was unsuitable for monetary values (binary representation, accumulated
+rounding error). All money columns become Numeric(12, 2) and the VAT-rate
+columns on shops become Numeric(5, 2). The PostgreSQL ``USING <col>::numeric``
+clause performs the in-place cast on existing rows.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "762f0ee89e95"
+down_revision = "8037ea701b64"
+branch_labels = None
+depends_on = None
+
+
+_MONEY_COLUMNS: list[tuple[str, str]] = [
+    ("orders", "total"),
+    ("orders", "shipping_fee_inc_btw"),
+    ("products", "price"),
+    ("products", "discounted_price"),
+    ("products", "recurring_price_monthly"),
+    ("products", "recurring_price_yearly"),
+]
+
+_VAT_RATE_COLUMNS: list[tuple[str, str]] = [
+    ("shops", "vat_standard"),
+    ("shops", "vat_lower_1"),
+    ("shops", "vat_lower_2"),
+    ("shops", "vat_lower_3"),
+    ("shops", "vat_special"),
+    ("shops", "vat_zero"),
+]
+
+
+def upgrade() -> None:
+    for table, column in _MONEY_COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            type_=sa.Numeric(12, 2),
+            existing_type=sa.Float(),
+            postgresql_using=f"{column}::numeric(12, 2)",
+        )
+    for table, column in _VAT_RATE_COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            type_=sa.Numeric(5, 2),
+            existing_type=sa.Float(),
+            postgresql_using=f"{column}::numeric(5, 2)",
+        )
+
+
+def downgrade() -> None:
+    for table, column in _MONEY_COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            type_=sa.Float(),
+            existing_type=sa.Numeric(12, 2),
+            postgresql_using=f"{column}::double precision",
+        )
+    for table, column in _VAT_RATE_COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            type_=sa.Float(),
+            existing_type=sa.Numeric(5, 2),
+            postgresql_using=f"{column}::double precision",
+        )

--- a/server/api/endpoints/shop_endpoints/orders.py
+++ b/server/api/endpoints/shop_endpoints/orders.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from decimal import Decimal
 from http import HTTPStatus
 from operator import or_
 from typing import Any, List, Optional
@@ -24,6 +25,7 @@ from server.db.models import Account, OrderTable, ShopTable, UserTable
 from server.mail import send_order_confirmation_emails
 from server.schemas import ProductUpdate
 from server.schemas.account import AccountCreate
+from server.schemas.base import quantize_money
 from server.schemas.order import OrderBase, OrderCreate, OrderCreated, OrderSchema, OrderUpdate, OrderUpdated
 from server.schemas.product import ProductTranslationBase
 from server.security import auth_required
@@ -311,8 +313,8 @@ def create(request: Request, data: OrderCreate = Body(...)) -> OrderCreated:
     # server-side so it can't be manipulated by the client.
     shipping_calc = compute_shipping_for_cart(data.order_info, shop)
     data.shipping_fee_inc_btw = shipping_calc.fee_inc_btw if shipping_calc is not None else None
-    items_total = sum(item.price * item.quantity for item in data.order_info)
-    data.total = round(items_total + (data.shipping_fee_inc_btw or 0.0), 2)
+    items_total = sum((item.price * item.quantity for item in data.order_info), Decimal("0"))
+    data.total = quantize_money(items_total + (data.shipping_fee_inc_btw or Decimal("0")))
 
     order = order_crud.create(obj_in=data)
 

--- a/server/api/endpoints/shop_endpoints/prices.py
+++ b/server/api/endpoints/shop_endpoints/prices.py
@@ -20,6 +20,7 @@ from server.db.models import (
     ProductAttributeValueTable,
     ProductTranslationTable,
 )
+from server.schemas.base import Money
 from server.schemas.product_attribute import ProductAttributeItem
 
 router = APIRouter()
@@ -47,17 +48,17 @@ class ProductResponse(BaseModel):
     description_short: str
     description: str
     tax_category: str
-    tax_percentage: float
-    price: float | None = None
-    recurring_price_monthly: float | None = None
-    recurring_price_yearly: float | None = None
+    tax_percentage: Money
+    price: Money | None = None
+    recurring_price_monthly: Money | None = None
+    recurring_price_yearly: Money | None = None
     max_one: bool
     shippable: bool
     attributes: list[str] = []
     digital: str | None = None
     featured: bool
     new_product: bool
-    discounted_price: float | None = None
+    discounted_price: Money | None = None
     discounted_from: datetime | None = None
     discounted_to: datetime | None = None
     image_1: str | None = None

--- a/server/api/endpoints/shop_endpoints/shipping.py
+++ b/server/api/endpoints/shop_endpoints/shipping.py
@@ -10,6 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from decimal import Decimal
 from http import HTTPStatus
 
 import structlog
@@ -37,9 +38,9 @@ def calculate(data: ShippingCalculateRequest = Body(...)) -> ShippingCalculation
         return ShippingCalculation(
             enabled=False,
             method=None,
-            fee_inc_btw=0.0,
-            fee_ex_btw=0.0,
-            fee_btw=0.0,
+            fee_inc_btw=Decimal("0.00"),
+            fee_ex_btw=Decimal("0.00"),
+            fee_btw=Decimal("0.00"),
             free_shipping_applied=False,
             free_shipping_threshold=None,
             lines=[],

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
+from decimal import Decimal
 from typing import Optional
 
 import sqlalchemy
@@ -24,9 +25,9 @@ from sqlalchemy import (
     Column,
     DateTime,
     Enum,
-    Float,
     ForeignKey,
     Integer,
+    Numeric,
     String,
     TypeDecorator,
     func,
@@ -174,12 +175,12 @@ class ShopTable(BaseModel):
     config_version = Column(Integer, nullable=False, server_default="1")
     stripe_secret_key = Column(String(255), nullable=True)
     stripe_public_key = Column(String(255), nullable=True)
-    vat_standard = Column(Float, default=21.0)
-    vat_lower_1 = Column(Float, default=10.0)
-    vat_lower_2 = Column(Float, default=5.0)
-    vat_lower_3 = Column(Float, default=2.0)
-    vat_special = Column(Float, default=12.0)
-    vat_zero = Column(Float, default=0.0)
+    vat_standard = Column(Numeric(5, 2), default=Decimal("21.00"))
+    vat_lower_1 = Column(Numeric(5, 2), default=Decimal("10.00"))
+    vat_lower_2 = Column(Numeric(5, 2), default=Decimal("5.00"))
+    vat_lower_3 = Column(Numeric(5, 2), default=Decimal("2.00"))
+    vat_special = Column(Numeric(5, 2), default=Decimal("12.00"))
+    vat_zero = Column(Numeric(5, 2), default=Decimal("0.00"))
     internal_url = Column(String(255), nullable=True, server_default="")
     external_url = Column(String(255), nullable=True, server_default="")
     created_at = Column(UtcTimestamp, server_default=text("CURRENT_TIMESTAMP"))
@@ -303,8 +304,8 @@ class OrderTable(BaseModel):
     shop_id = Column(UUIDType, ForeignKey("shops.id"), index=True)
     account_id = Column(UUIDType, ForeignKey("accounts.id", ondelete="CASCADE"), nullable=True)
     order_info = Column(postgresql.JSONB())
-    total = Column(Float())
-    shipping_fee_inc_btw = Column(Float(), nullable=True)
+    total = Column(Numeric(12, 2))
+    shipping_fee_inc_btw = Column(Numeric(12, 2), nullable=True)
     status = Column(String(), default="pending")
     created_at = Column(DateTime, server_default=func.now())
     completed_by = Column("completed_by", UUIDType, ForeignKey("users.id"), nullable=True)
@@ -328,13 +329,13 @@ class ProductTable(BaseModel):
     )
     shop_id = Column("shop_id", UUIDType, ForeignKey("shops.id"), index=True)
     category_id = Column("category_id", UUIDType, ForeignKey("categories.id"), index=True)
-    price = Column(Float(), nullable=True)
+    price = Column(Numeric(12, 2), nullable=True)
     tax_category = Column(String(20), default="vat_standard")
-    discounted_price = Column(Float(), nullable=True)
+    discounted_price = Column(Numeric(12, 2), nullable=True)
     discounted_from = Column(DateTime, nullable=True)
     discounted_to = Column(DateTime, nullable=True)
-    recurring_price_monthly = Column(Float(), nullable=True)
-    recurring_price_yearly = Column(Float(), nullable=True)
+    recurring_price_monthly = Column(Numeric(12, 2), nullable=True)
+    recurring_price_yearly = Column(Numeric(12, 2), nullable=True)
     max_one = Column(Boolean(), default=False)
     digital = Column(String(255), nullable=True)  # if provided: links to original asset
     shippable = Column(Boolean(), default=True)

--- a/server/mail.py
+++ b/server/mail.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timezone
+from decimal import Decimal
 from email.encoders import encode_base64
 from email.mime.base import MIMEBase
 from email.mime.image import MIMEImage
@@ -15,6 +16,7 @@ import html2text
 import jinja2
 import structlog
 
+from server.schemas.base import quantize_money
 from server.schemas.product import ProductBase
 from server.settings import mail_settings, template_environment
 from server.utils.date_utils import nowtz
@@ -398,11 +400,12 @@ def _compute_order_lines_for_email(order_info: list[dict], shop: Any) -> list[di
         # the rate, and keep the inc-VAT line total as the authoritative value
         # so shown totals match what the customer paid.
         quantity = item.get("quantity", 1)
-        price_inc = item["price"]
-        vat_divisor = 1 + vat_rate / 100
-        price_ex = round(price_inc / vat_divisor, 2)
-        line_total_inc = round(price_inc * quantity, 2)
-        line_total_ex = round(line_total_inc / vat_divisor, 2)
+        price_inc_raw = item["price"]
+        price_inc = price_inc_raw if isinstance(price_inc_raw, Decimal) else Decimal(str(price_inc_raw))
+        vat_divisor = Decimal("1") + vat_rate / Decimal("100")
+        price_ex = quantize_money(price_inc / vat_divisor)
+        line_total_inc = quantize_money(price_inc * quantity)
+        line_total_ex = quantize_money(line_total_inc / vat_divisor)
 
         # Collect product attributes
         attributes = []
@@ -455,16 +458,21 @@ def send_order_confirmation_emails(order: Any, shop: Any, account: Any) -> None:
         order_lines = _compute_order_lines_for_email(order.order_info, shop)
 
         # Compute item totals
-        items_total_ex_btw = round(sum(line["line_total_ex_btw"] for line in order_lines), 2)
-        items_total_inc_btw = round(sum(line["line_total_inc_btw"] for line in order_lines), 2)
+        items_total_ex_btw = quantize_money(sum((line["line_total_ex_btw"] for line in order_lines), Decimal("0")))
+        items_total_inc_btw = quantize_money(sum((line["line_total_inc_btw"] for line in order_lines), Decimal("0")))
 
         # Build shipping lines (one per VAT rate) using the same allocation logic
         # the order create endpoint used. Persisted on the order as a single
         # inc-VAT figure; we re-derive the per-rate split for display.
-        shipping_fee_inc_btw = getattr(order, "shipping_fee_inc_btw", None)
+        shipping_fee_raw = getattr(order, "shipping_fee_inc_btw", None)
+        shipping_fee_inc_btw: Decimal | None = (
+            None
+            if shipping_fee_raw is None
+            else (shipping_fee_raw if isinstance(shipping_fee_raw, Decimal) else Decimal(str(shipping_fee_raw)))
+        )
         shipping_lines: list[dict] = []
-        shipping_total_ex_btw = 0.0
-        shipping_total_inc_btw = 0.0
+        shipping_total_ex_btw = Decimal("0")
+        shipping_total_inc_btw = Decimal("0")
         if shipping_fee_inc_btw is not None and shipping_fee_inc_btw > 0:
             from server.services.shipping import allocate_shipping_lines, build_rate_subtotals
 
@@ -478,12 +486,14 @@ def send_order_confirmation_emails(order: Any, shop: Any, account: Any) -> None:
                         "amount_btw": sl.amount_btw,
                     }
                 )
-            shipping_total_ex_btw = round(sum(line["amount_ex_btw"] for line in shipping_lines), 2)
-            shipping_total_inc_btw = round(shipping_fee_inc_btw, 2)
+            shipping_total_ex_btw = quantize_money(
+                sum((line["amount_ex_btw"] for line in shipping_lines), Decimal("0"))
+            )
+            shipping_total_inc_btw = quantize_money(shipping_fee_inc_btw)
 
-        total_ex_btw = round(items_total_ex_btw + shipping_total_ex_btw, 2)
-        total_inc_btw = round(items_total_inc_btw + shipping_total_inc_btw, 2)
-        total_btw = round(total_inc_btw - total_ex_btw, 2)
+        total_ex_btw = quantize_money(items_total_ex_btw + shipping_total_ex_btw)
+        total_inc_btw = quantize_money(items_total_inc_btw + shipping_total_inc_btw)
+        total_btw = quantize_money(total_inc_btw - total_ex_btw)
 
         # Extract business info from account details
         account_details = account.details or {} if account.details else {}

--- a/server/mail.py
+++ b/server/mail.py
@@ -463,7 +463,10 @@ def send_order_confirmation_emails(order: Any, shop: Any, account: Any) -> None:
 
         # Build shipping lines (one per VAT rate) using the same allocation logic
         # the order create endpoint used. Persisted on the order as a single
-        # inc-VAT figure; we re-derive the per-rate split for display.
+        # inc-VAT figure; we re-derive the per-rate split for display by
+        # re-running the shipping calculation against current shop config.
+        # When the shop opts out of VAT on shipping, the calc returns no lines
+        # and the fee is rendered flat.
         shipping_fee_raw = getattr(order, "shipping_fee_inc_btw", None)
         shipping_fee_inc_btw: Decimal | None = (
             None
@@ -474,22 +477,27 @@ def send_order_confirmation_emails(order: Any, shop: Any, account: Any) -> None:
         shipping_total_ex_btw = Decimal("0")
         shipping_total_inc_btw = Decimal("0")
         if shipping_fee_inc_btw is not None and shipping_fee_inc_btw > 0:
-            from server.services.shipping import allocate_shipping_lines, build_rate_subtotals
+            from server.services.shipping import compute_shipping_for_cart
 
-            rate_subtotals = build_rate_subtotals(order.order_info, shop)
-            for sl in allocate_shipping_lines(shipping_fee_inc_btw, rate_subtotals):
-                shipping_lines.append(
-                    {
-                        "btw_rate": sl.btw_rate,
-                        "amount_ex_btw": sl.amount_ex_btw,
-                        "amount_inc_btw": sl.amount_inc_btw,
-                        "amount_btw": sl.amount_btw,
-                    }
-                )
-            shipping_total_ex_btw = quantize_money(
-                sum((line["amount_ex_btw"] for line in shipping_lines), Decimal("0"))
-            )
+            shipping_calc = compute_shipping_for_cart(order.order_info, shop)
+            if shipping_calc is not None and not shipping_calc.free_shipping_applied:
+                for sl in shipping_calc.lines:
+                    shipping_lines.append(
+                        {
+                            "btw_rate": sl.btw_rate,
+                            "amount_ex_btw": sl.amount_ex_btw,
+                            "amount_inc_btw": sl.amount_inc_btw,
+                            "amount_btw": sl.amount_btw,
+                        }
+                    )
             shipping_total_inc_btw = quantize_money(shipping_fee_inc_btw)
+            if shipping_lines:
+                shipping_total_ex_btw = quantize_money(
+                    sum((line["amount_ex_btw"] for line in shipping_lines), Decimal("0"))
+                )
+            else:
+                # VAT bypass (or unknown config): flat fee with no VAT split.
+                shipping_total_ex_btw = shipping_total_inc_btw
 
         total_ex_btw = quantize_money(items_total_ex_btw + shipping_total_ex_btw)
         total_inc_btw = quantize_money(items_total_inc_btw + shipping_total_inc_btw)

--- a/server/mail_templates/en/mail_order_confirmation_customer.html.j2
+++ b/server/mail_templates/en/mail_order_confirmation_customer.html.j2
@@ -52,10 +52,10 @@
                     {% endif %}
                 </td>
                 <td style="text-align: right; padding: 10px;">{{ line.quantity }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.price_ex_btw) }}</td>
                 <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(line.btw_rate) }}%</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_inc_btw) }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.line_total_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.price_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.line_total_inc_btw) }}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -64,12 +64,17 @@
             {% for s in shipping_lines %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="2" style="padding: 10px;"><strong>Shipping</strong></td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_ex_btw) }}</td>
                 <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(s.btw_rate) }}%</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_inc_btw) }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_inc_btw) }}</td>
             </tr>
             {% endfor %}
+            {% elif shipping_fee_inc_btw is not none and shipping_fee_inc_btw > 0 %}
+            <tr style="border-top: 2px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px;"><strong>Shipping:</strong></td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(shipping_fee_inc_btw) }}</td>
+            </tr>
             {% elif shipping_fee_inc_btw is not none and shipping_fee_inc_btw == 0 %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px;"><strong>Shipping:</strong></td>
@@ -78,15 +83,15 @@
             {% endif %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">Total ex VAT:</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(total_ex_btw) }}</td>
             </tr>
             <tr>
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">VAT:</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(total_btw) }}</td>
             </tr>
             <tr style="border-top: 1px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">Total inc VAT:</td>
-                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro; {{ "%.2f"|format(total_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro;&nbsp;{{ "%.2f"|format(total_inc_btw) }}</td>
             </tr>
         </tfoot>
     </table>

--- a/server/mail_templates/en/mail_order_confirmation_owner.html.j2
+++ b/server/mail_templates/en/mail_order_confirmation_owner.html.j2
@@ -60,10 +60,10 @@
                     {% endif %}
                 </td>
                 <td style="text-align: right; padding: 10px;">{{ line.quantity }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.price_ex_btw) }}</td>
                 <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(line.btw_rate) }}%</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_inc_btw) }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.line_total_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.price_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.line_total_inc_btw) }}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -72,12 +72,17 @@
             {% for s in shipping_lines %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="2" style="padding: 10px;"><strong>Shipping</strong></td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_ex_btw) }}</td>
                 <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(s.btw_rate) }}%</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_inc_btw) }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_inc_btw) }}</td>
             </tr>
             {% endfor %}
+            {% elif shipping_fee_inc_btw is not none and shipping_fee_inc_btw > 0 %}
+            <tr style="border-top: 2px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px;"><strong>Shipping:</strong></td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(shipping_fee_inc_btw) }}</td>
+            </tr>
             {% elif shipping_fee_inc_btw is not none and shipping_fee_inc_btw == 0 %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px;"><strong>Shipping:</strong></td>
@@ -86,15 +91,15 @@
             {% endif %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">Total ex VAT:</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(total_ex_btw) }}</td>
             </tr>
             <tr>
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">VAT:</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(total_btw) }}</td>
             </tr>
             <tr style="border-top: 1px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">Total inc VAT:</td>
-                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro; {{ "%.2f"|format(total_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro;&nbsp;{{ "%.2f"|format(total_inc_btw) }}</td>
             </tr>
         </tfoot>
     </table>

--- a/server/mail_templates/nl/mail_order_confirmation_customer.html.j2
+++ b/server/mail_templates/nl/mail_order_confirmation_customer.html.j2
@@ -52,10 +52,10 @@
                     {% endif %}
                 </td>
                 <td style="text-align: right; padding: 10px;">{{ line.quantity }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.price_ex_btw) }}</td>
                 <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(line.btw_rate) }}%</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_inc_btw) }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.line_total_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.price_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.line_total_inc_btw) }}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -64,12 +64,17 @@
             {% for s in shipping_lines %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="2" style="padding: 10px;"><strong>Verzendkosten</strong></td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_ex_btw) }}</td>
                 <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(s.btw_rate) }}%</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_inc_btw) }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_inc_btw) }}</td>
             </tr>
             {% endfor %}
+            {% elif shipping_fee_inc_btw is not none and shipping_fee_inc_btw > 0 %}
+            <tr style="border-top: 2px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px;"><strong>Verzendkosten:</strong></td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(shipping_fee_inc_btw) }}</td>
+            </tr>
             {% elif shipping_fee_inc_btw is not none and shipping_fee_inc_btw == 0 %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px;"><strong>Verzendkosten:</strong></td>
@@ -78,15 +83,15 @@
             {% endif %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">Totaal ex BTW:</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(total_ex_btw) }}</td>
             </tr>
             <tr>
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">BTW:</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(total_btw) }}</td>
             </tr>
             <tr style="border-top: 1px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">Totaal inc BTW:</td>
-                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro; {{ "%.2f"|format(total_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro;&nbsp;{{ "%.2f"|format(total_inc_btw) }}</td>
             </tr>
         </tfoot>
     </table>

--- a/server/mail_templates/nl/mail_order_confirmation_owner.html.j2
+++ b/server/mail_templates/nl/mail_order_confirmation_owner.html.j2
@@ -60,10 +60,10 @@
                     {% endif %}
                 </td>
                 <td style="text-align: right; padding: 10px;">{{ line.quantity }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.price_ex_btw) }}</td>
                 <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(line.btw_rate) }}%</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.price_inc_btw) }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(line.line_total_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.price_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(line.line_total_inc_btw) }}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -72,12 +72,17 @@
             {% for s in shipping_lines %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="2" style="padding: 10px;"><strong>Verzendkosten</strong></td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_ex_btw) }}</td>
                 <td style="text-align: right; padding: 10px;">{{ "%.0f"|format(s.btw_rate) }}%</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_inc_btw) }}</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(s.amount_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(s.amount_inc_btw) }}</td>
             </tr>
             {% endfor %}
+            {% elif shipping_fee_inc_btw is not none and shipping_fee_inc_btw > 0 %}
+            <tr style="border-top: 2px solid #ddd;">
+                <td colspan="5" style="text-align: right; padding: 10px;"><strong>Verzendkosten:</strong></td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(shipping_fee_inc_btw) }}</td>
+            </tr>
             {% elif shipping_fee_inc_btw is not none and shipping_fee_inc_btw == 0 %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px;"><strong>Verzendkosten:</strong></td>
@@ -86,15 +91,15 @@
             {% endif %}
             <tr style="border-top: 2px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">Totaal ex BTW:</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_ex_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(total_ex_btw) }}</td>
             </tr>
             <tr>
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold;">BTW:</td>
-                <td style="text-align: right; padding: 10px;">&euro; {{ "%.2f"|format(total_btw) }}</td>
+                <td style="text-align: right; padding: 10px;">&euro;&nbsp;{{ "%.2f"|format(total_btw) }}</td>
             </tr>
             <tr style="border-top: 1px solid #ddd;">
                 <td colspan="5" style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">Totaal inc BTW:</td>
-                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro; {{ "%.2f"|format(total_inc_btw) }}</td>
+                <td style="text-align: right; padding: 10px; font-weight: bold; font-size: 18px;">&euro;&nbsp;{{ "%.2f"|format(total_inc_btw) }}</td>
             </tr>
         </tfoot>
     </table>

--- a/server/main.py
+++ b/server/main.py
@@ -67,7 +67,7 @@ async def lifespan(app_: FastAPI):
     yield
 
 
-APP_VERSION = "0.2.8"
+APP_VERSION = "0.2.9"
 
 app = FastAPI(
     title="ShopVirge API",

--- a/server/schemas/base.py
+++ b/server/schemas/base.py
@@ -12,8 +12,31 @@
 # limitations under the License.
 
 from datetime import datetime
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Annotated, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, PlainSerializer
+
+
+def quantize_money(value: Union[Decimal, int, float, str], places: int = 2) -> Decimal:
+    """Quantize a value to ``places`` decimal places using ROUND_HALF_UP.
+
+    Accepts Decimal, int, float, or string. Floats are converted via ``str()``
+    first to avoid binary-representation noise (e.g. ``Decimal(0.1)`` carries
+    the float artefact, but ``Decimal(str(0.1))`` is exact).
+    """
+    if not isinstance(value, Decimal):
+        value = Decimal(str(value))
+    q = Decimal(10) ** -places
+    return value.quantize(q, rounding=ROUND_HALF_UP)
+
+
+# Money: Decimal internally, but JSON-serialized as a number (not a string) so
+# the wire format stays backward compatible with clients that expect floats.
+Money = Annotated[
+    Decimal,
+    PlainSerializer(lambda v: float(v), return_type=float, when_used="json"),
+]
 
 
 class BoilerplateBaseModel(BaseModel):

--- a/server/schemas/order.py
+++ b/server/schemas/order.py
@@ -15,15 +15,13 @@ from datetime import datetime
 from typing import Any, List, Optional
 from uuid import UUID
 
-from pydantic.v1 import BaseModel, root_validator
-
-from server.schemas.base import BoilerplateBaseModel
+from server.schemas.base import BoilerplateBaseModel, Money
 
 
 # Made them optional for now because there are some empty order_info fields in DB
 class OrderItem(BoilerplateBaseModel):
     description: Optional[str]
-    price: float  # Was optional
+    price: Money  # Was optional
     # kind_id: Optional[str]
     # kind_name: Optional[str]
     product_id: UUID  # Was optional
@@ -46,11 +44,11 @@ class OrderItem(BoilerplateBaseModel):
 
 class OrderBase(BoilerplateBaseModel):
     account_id: Optional[UUID] = None  # Optional for account creation on absence
-    total: Optional[float]
+    total: Optional[Money]
     notes: Optional[str]
     customer_order_id: Optional[int]  # Optional or required ?
     status: Optional[str]
-    shipping_fee_inc_btw: Optional[float] = None
+    shipping_fee_inc_btw: Optional[Money] = None
 
 
 # Properties to receive via API on creation

--- a/server/schemas/price.py
+++ b/server/schemas/price.py
@@ -14,17 +14,17 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from server.schemas.base import BoilerplateBaseModel
+from server.schemas.base import BoilerplateBaseModel, Money
 
 
 class PriceBase(BoilerplateBaseModel):
     internal_product_id: Optional[str]
-    half: Optional[float]
-    one: Optional[float]
-    two_five: Optional[float]
-    five: Optional[float]
-    joint: Optional[float]
-    piece: Optional[float]
+    half: Optional[Money]
+    one: Optional[Money]
+    two_five: Optional[Money]
+    five: Optional[Money]
+    joint: Optional[Money]
+    piece: Optional[Money]
 
 
 # Properties to receive via API on creation
@@ -61,8 +61,8 @@ class DefaultPrice(BoilerplateBaseModel):
     internal_product_id: Optional[str] = None
     active: Optional[bool] = None
     new: Optional[bool] = None
-    one: Optional[float] = None
-    two_five: Optional[float] = None
-    five: Optional[float] = None
-    joint: Optional[float] = None
-    piece: Optional[float] = None
+    one: Optional[Money] = None
+    two_five: Optional[Money] = None
+    five: Optional[Money] = None
+    joint: Optional[Money] = None
+    piece: Optional[Money] = None

--- a/server/schemas/product.py
+++ b/server/schemas/product.py
@@ -18,7 +18,7 @@ from uuid import UUID
 from pydantic import ConfigDict, Field, ValidationError, model_validator
 
 from server.api.error_handling import raise_status
-from server.schemas.base import BoilerplateBaseModel
+from server.schemas.base import BoilerplateBaseModel, Money
 from server.schemas.price import DefaultPrice
 from server.schemas.product_attribute import ProductAttributeItem
 
@@ -46,9 +46,9 @@ class ProductBase(BoilerplateBaseModel):
 
     shop_id: UUID
     category_id: UUID
-    price: Optional[float] = None
-    recurring_price_monthly: Optional[float] = None
-    recurring_price_yearly: Optional[float] = None
+    price: Optional[Money] = None
+    recurring_price_monthly: Optional[Money] = None
+    recurring_price_yearly: Optional[Money] = None
     max_one: bool
     shippable: bool
     digital: Optional[str] = None
@@ -56,7 +56,7 @@ class ProductBase(BoilerplateBaseModel):
     new_product: bool
     # Todo: make enum with: vat_standard, vat_lower_1, vat_lower_2, vat_lower_3, vat_special, vat_zero
     tax_category: str
-    discounted_price: Optional[float] = None
+    discounted_price: Optional[Money] = None
     discounted_from: Optional[datetime] = None
     discounted_to: Optional[datetime] = None
     order_number: Optional[int] = None

--- a/server/schemas/shipping.py
+++ b/server/schemas/shipping.py
@@ -13,7 +13,7 @@
 from typing import List, Optional
 from uuid import UUID
 
-from server.schemas.base import BoilerplateBaseModel
+from server.schemas.base import BoilerplateBaseModel, Money
 from server.schemas.order import OrderItem
 
 
@@ -23,18 +23,18 @@ class ShippingCalculateRequest(BoilerplateBaseModel):
 
 
 class ShippingLine(BoilerplateBaseModel):
-    btw_rate: float
-    amount_ex_btw: float
-    amount_inc_btw: float
-    amount_btw: float
+    btw_rate: Money
+    amount_ex_btw: Money
+    amount_inc_btw: Money
+    amount_btw: Money
 
 
 class ShippingCalculation(BoilerplateBaseModel):
     enabled: bool
     method: Optional[str] = None
-    fee_inc_btw: float
-    fee_ex_btw: float
-    fee_btw: float
+    fee_inc_btw: Money
+    fee_ex_btw: Money
+    fee_btw: Money
     free_shipping_applied: bool
-    free_shipping_threshold: Optional[float] = None
+    free_shipping_threshold: Optional[Money] = None
     lines: List[ShippingLine]

--- a/server/schemas/shop.py
+++ b/server/schemas/shop.py
@@ -173,6 +173,7 @@ class ConfigurationShipping(BoilerplateBaseModel):
     enabled: bool = False
     method: str = "fixed"
     fixed_fee: Money = Decimal("0")
+    vat_calculation_enabled: bool = True
     free_shipping_above_enabled: bool = False
     free_shipping_above_amount: Money = Decimal("0")
 

--- a/server/schemas/shop.py
+++ b/server/schemas/shop.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from datetime import datetime
+from decimal import Decimal
 from enum import Enum
 from typing import Annotated, List, Optional
 from uuid import UUID
@@ -19,7 +20,7 @@ from pydantic import EmailStr, UrlConstraints
 from pydantic_core import Url
 from pydantic_extra_types.phone_numbers import PhoneNumber
 
-from server.schemas.base import BoilerplateBaseModel
+from server.schemas.base import BoilerplateBaseModel, Money
 
 
 class PhoneNumberNl(PhoneNumber):
@@ -45,12 +46,12 @@ class ShopBase(BoilerplateBaseModel):
     description: str
     internal_url: str | None = None
     external_url: str | None = None
-    vat_standard: float
-    vat_lower_1: float
-    vat_lower_2: float
-    vat_lower_3: float
-    vat_special: float
-    vat_zero: float
+    vat_standard: Money
+    vat_lower_1: Money
+    vat_lower_2: Money
+    vat_lower_3: Money
+    vat_special: Money
+    vat_zero: Money
 
 
 # Properties to receive via API on creation
@@ -171,9 +172,9 @@ class Toggles(BoilerplateBaseModel):
 class ConfigurationShipping(BoilerplateBaseModel):
     enabled: bool = False
     method: str = "fixed"
-    fixed_fee: float = 0.0
+    fixed_fee: Money = Decimal("0")
     free_shipping_above_enabled: bool = False
-    free_shipping_above_amount: float = 0.0
+    free_shipping_above_amount: Money = Decimal("0")
 
 
 class ConfigurationV1(BoilerplateBaseModel):

--- a/server/services/shipping.py
+++ b/server/services/shipping.py
@@ -50,13 +50,13 @@ def build_rate_subtotals(order_info: list, shop: Any) -> dict[Decimal, Decimal]:
     return subtotals
 
 
-def allocate_shipping_lines(fee_inc_btw: Decimal, rate_subtotals: dict[Decimal, Decimal]) -> list[ShippingLine]:
-    """Split a single inc-VAT shipping fee proportionally across cart VAT rates.
+def allocate_shipping_lines(fee_ex_btw: Decimal, rate_subtotals: dict[Decimal, Decimal]) -> list[ShippingLine]:
+    """Split an ex-VAT shipping fee proportionally across cart VAT rates and add VAT per rate.
 
     The rounding remainder (positive or negative) is folded into the last
-    sorted rate so the per-line inc-VAT amounts sum exactly to ``fee_inc_btw``.
+    sorted rate so the per-line ex-VAT amounts sum exactly to ``fee_ex_btw``.
     """
-    if fee_inc_btw <= 0 or not rate_subtotals:
+    if fee_ex_btw <= 0 or not rate_subtotals:
         return []
 
     grand_total = sum(rate_subtotals.values(), Decimal("0"))
@@ -68,18 +68,17 @@ def allocate_shipping_lines(fee_inc_btw: Decimal, rate_subtotals: dict[Decimal, 
     allocated = Decimal("0")
     for i, rate in enumerate(sorted_rates):
         if i == len(sorted_rates) - 1:
-            amount_inc = quantize_money(fee_inc_btw - allocated)
+            amount_ex = quantize_money(fee_ex_btw - allocated)
         else:
-            amount_inc = quantize_money(fee_inc_btw * rate_subtotals[rate] / grand_total)
-            allocated = quantize_money(allocated + amount_inc)
-        if amount_inc > 0:
-            allocations.append((rate, amount_inc))
+            amount_ex = quantize_money(fee_ex_btw * rate_subtotals[rate] / grand_total)
+            allocated = quantize_money(allocated + amount_ex)
+        if amount_ex > 0:
+            allocations.append((rate, amount_ex))
 
     lines: list[ShippingLine] = []
-    for rate, amount_inc in allocations:
-        vat_divisor = Decimal("1") + rate / Decimal("100")
-        amount_ex = quantize_money(amount_inc / vat_divisor)
-        amount_btw = quantize_money(amount_inc - amount_ex)
+    for rate, amount_ex in allocations:
+        amount_btw = quantize_money(amount_ex * rate / Decimal("100"))
+        amount_inc = quantize_money(amount_ex + amount_btw)
         lines.append(
             ShippingLine(
                 btw_rate=rate,
@@ -93,6 +92,10 @@ def allocate_shipping_lines(fee_inc_btw: Decimal, rate_subtotals: dict[Decimal, 
 
 def compute_shipping_for_cart(order_info: list, shop: Any) -> Optional[ShippingCalculation]:
     """Compute the shipping fee and per-VAT-rate breakdown for a cart.
+
+    The configured ``fixed_fee`` is interpreted as ex-VAT; VAT is added on top
+    proportionally across the cart's VAT rates. When ``vat_calculation_enabled``
+    is ``False``, the fee is added flat (no VAT split, no per-rate lines).
 
     Returns ``None`` when shipping is not configured or not enabled on the shop.
     Returns a ``ShippingCalculation`` with ``fee_inc_btw=0`` and
@@ -109,6 +112,7 @@ def compute_shipping_for_cart(order_info: list, shop: Any) -> Optional[ShippingC
 
     method = shipping_cfg.get("method", "fixed")
     fixed_fee = Decimal(str(shipping_cfg.get("fixed_fee", "0") or "0"))
+    vat_enabled = bool(shipping_cfg.get("vat_calculation_enabled", True))
     free_above_enabled = bool(shipping_cfg.get("free_shipping_above_enabled", False))
     free_above_amount = Decimal(str(shipping_cfg.get("free_shipping_above_amount", "0") or "0"))
 
@@ -117,14 +121,39 @@ def compute_shipping_for_cart(order_info: list, shop: Any) -> Optional[ShippingC
 
     free_shipping_applied = False
     if free_above_enabled and free_above_amount > 0 and cart_total_inc >= free_above_amount:
-        fee_inc_btw = Decimal("0.00")
-        free_shipping_applied = True
-    else:
-        fee_inc_btw = quantize_money(fixed_fee)
+        return ShippingCalculation(
+            enabled=True,
+            method=method,
+            fee_inc_btw=Decimal("0.00"),
+            fee_ex_btw=Decimal("0.00"),
+            fee_btw=Decimal("0.00"),
+            free_shipping_applied=True,
+            free_shipping_threshold=free_above_amount,
+            lines=[],
+        )
 
-    lines = allocate_shipping_lines(fee_inc_btw, rate_subtotals)
-    fee_ex_btw = quantize_money(sum((line.amount_ex_btw for line in lines), Decimal("0")))
-    fee_btw = quantize_money(fee_inc_btw - fee_ex_btw)
+    if not vat_enabled:
+        fee = quantize_money(fixed_fee)
+        return ShippingCalculation(
+            enabled=True,
+            method=method,
+            fee_inc_btw=fee,
+            fee_ex_btw=fee,
+            fee_btw=Decimal("0.00"),
+            free_shipping_applied=False,
+            free_shipping_threshold=free_above_amount if free_above_enabled else None,
+            lines=[],
+        )
+
+    fee_ex_btw = quantize_money(fixed_fee)
+    lines = allocate_shipping_lines(fee_ex_btw, rate_subtotals)
+    if lines:
+        fee_inc_btw = quantize_money(sum((line.amount_inc_btw for line in lines), Decimal("0")))
+        fee_ex_btw = quantize_money(sum((line.amount_ex_btw for line in lines), Decimal("0")))
+        fee_btw = quantize_money(fee_inc_btw - fee_ex_btw)
+    else:
+        fee_inc_btw = fee_ex_btw
+        fee_btw = Decimal("0.00")
 
     return ShippingCalculation(
         enabled=True,
@@ -132,7 +161,7 @@ def compute_shipping_for_cart(order_info: list, shop: Any) -> Optional[ShippingC
         fee_inc_btw=fee_inc_btw,
         fee_ex_btw=fee_ex_btw,
         fee_btw=fee_btw,
-        free_shipping_applied=free_shipping_applied,
+        free_shipping_applied=False,
         free_shipping_threshold=free_above_amount if free_above_enabled else None,
         lines=lines,
     )

--- a/server/services/shipping.py
+++ b/server/services/shipping.py
@@ -10,42 +10,47 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from decimal import Decimal
 from typing import Any, Optional
 
+from server.schemas.base import quantize_money
 from server.schemas.shipping import ShippingCalculation, ShippingLine
 
 
-def resolve_vat_rate(product: Any, shop: Any) -> float:
+def resolve_vat_rate(product: Any, shop: Any) -> Decimal:
     """Look up the VAT rate for a product, falling back to shop.vat_standard.
 
     Mirrors the resolution used elsewhere (mail rendering): the product's
-    `tax_category` is the name of a Float column on the shop (e.g.
+    `tax_category` is the name of a Numeric column on the shop (e.g.
     ``vat_standard``, ``vat_lower_1``).
     """
     if product is not None and getattr(product, "tax_category", None):
-        return getattr(shop, product.tax_category, shop.vat_standard)
-    return shop.vat_standard
+        rate = getattr(shop, product.tax_category, shop.vat_standard)
+    else:
+        rate = shop.vat_standard
+    return rate if isinstance(rate, Decimal) else Decimal(str(rate))
 
 
-def build_rate_subtotals(order_info: list, shop: Any) -> dict[float, float]:
+def build_rate_subtotals(order_info: list, shop: Any) -> dict[Decimal, Decimal]:
     """Sum cart inc-VAT line totals grouped by VAT rate.
 
     `order_info` may contain dicts or Pydantic items; both are accepted.
     """
     from server.crud.crud_product import product_crud
 
-    subtotals: dict[float, float] = {}
+    subtotals: dict[Decimal, Decimal] = {}
     for raw in order_info:
         item = raw.model_dump() if hasattr(raw, "model_dump") else dict(raw)
         product = product_crud.get_id_by_shop_id(shop.id, item["product_id"])
         rate = resolve_vat_rate(product, shop)
         quantity = item.get("quantity", 1)
-        line_total_inc = round(item["price"] * quantity, 2)
-        subtotals[rate] = round(subtotals.get(rate, 0.0) + line_total_inc, 2)
+        price = item["price"] if isinstance(item["price"], Decimal) else Decimal(str(item["price"]))
+        line_total_inc = quantize_money(price * quantity)
+        subtotals[rate] = quantize_money(subtotals.get(rate, Decimal("0")) + line_total_inc)
     return subtotals
 
 
-def allocate_shipping_lines(fee_inc_btw: float, rate_subtotals: dict[float, float]) -> list[ShippingLine]:
+def allocate_shipping_lines(fee_inc_btw: Decimal, rate_subtotals: dict[Decimal, Decimal]) -> list[ShippingLine]:
     """Split a single inc-VAT shipping fee proportionally across cart VAT rates.
 
     The rounding remainder (positive or negative) is folded into the last
@@ -54,27 +59,27 @@ def allocate_shipping_lines(fee_inc_btw: float, rate_subtotals: dict[float, floa
     if fee_inc_btw <= 0 or not rate_subtotals:
         return []
 
-    grand_total = sum(rate_subtotals.values())
+    grand_total = sum(rate_subtotals.values(), Decimal("0"))
     if grand_total <= 0:
         return []
 
     sorted_rates = sorted(rate_subtotals.keys())
-    allocations: list[tuple[float, float]] = []
-    allocated = 0.0
+    allocations: list[tuple[Decimal, Decimal]] = []
+    allocated = Decimal("0")
     for i, rate in enumerate(sorted_rates):
         if i == len(sorted_rates) - 1:
-            amount_inc = round(fee_inc_btw - allocated, 2)
+            amount_inc = quantize_money(fee_inc_btw - allocated)
         else:
-            amount_inc = round(fee_inc_btw * rate_subtotals[rate] / grand_total, 2)
-            allocated = round(allocated + amount_inc, 2)
+            amount_inc = quantize_money(fee_inc_btw * rate_subtotals[rate] / grand_total)
+            allocated = quantize_money(allocated + amount_inc)
         if amount_inc > 0:
             allocations.append((rate, amount_inc))
 
     lines: list[ShippingLine] = []
     for rate, amount_inc in allocations:
-        vat_divisor = 1 + rate / 100
-        amount_ex = round(amount_inc / vat_divisor, 2)
-        amount_btw = round(amount_inc - amount_ex, 2)
+        vat_divisor = Decimal("1") + rate / Decimal("100")
+        amount_ex = quantize_money(amount_inc / vat_divisor)
+        amount_btw = quantize_money(amount_inc - amount_ex)
         lines.append(
             ShippingLine(
                 btw_rate=rate,
@@ -103,23 +108,23 @@ def compute_shipping_for_cart(order_info: list, shop: Any) -> Optional[ShippingC
         return None
 
     method = shipping_cfg.get("method", "fixed")
-    fixed_fee = float(shipping_cfg.get("fixed_fee", 0.0) or 0.0)
+    fixed_fee = Decimal(str(shipping_cfg.get("fixed_fee", "0") or "0"))
     free_above_enabled = bool(shipping_cfg.get("free_shipping_above_enabled", False))
-    free_above_amount = float(shipping_cfg.get("free_shipping_above_amount", 0.0) or 0.0)
+    free_above_amount = Decimal(str(shipping_cfg.get("free_shipping_above_amount", "0") or "0"))
 
     rate_subtotals = build_rate_subtotals(order_info, shop)
-    cart_total_inc = round(sum(rate_subtotals.values()), 2)
+    cart_total_inc = quantize_money(sum(rate_subtotals.values(), Decimal("0")))
 
     free_shipping_applied = False
     if free_above_enabled and free_above_amount > 0 and cart_total_inc >= free_above_amount:
-        fee_inc_btw = 0.0
+        fee_inc_btw = Decimal("0.00")
         free_shipping_applied = True
     else:
-        fee_inc_btw = round(fixed_fee, 2)
+        fee_inc_btw = quantize_money(fixed_fee)
 
     lines = allocate_shipping_lines(fee_inc_btw, rate_subtotals)
-    fee_ex_btw = round(sum(line.amount_ex_btw for line in lines), 2)
-    fee_btw = round(fee_inc_btw - fee_ex_btw, 2)
+    fee_ex_btw = quantize_money(sum((line.amount_ex_btw for line in lines), Decimal("0")))
+    fee_btw = quantize_money(fee_inc_btw - fee_ex_btw)
 
     return ShippingCalculation(
         enabled=True,

--- a/server/utils/json.py
+++ b/server/utils/json.py
@@ -78,6 +78,7 @@ decoding functions differently then `default` and `object_hook` is that they are
 from contextlib import suppress
 from dataclasses import asdict, is_dataclass
 from datetime import datetime
+from decimal import Decimal
 from typing import Any, Dict, List, Tuple, Union
 from uuid import UUID
 
@@ -117,6 +118,10 @@ def to_serializable(o: Any) -> Any:
         return str(o)
     if isinstance(o, datetime):
         return isoformat(o)
+    if isinstance(o, Decimal):
+        # Stored as JSON number to preserve the shape of existing JSONB columns
+        # (shop config etc.). Pydantic re-coerces float → Decimal on read.
+        return float(o)
     if is_dataclass(o):
         return asdict(o)
     if hasattr(o, "__json__"):

--- a/tests/unit_tests/api/test_orders.py
+++ b/tests/unit_tests/api/test_orders.py
@@ -100,9 +100,10 @@ def test_create_order_with_shipping_single_rate(shop_shipping_fixed_with_product
     response = test_client.post("/orders/", json=body)
     assert response.status_code == 201, response.json()
     j = response.json()
-    assert j["shipping_fee_inc_btw"] == 4.95
-    # items_total = 20; total = 20 + 4.95
-    assert j["total"] == 24.95
+    # fixed_fee=4.95 is ex-VAT; with 21% VAT → 5.99 inc
+    assert j["shipping_fee_inc_btw"] == 5.99
+    # items_total = 20; total = 20 + 5.99
+    assert j["total"] == 25.99
 
 
 def test_create_order_with_shipping_mixed_vat(shop_shipping_mixed_vat, test_client):
@@ -115,9 +116,10 @@ def test_create_order_with_shipping_mixed_vat(shop_shipping_mixed_vat, test_clie
     response = test_client.post("/orders/", json=body)
     assert response.status_code == 201, response.json()
     j = response.json()
-    assert j["shipping_fee_inc_btw"] == 10.0
-    # items_total = 200; total = 200 + 10
-    assert j["total"] == 210.0
+    # fixed_fee=10.0 ex-VAT split 50/50 → 5*1.21 + 5*1.09 = 11.50 inc
+    assert j["shipping_fee_inc_btw"] == 11.5
+    # items_total = 200; total = 200 + 11.50
+    assert j["total"] == 211.5
 
 
 def test_create_order_free_shipping_threshold(shop_shipping_free_above, test_client):
@@ -136,7 +138,7 @@ def test_create_order_free_shipping_threshold(shop_shipping_free_above, test_cli
 
 def test_create_order_below_free_shipping_threshold(shop_shipping_free_above, test_client):
     ids = shop_shipping_free_above
-    # Cart total inc-VAT = 30, threshold = 50 -> shipping should be 4.95
+    # Cart total inc-VAT = 30, threshold = 50 -> shipping should apply
     items = [
         {"description": "x", "price": 10.0, "product_id": str(ids["p1"]), "product_name": "Item 1", "quantity": 3},
     ]
@@ -144,8 +146,9 @@ def test_create_order_below_free_shipping_threshold(shop_shipping_free_above, te
     response = test_client.post("/orders/", json=body)
     assert response.status_code == 201, response.json()
     j = response.json()
-    assert j["shipping_fee_inc_btw"] == 4.95
-    assert j["total"] == 34.95
+    # 4.95 ex-VAT @ 21% → 5.99 inc
+    assert j["shipping_fee_inc_btw"] == 5.99
+    assert j["total"] == 35.99
 
 
 def test_create_order_client_total_overridden(shop_shipping_fixed_with_products, test_client):
@@ -157,9 +160,32 @@ def test_create_order_client_total_overridden(shop_shipping_fixed_with_products,
     response = test_client.post("/orders/", json=body)
     assert response.status_code == 201, response.json()
     j = response.json()
-    # Client sent total=1.0 but server should override with items + shipping = 10 + 4.95
-    assert j["total"] == 14.95
-    assert j["shipping_fee_inc_btw"] == 4.95
+    # Client sent total=1.0 but server should override with items + shipping = 10 + 5.99
+    assert j["total"] == 15.99
+    assert j["shipping_fee_inc_btw"] == 5.99
+
+
+@pytest.fixture()
+def shop_shipping_vat_bypass_with_products():
+    shop_id = make_shop_with_shipping(fixed_fee=5.00, vat_calculation_enabled=False)
+    category = make_category(shop_id=shop_id)
+    p1 = make_product(shop_id=shop_id, category_id=category, main_name="Item 1", price=10.0)
+    return {"shop_id": shop_id, "p1": p1}
+
+
+def test_create_order_vat_bypass_adds_flat_fee(shop_shipping_vat_bypass_with_products, test_client):
+    """With VAT bypass on, configured fee is added to total without VAT calc."""
+    ids = shop_shipping_vat_bypass_with_products
+    items = [
+        {"description": "x", "price": 10.0, "product_id": str(ids["p1"]), "product_name": "Item 1", "quantity": 2},
+    ]
+    body = _order_body(ids["shop_id"], items)
+    response = test_client.post("/orders/", json=body)
+    assert response.status_code == 201, response.json()
+    j = response.json()
+    # Configured 5.00 added flat (no VAT split, no per-rate inflation)
+    assert j["shipping_fee_inc_btw"] == 5.0
+    assert j["total"] == 25.0
 
 
 # from server.api.endpoints.shop_endpoints.orders import get_price_rules_total

--- a/tests/unit_tests/api/test_shipping.py
+++ b/tests/unit_tests/api/test_shipping.py
@@ -54,6 +54,23 @@ def shop_shipping_with_threshold():
     return {"shop_id": shop_id, "p": p}
 
 
+@pytest.fixture()
+def shop_shipping_vat_bypass():
+    shop_id = make_shop_with_shipping(fixed_fee=5.00, vat_calculation_enabled=False)
+    category = make_category(shop_id=shop_id)
+    p = make_product(shop_id=shop_id, category_id=category, price=10.0)
+    return {"shop_id": shop_id, "p": p}
+
+
+@pytest.fixture()
+def shop_shipping_vat_bypass_mixed():
+    shop_id = make_shop_with_shipping(fixed_fee=5.00, vat_calculation_enabled=False)
+    category = make_category(shop_id=shop_id)
+    p_high = make_product(shop_id=shop_id, category_id=category, price=100.0, tax_category="vat_standard")
+    p_low = make_product(shop_id=shop_id, category_id=category, price=100.0, tax_category="vat_lower_1")
+    return {"shop_id": shop_id, "p_high": p_high, "p_low": p_low}
+
+
 def _calc_body(shop_id, items):
     return {"shop_id": str(shop_id), "order_info": items}
 
@@ -93,14 +110,15 @@ def test_calculate_shipping_fixed_single_rate(shop_shipping_fixed, test_client):
     j = response.json()
     assert j["enabled"] is True
     assert j["method"] == "fixed"
-    assert j["fee_inc_btw"] == 4.95
+    # fixed_fee=4.95 is now ex-VAT; with 21% VAT → inc = 4.95 * 1.21 = 5.9895 → 5.99
+    assert j["fee_ex_btw"] == 4.95
+    assert j["fee_inc_btw"] == 5.99
     assert len(j["lines"]) == 1
     line = j["lines"][0]
     assert line["btw_rate"] == 21.0
-    assert line["amount_inc_btw"] == 4.95
-    # ex-VAT = 4.95 / 1.21 = 4.0909... → round(2) = 4.09
-    assert line["amount_ex_btw"] == 4.09
-    assert line["amount_btw"] == round(4.95 - 4.09, 2)
+    assert line["amount_ex_btw"] == 4.95
+    assert line["amount_inc_btw"] == 5.99
+    assert line["amount_btw"] == round(5.99 - 4.95, 2)
     # Sums reconcile
     assert round(j["fee_ex_btw"] + j["fee_btw"], 2) == j["fee_inc_btw"]
 
@@ -115,16 +133,20 @@ def test_calculate_shipping_mixed_vat(shop_shipping_mixed, test_client):
     assert response.status_code == 200
     j = response.json()
     assert j["enabled"] is True
-    assert j["fee_inc_btw"] == 10.0
-    # 100 inc-VAT at 21% and 100 inc-VAT at 9% → 50/50 split
+    # fixed_fee=10.0 is now ex-VAT, allocated 50/50 (5.00 ex per rate),
+    # then VAT added: 5*1.21=6.05, 5*1.09=5.45 → fee_inc = 11.50, fee_ex = 10.00
+    assert j["fee_ex_btw"] == 10.0
+    assert j["fee_inc_btw"] == 11.5
     assert len(j["lines"]) == 2
     rates = sorted(line["btw_rate"] for line in j["lines"])
     assert rates == [9.0, 21.0]
-    inc_sum = round(sum(line["amount_inc_btw"] for line in j["lines"]), 2)
-    assert inc_sum == 10.0
-    # Each split is around 5.00 inc-VAT
-    for line in j["lines"]:
-        assert 4.99 <= line["amount_inc_btw"] <= 5.01
+    by_rate = {line["btw_rate"]: line for line in j["lines"]}
+    assert by_rate[21.0]["amount_ex_btw"] == 5.0
+    assert by_rate[21.0]["amount_inc_btw"] == 6.05
+    assert by_rate[9.0]["amount_ex_btw"] == 5.0
+    assert by_rate[9.0]["amount_inc_btw"] == 5.45
+    ex_sum = round(sum(line["amount_ex_btw"] for line in j["lines"]), 2)
+    assert ex_sum == 10.0
 
 
 def test_calculate_free_shipping_threshold_met(shop_shipping_with_threshold, test_client):
@@ -147,6 +169,39 @@ def test_calculate_free_shipping_threshold_not_met(shop_shipping_with_threshold,
     assert response.status_code == 200
     j = response.json()
     assert j["enabled"] is True
-    assert j["fee_inc_btw"] == 4.95
+    # fixed_fee=4.95 is ex-VAT; with 21% VAT → 5.99 inc
+    assert j["fee_ex_btw"] == 4.95
+    assert j["fee_inc_btw"] == 5.99
     assert j["free_shipping_applied"] is False
     assert j["free_shipping_threshold"] == 50.0
+
+
+def test_calculate_shipping_vat_bypass_single_rate(shop_shipping_vat_bypass, test_client):
+    ids = shop_shipping_vat_bypass
+    items = [{"description": "x", "price": 10.0, "product_id": str(ids["p"]), "product_name": "p", "quantity": 1}]
+    response = test_client.post("/shipping/calculate", json=_calc_body(ids["shop_id"], items))
+    assert response.status_code == 200
+    j = response.json()
+    assert j["enabled"] is True
+    # VAT bypass: configured 5.00 added flat, no per-rate split
+    assert j["fee_ex_btw"] == 5.0
+    assert j["fee_inc_btw"] == 5.0
+    assert j["fee_btw"] == 0.0
+    assert j["lines"] == []
+
+
+def test_calculate_shipping_vat_bypass_mixed_rates(shop_shipping_vat_bypass_mixed, test_client):
+    """With VAT bypass on, mixed cart VAT rates don't trigger any split."""
+    ids = shop_shipping_vat_bypass_mixed
+    items = [
+        {"description": "x", "price": 100.0, "product_id": str(ids["p_high"]), "product_name": "h", "quantity": 1},
+        {"description": "x", "price": 100.0, "product_id": str(ids["p_low"]), "product_name": "l", "quantity": 1},
+    ]
+    response = test_client.post("/shipping/calculate", json=_calc_body(ids["shop_id"], items))
+    assert response.status_code == 200
+    j = response.json()
+    assert j["enabled"] is True
+    assert j["fee_ex_btw"] == 5.0
+    assert j["fee_inc_btw"] == 5.0
+    assert j["fee_btw"] == 0.0
+    assert j["lines"] == []

--- a/tests/unit_tests/factories/shop.py
+++ b/tests/unit_tests/factories/shop.py
@@ -125,6 +125,7 @@ def make_shop_with_shipping(
     free_shipping_above_amount: float = 0.0,
     enabled: bool = True,
     method: str = "fixed",
+    vat_calculation_enabled: bool = True,
 ):
     """Create a shop with a populated config and a shipping block."""
     menu_items = ConfigurationLanguageFieldMenuItems(
@@ -162,6 +163,7 @@ def make_shop_with_shipping(
         enabled=enabled,
         method=method,
         fixed_fee=fixed_fee,
+        vat_calculation_enabled=vat_calculation_enabled,
         free_shipping_above_enabled=free_shipping_above_enabled,
         free_shipping_above_amount=free_shipping_above_amount,
     )

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -1332,6 +1332,11 @@
             "default": "fixed",
             "title": "Method",
             "type": "string"
+          },
+          "vat_calculation_enabled": {
+            "default": true,
+            "title": "Vat Calculation Enabled",
+            "type": "boolean"
           }
         },
         "title": "ConfigurationShipping",
@@ -1363,6 +1368,11 @@
             "default": "fixed",
             "title": "Method",
             "type": "string"
+          },
+          "vat_calculation_enabled": {
+            "default": true,
+            "title": "Vat Calculation Enabled",
+            "type": "boolean"
           }
         },
         "title": "ConfigurationShipping",

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -1292,7 +1292,7 @@
         "title": "ConfigurationLegal",
         "type": "object"
       },
-      "ConfigurationShipping": {
+      "ConfigurationShipping-Input": {
         "properties": {
           "enabled": {
             "default": false,
@@ -1300,12 +1300,57 @@
             "type": "boolean"
           },
           "fixed_fee": {
-            "default": 0.0,
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "default": "0",
+            "title": "Fixed Fee"
+          },
+          "free_shipping_above_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "default": "0",
+            "title": "Free Shipping Above Amount"
+          },
+          "free_shipping_above_enabled": {
+            "default": false,
+            "title": "Free Shipping Above Enabled",
+            "type": "boolean"
+          },
+          "method": {
+            "default": "fixed",
+            "title": "Method",
+            "type": "string"
+          }
+        },
+        "title": "ConfigurationShipping",
+        "type": "object"
+      },
+      "ConfigurationShipping-Output": {
+        "properties": {
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "fixed_fee": {
+            "default": "0",
             "title": "Fixed Fee",
             "type": "number"
           },
           "free_shipping_above_amount": {
-            "default": 0.0,
+            "default": "0",
             "title": "Free Shipping Above Amount",
             "type": "number"
           },
@@ -1390,7 +1435,7 @@
           "shipping": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ConfigurationShipping"
+                "$ref": "#/components/schemas/ConfigurationShipping-Input"
               },
               {
                 "type": "null"
@@ -1483,7 +1528,7 @@
           "shipping": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ConfigurationShipping"
+                "$ref": "#/components/schemas/ConfigurationShipping-Output"
               },
               {
                 "type": "null"
@@ -2054,6 +2099,9 @@
                 "type": "number"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -2074,6 +2122,9 @@
             "anyOf": [
               {
                 "type": "number"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2152,7 +2203,7 @@
           },
           "order_info": {
             "items": {
-              "$ref": "#/components/schemas/OrderItem"
+              "$ref": "#/components/schemas/OrderItem-Input"
             },
             "title": "Order Info",
             "type": "array"
@@ -2161,6 +2212,9 @@
             "anyOf": [
               {
                 "type": "number"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2188,6 +2242,9 @@
             "anyOf": [
               {
                 "type": "number"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2322,7 +2379,55 @@
         "title": "OrderCreated",
         "type": "object"
       },
-      "OrderItem": {
+      "OrderItem-Input": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Price"
+          },
+          "product_id": {
+            "format": "uuid",
+            "title": "Product Id",
+            "type": "string"
+          },
+          "product_name": {
+            "title": "Product Name",
+            "type": "string"
+          },
+          "quantity": {
+            "title": "Quantity",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "description",
+          "price",
+          "product_id",
+          "product_name",
+          "quantity"
+        ],
+        "title": "OrderItem",
+        "type": "object"
+      },
+      "OrderItem-Output": {
         "properties": {
           "description": {
             "anyOf": [
@@ -2457,7 +2562,7 @@
           },
           "order_info": {
             "items": {
-              "$ref": "#/components/schemas/OrderItem"
+              "$ref": "#/components/schemas/OrderItem-Output"
             },
             "title": "Order Info",
             "type": "array"
@@ -2566,7 +2671,7 @@
           },
           "order_info": {
             "items": {
-              "$ref": "#/components/schemas/OrderItem"
+              "$ref": "#/components/schemas/OrderItem-Input"
             },
             "title": "Order Info",
             "type": "array"
@@ -2575,6 +2680,9 @@
             "anyOf": [
               {
                 "type": "number"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2602,6 +2710,9 @@
             "anyOf": [
               {
                 "type": "number"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"
@@ -2664,7 +2775,7 @@
           },
           "order_info": {
             "items": {
-              "$ref": "#/components/schemas/OrderItem"
+              "$ref": "#/components/schemas/OrderItem-Output"
             },
             "title": "Order Info",
             "type": "array"
@@ -2913,6 +3024,9 @@
                 "type": "number"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -3043,6 +3157,9 @@
                 "type": "number"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -3054,6 +3171,9 @@
                 "type": "number"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -3063,6 +3183,9 @@
             "anyOf": [
               {
                 "type": "number"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"
@@ -3583,6 +3706,9 @@
                 "type": "number"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -3725,6 +3851,9 @@
                 "type": "number"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -3736,6 +3865,9 @@
                 "type": "number"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -3745,6 +3877,9 @@
             "anyOf": [
               {
                 "type": "number"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"
@@ -4396,7 +4531,7 @@
         "properties": {
           "order_info": {
             "items": {
-              "$ref": "#/components/schemas/OrderItem"
+              "$ref": "#/components/schemas/OrderItem-Input"
             },
             "title": "Order Info",
             "type": "array"
@@ -4626,28 +4761,70 @@
             "type": "string"
           },
           "vat_lower_1": {
-            "title": "Vat Lower 1",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Lower 1"
           },
           "vat_lower_2": {
-            "title": "Vat Lower 2",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Lower 2"
           },
           "vat_lower_3": {
-            "title": "Vat Lower 3",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Lower 3"
           },
           "vat_special": {
-            "title": "Vat Special",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Special"
           },
           "vat_standard": {
-            "title": "Vat Standard",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Standard"
           },
           "vat_zero": {
-            "title": "Vat Zero",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Zero"
           }
         },
         "required": [
@@ -4903,28 +5080,70 @@
             "type": "string"
           },
           "vat_lower_1": {
-            "title": "Vat Lower 1",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Lower 1"
           },
           "vat_lower_2": {
-            "title": "Vat Lower 2",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Lower 2"
           },
           "vat_lower_3": {
-            "title": "Vat Lower 3",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Lower 3"
           },
           "vat_special": {
-            "title": "Vat Special",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Special"
           },
           "vat_standard": {
-            "title": "Vat Standard",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Standard"
           },
           "vat_zero": {
-            "title": "Vat Zero",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vat Zero"
           }
         },
         "required": [
@@ -5426,7 +5645,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.2.8"
+    "version": "0.2.9"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/tests/unit_tests/test_mail.py
+++ b/tests/unit_tests/test_mail.py
@@ -11,6 +11,7 @@ from server.schemas.base import quantize_money
 from tests.unit_tests.factories.account import make_account
 from tests.unit_tests.factories.categories import make_category
 from tests.unit_tests.factories.product import make_product
+from tests.unit_tests.factories.shop import make_shop_with_shipping
 
 
 @pytest.fixture()
@@ -183,3 +184,59 @@ def test_compute_order_lines_zero_vat_is_lossless(completed_order, shop_with_con
     for line in lines:
         assert line["price_ex_btw"] == line["price_inc_btw"]
         assert line["line_total_ex_btw"] == line["line_total_inc_btw"]
+
+
+@pytest.fixture()
+def completed_order_with_vat_bypass_shipping():
+    """Shop with VAT-bypass shipping (5.00 flat) and one order line."""
+    shop_id = make_shop_with_shipping(fixed_fee=5.00, vat_calculation_enabled=False)
+    account_id = make_account(shop_id=shop_id, name="customer@example.com")
+    category = make_category(shop_id=shop_id)
+    product_id = make_product(shop_id=shop_id, category_id=category, main_name="Widget A")
+    order = OrderTable(
+        shop_id=shop_id,
+        account_id=account_id,
+        customer_order_id=99,
+        order_info=[
+            {
+                "description": "first line",
+                "product_name": "Widget A",
+                "price": 10.0,
+                "quantity": 2,
+                "product_id": str(product_id),
+            },
+        ],
+        total=Decimal("25.00"),
+        shipping_fee_inc_btw=Decimal("5.00"),
+        status="complete",
+        completed_at=datetime(2026, 4, 23, 12, 0, tzinfo=timezone.utc),
+    )
+    db.session.add(order)
+    db.session.commit()
+    return {"order_id": order.id, "shop_id": shop_id}
+
+
+def test_mail_renders_vat_bypass_shipping_as_flat_line(completed_order_with_vat_bypass_shipping, mock_smtp):
+    """When VAT bypass is on, mail body shows shipping as a flat fee with no per-rate split."""
+    _, smtp_instance = mock_smtp
+    fixt = completed_order_with_vat_bypass_shipping
+    order = db.session.get(OrderTable, fixt["order_id"])
+    shop = db.session.get(ShopTable, fixt["shop_id"])
+
+    send_order_confirmation_emails(order=order, shop=shop, account=order.account)
+
+    customer_call = next(
+        call for call in smtp_instance.send_message.call_args_list if call.args[0]["To"] == "customer@example.com"
+    )
+    message = customer_call.args[0]
+    html_parts = [part for part in message.walk() if part.get_content_type() == "text/html"]
+    assert html_parts, "no HTML part in customer mail"
+    html_body = html_parts[0].get_payload(decode=True).decode("utf-8")
+
+    # No per-rate VAT row for shipping (would render "21%" or similar) — flat line uses "Verzendkosten:" label
+    assert "Verzendkosten:" in html_body
+    # Flat fee amount is shown without splitting; &nbsp; prevents the symbol from wrapping off the amount.
+    assert "&euro;&nbsp;5.00" in html_body
+    # Items: 10 inc-VAT * 2 = 20.00; shipping: 5.00 flat → total = 25.00
+    assert "Totaal inc BTW:" in html_body
+    assert "25.00" in html_body

--- a/tests/unit_tests/test_mail.py
+++ b/tests/unit_tests/test_mail.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
@@ -6,6 +7,7 @@ import pytest
 from server.db import db
 from server.db.models import OrderTable, ShopTable
 from server.mail import _compute_order_lines_for_email, send_order_confirmation_emails
+from server.schemas.base import quantize_money
 from tests.unit_tests.factories.account import make_account
 from tests.unit_tests.factories.categories import make_category
 from tests.unit_tests.factories.product import make_product
@@ -132,15 +134,15 @@ def test_compute_order_lines_treats_stored_price_as_vat_inclusive(completed_orde
 
     widget_a = next(line for line in lines if line["product_name"] == "Widget A")
     assert widget_a["btw_rate"] == shop.vat_standard
-    assert widget_a["price_inc_btw"] == 10.0, "stored price must be surfaced as the inc-VAT price"
-    assert widget_a["price_ex_btw"] == round(10.0 / 1.21, 2)
-    assert widget_a["line_total_inc_btw"] == 20.0
-    assert widget_a["line_total_ex_btw"] == round(20.0 / 1.21, 2)
+    assert widget_a["price_inc_btw"] == Decimal("10.00"), "stored price must be surfaced as the inc-VAT price"
+    assert widget_a["price_ex_btw"] == quantize_money(Decimal("10") / Decimal("1.21"))
+    assert widget_a["line_total_inc_btw"] == Decimal("20.00")
+    assert widget_a["line_total_ex_btw"] == quantize_money(Decimal("20") / Decimal("1.21"))
 
     widget_b = next(line for line in lines if line["product_name"] == "Widget B")
-    assert widget_b["price_inc_btw"] == 5.0
-    assert widget_b["price_ex_btw"] == round(5.0 / 1.21, 2)
-    assert widget_b["line_total_inc_btw"] == 5.0
+    assert widget_b["price_inc_btw"] == Decimal("5.00")
+    assert widget_b["price_ex_btw"] == quantize_money(Decimal("5") / Decimal("1.21"))
+    assert widget_b["line_total_inc_btw"] == Decimal("5.00")
 
 
 def test_customer_mail_shows_completed_at_in_europe_amsterdam_for_nl(completed_order, shop_with_config, mock_smtp):
@@ -172,7 +174,7 @@ def test_customer_mail_shows_completed_at_in_europe_amsterdam_for_nl(completed_o
 def test_compute_order_lines_zero_vat_is_lossless(completed_order, shop_with_config):
     """With a 0% VAT rate, ex and inc figures must be identical (no division by zero fragility)."""
     shop = db.session.get(ShopTable, shop_with_config)
-    shop.vat_standard = 0.0
+    shop.vat_standard = Decimal("0")
     db.session.commit()
 
     order = db.session.get(OrderTable, completed_order)


### PR DESCRIPTION
Closes #114.

This PR now bundles **two** changes on the same branch:

1. **Float → Decimal migration** (storage + computation switch).
2. **Shipping VAT bypass toggle + ex-VAT fee semantics** (new shipping config option, default behavior change for `fixed_fee`).

---

## Part 1 — Decimal migration

Floats are unsuitable for financial math — accumulated rounding error, non-representable cents (`0.1 + 0.2 ≠ 0.3`), platform-dependent precision. The recent VAT/shipping work (`bee10e8`, `de56894`) made the codebase increasingly sensitive to numeric precision, so the time to migrate is now.

This part switches storage and computation to `Decimal` **while keeping the JSON API wire format identical** (numeric, not string). No client-side changes required — the OpenAPI types stay `number` and `response.json()` still decodes prices to Python `float`.

### Decisions captured

| Decision | Choice | Rationale |
|---|---|---|
| Wire format | JSON **numbers** (`"total": 4.95`) | Backward compatible with every existing client. The `Money` type uses `PlainSerializer(float, return_type=float, when_used="json")` to emit numbers while keeping `Decimal` internally. |
| Rounding | `ROUND_HALF_UP` | Standard financial rounding (`2.345 → 2.35`) — replaces Python `round()`'s banker's rounding. |
| DB scope | All money + 6 VAT-rate columns | Single coherent migration; VAT rates flow into Decimal math as dividers. |

### What changed

**Foundation** (`server/schemas/base.py`)
- New `Money = Annotated[Decimal, PlainSerializer(...)]` type.
- New `quantize_money(value, places=2)` helper using `ROUND_HALF_UP`.

**Pydantic schemas** — every monetary `float` → `Money`:
- `order.py` (price, total, shipping_fee_inc_btw)
- `product.py` (price, discounted_price, recurring_price_*)
- `shipping.py` (4 ShippingLine + 4 ShippingCalculation fields)
- `shop.py` (6 vat_*, fixed_fee, free_shipping_above_amount)
- `price.py` (PriceBase + DefaultPrice)
- `endpoints/shop_endpoints/prices.py` (public `ProductResponse`)

**SQLAlchemy** (`server/db/models.py`)
- `Float` → `Numeric(12, 2)` for 6 money columns.
- `Float` → `Numeric(5, 2)` for 6 shop VAT-rate columns.
- Removed unused `Float` import.

**Business logic** — replaced float arithmetic and `round(x, 2)` with `Decimal` + `quantize_money()`:
- `services/shipping.py` (rate subtotals, allocation with remainder folding, cart computation)
- `endpoints/shop_endpoints/orders.py` (server-side total recompute)
- `endpoints/shop_endpoints/shipping.py` (`/calculate` empty-state response)
- `mail.py` (order line VAT split + totals in confirmation mail)

**JSON serializer** (`server/utils/json.py`)
- Added `Decimal → float` branch so the shop config JSONB blob keeps its existing shape. Pydantic re-coerces float → Decimal on read.

**Schema migration** (`migrations/versions/schema/2026-05-07_762f0ee89e95_money_columns_to_numeric.py`)
- One Alembic revision altering all 12 columns via `op.alter_column(..., postgresql_using="<col>::numeric(...)")`.
- Symmetric `downgrade()` casting back to `Float`.

**OpenAPI guard**
- `APP_VERSION` bumped 0.2.8 → 0.2.9.
- `tests/unit_tests/openapi_snapshot.json` regenerated. Money fields still surface as `"type": "number"` — verified by spot-check.

---

## Part 2 — Shipping VAT bypass + ex-VAT default

Adds a `vat_calculation_enabled` flag to `ConfigurationShipping` (defaults to `True`) and **changes the default semantics of `fixed_fee`**.

### Behavior

| Mode | `fixed_fee` interpretation | Per-rate split | Mail rendering |
|---|---|---|---|
| `vat_calculation_enabled=True` (**default**) | **ex-VAT** — VAT is added on top, allocated proportionally across the cart's VAT rates | Yes — one line per cart rate | One row per rate, with ex/inc/% columns |
| `vat_calculation_enabled=False` | flat fee — added to the total as-is | No — `lines = []`, `fee_btw = 0` | Single row showing the configured amount |

### Default-mode change ⚠️

The pre-existing default treated `fixed_fee` as **inc-VAT** (split proportionally to derive ex+btw per rate). It is now **ex-VAT** (split proportionally for ex, then VAT applied per rate). Concretely: a configured `4.95` at 21% used to bill 4.95 to the customer; it now bills 5.99. Existing tests have been updated; **shops will see their shipping totals shift up by the VAT amount** unless they reduce `fixed_fee` to compensate or flip the new toggle off.

### What changed

**Schema** (`server/schemas/shop.py`)
- `ConfigurationShipping.vat_calculation_enabled: bool = True`.

**Service** (`server/services/shipping.py`)
- `allocate_shipping_lines` now takes ex-VAT input and adds per-rate VAT.
- `compute_shipping_for_cart` reads the flag; bypass path returns `fee_inc = fee_ex = fixed_fee`, `fee_btw = 0`, `lines = []`.

**Mail** (`server/mail.py` + 4 Jinja templates)
- Mail re-derivation calls `compute_shipping_for_cart` to get fresh per-rate lines (or none, in bypass mode).
- New flat shipping branch in templates (`{% elif shipping_fee_inc_btw > 0 %}`) for bypass mode.
- `&euro; ` → `&euro;&nbsp;` everywhere so the currency symbol can't wrap onto its own line (fixes a layout glitch in the Totaal-inc-BTW row, reported in shop-poc#234).

**Tests**
- Existing shipping/order tests updated for ex-VAT default (e.g. `4.95 → 5.99` at 21%).
- New: `test_calculate_shipping_vat_bypass_single_rate`, `test_calculate_shipping_vat_bypass_mixed_rates`, `test_create_order_vat_bypass_adds_flat_fee`, `test_mail_renders_vat_bypass_shipping_as_flat_line`.
- Factory `make_shop_with_shipping` accepts `vat_calculation_enabled`.

**OpenAPI snapshot** regenerated for the new `vat_calculation_enabled` field; `APP_VERSION` stays at `0.2.9` since this branch is unreleased.

---

## Test plan

- [x] `PYTHONPATH=. pytest tests/unit_tests` — **152 passed, 0 failed**
- [x] OpenAPI drift guard green at version 0.2.9
- [x] `isort -c .` and `black --check .` clean
- [x] Wire format spot-check: `"type": "number"` confirmed for `total`, `price`, `fee_inc_btw`, etc. in the regenerated snapshot
- [x] **Migration round-trip on a copy of dev DB** (reviewer to verify):
      ```
      PYTHONPATH=. alembic upgrade heads
      PYTHONPATH=. alembic downgrade -1
      PYTHONPATH=. alembic upgrade heads
      ```
      Then inspect column types via `\d+ orders` / `\d+ products` / `\d+ shops` in psql.
- [x] Live order create against staging — confirm response body still `"total": 24.95` (number, not string)
- [x] Trigger the order-confirmation mail flow locally — verify `€ 19.95` formatting still renders, and that the Totaal-inc-BTW row keeps the symbol on the same line as the amount.
- [x] Set `shipping.vat_calculation_enabled = false` in a staging shop config, place an order with a non-zero `fixed_fee`, confirm: order `total = items + fixed_fee` exactly; mail shows a single flat shipping row with no VAT % column; total row math is still self-consistent.

## Notes for the reviewer

- The `pydantic.v1` import in `server/schemas/order.py` was dead code (its classes already inherited from the v2 `BoilerplateBaseModel`). Removed.
- One mail test (`test_compute_order_lines_treats_stored_price_as_vat_inclusive`) needed Decimal-aware assertions — it reads order lines directly (not through JSON), so its values are now Decimal. All other tests use `response.json()` which decodes to float, so they pass unchanged.
- Mail templates (`*.html.j2`) needed no Decimal-related edits — Jinja's `"%.2f"|format()` works natively on `Decimal`. They did get the bypass branch and the `&nbsp;` fix.
- The default-mode semantics change in part 2 is a deliberate, breaking-ish behavior change discussed in the issue thread. Shops can flip the new toggle off to keep the literal `fixed_fee` they had — but the per-rate inc-VAT proportional split they had before is gone (it would mean a third mode, which we judged not worth the surface area).

🤖 Generated with [Claude Code](https://claude.com/claude-code)