### PR TITLE
Add stock_status filter to product list endpoints

### DIFF
--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from http import HTTPStatus
 from textwrap import dedent
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
 from uuid import UUID
 
 import structlog
@@ -41,7 +41,16 @@ def get_shop(shop_id: UUID):
 
 @router.get("/", response_model=List[ProductWithDefaultPrice])
 def get_multi(
-    shop_id: UUID, response: Response, common: dict = Depends(common_parameters)
+    shop_id: UUID,
+    response: Response,
+    stock_status: Literal["in_stock", "out_of_stock", "all"] = Query(
+        "all",
+        description=(
+            "Filter products by inventory state. `in_stock` returns products with stock > 0, "
+            "`out_of_stock` returns products with stock = 0, `all` (default) returns everything."
+        ),
+    ),
+    common: dict = Depends(common_parameters),
 ) -> List[ProductWithDefaultPrice]:
     products, header_range = product_crud.get_multi_by_shop_id(
         shop_id=shop_id,
@@ -49,6 +58,7 @@ def get_multi(
         limit=common["limit"],
         filter_parameters=common["filter"],
         sort_parameters=common["sort"],
+        stock_status=stock_status,
     )
     response.headers["Content-Range"] = header_range
 
@@ -76,6 +86,9 @@ You can filter the results using one of the following mutually exclusive attribu
 * `attribute_name` array[str]: Filter by one or multiple attribute names (e.g., 'Color', 'Size').
 
 Only one attribute filter can be used at a time.
+
+You can additionally narrow results by inventory state with `stock_status`:
+`in_stock` (stock > 0), `out_of_stock` (stock = 0), or `all` (default).
 """,
 )
 def get_multi_with_attributes(
@@ -85,6 +98,13 @@ def get_multi_with_attributes(
     attribute_id: UUID = Query(None),
     option_value_key: List[str] = Query(None),
     attribute_name: str = Query(None),
+    stock_status: Literal["in_stock", "out_of_stock", "all"] = Query(
+        "all",
+        description=(
+            "Filter products by inventory state. `in_stock` returns products with stock > 0, "
+            "`out_of_stock` returns products with stock = 0, `all` (default) returns everything."
+        ),
+    ),
     common: dict = Depends(common_parameters),
 ) -> List[ProductWithAttributes]:
     attribute_filters = AttributeFilters(
@@ -109,6 +129,7 @@ def get_multi_with_attributes(
         limit=common["limit"],
         filter_parameters=filter_parameters,
         sort_parameters=common["sort"],
+        stock_status=stock_status,
     )
     # We will update Content-Range if filtering by option_id changes the visible count
     response.headers["Content-Range"] = header_range

--- a/server/crud/crud_product.py
+++ b/server/crud/crud_product.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Literal, Optional, Tuple
 
 from sqlalchemy import or_
 from sqlalchemy.orm import aliased
@@ -37,10 +37,16 @@ class CRUDProduct(CRUDBase[ProductTable, ProductCreate, ProductUpdate]):
         filter_parameters: Optional[List[str]],
         sort_parameters: Optional[List[str]],
         query_parameter: Optional[Any] = None,
+        stock_status: Literal["in_stock", "out_of_stock", "all"] = "all",
     ) -> Tuple[List[ProductTable], str]:
         query = query_parameter
         if query is None:
             query = db.session.query(self.model).filter(self.model.shop_id == shop_id)
+
+        if stock_status == "in_stock":
+            query = query.filter(ProductTable.stock > 0)
+        elif stock_status == "out_of_stock":
+            query = query.filter(ProductTable.stock == 0)
 
         if filter_parameters:
             for filter_parameter in filter_parameters:

--- a/server/main.py
+++ b/server/main.py
@@ -67,7 +67,7 @@ async def lifespan(app_: FastAPI):
     yield
 
 
-APP_VERSION = "0.2.9"
+APP_VERSION = "0.2.10"
 
 app = FastAPI(
     title="ShopVirge API",

--- a/tests/unit_tests/api/test_products.py
+++ b/tests/unit_tests/api/test_products.py
@@ -2,6 +2,7 @@ from http import HTTPStatus
 
 from server.db.models import ProductTable
 from server.utils.json import json_dumps
+from tests.unit_tests.factories.product import make_product
 
 
 def test_products_get_multi(shop_with_products, test_client):
@@ -243,3 +244,53 @@ def test_products_get_multi_with_attributes_mutually_exclusive_filters(test_clie
     )
     assert response.status_code == 400
     assert "Only one filter may be used at a time" in response.json()["detail"]["message"]
+
+
+def test_products_get_multi_filter_in_stock(shop, category, test_client):
+    in_id = make_product(shop_id=shop, category_id=category, main_name="HasStock", stock=5)
+    out_id = make_product(shop_id=shop, category_id=category, main_name="NoStock", stock=0)
+
+    response = test_client.get(f"/shops/{shop}/products/?stock_status=in_stock")
+    assert response.status_code == 200
+    ids = {p["id"] for p in response.json()}
+    assert str(in_id) in ids
+    assert str(out_id) not in ids
+
+
+def test_products_get_multi_filter_out_of_stock(shop, category, test_client):
+    in_id = make_product(shop_id=shop, category_id=category, main_name="HasStock", stock=5)
+    out_id = make_product(shop_id=shop, category_id=category, main_name="NoStock", stock=0)
+
+    response = test_client.get(f"/shops/{shop}/products/?stock_status=out_of_stock")
+    assert response.status_code == 200
+    ids = {p["id"] for p in response.json()}
+    assert str(out_id) in ids
+    assert str(in_id) not in ids
+
+
+def test_products_get_multi_filter_all_is_default(shop, category, test_client):
+    make_product(shop_id=shop, category_id=category, main_name="HasStock", stock=5)
+    make_product(shop_id=shop, category_id=category, main_name="NoStock", stock=0)
+
+    default_response = test_client.get(f"/shops/{shop}/products/")
+    explicit_response = test_client.get(f"/shops/{shop}/products/?stock_status=all")
+    assert default_response.status_code == 200
+    assert explicit_response.status_code == 200
+    assert len(default_response.json()) == 2
+    assert {p["id"] for p in default_response.json()} == {p["id"] for p in explicit_response.json()}
+
+
+def test_products_get_multi_filter_invalid_stock_status(shop, test_client):
+    response = test_client.get(f"/shops/{shop}/products/?stock_status=bogus")
+    assert response.status_code == 422
+
+
+def test_products_get_multi_with_attributes_filter_out_of_stock(shop, category, test_client):
+    in_id = make_product(shop_id=shop, category_id=category, main_name="HasStock", stock=5)
+    out_id = make_product(shop_id=shop, category_id=category, main_name="NoStock", stock=0)
+
+    response = test_client.get(f"/shops/{shop}/products/with_attributes?stock_status=out_of_stock")
+    assert response.status_code == 200
+    ids = {p["product"]["id"] for p in response.json()}
+    assert str(out_id) in ids
+    assert str(in_id) not in ids

--- a/tests/unit_tests/factories/product.py
+++ b/tests/unit_tests/factories/product.py
@@ -16,12 +16,13 @@ def make_product(
     main_description="Test Product Description",
     price=1.0,
     tax_category="vat_standard",
+    stock: int = 1,
 ):
     product = ProductTable(
         shop_id=shop_id,
         category_id=category_id,
         price=price,
-        stock=1,
+        stock=stock,
         tax_category=tax_category,
     )
     db.session.add(product)

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -5655,7 +5655,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.2.9"
+    "version": "0.2.10"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -11604,6 +11604,23 @@
             }
           },
           {
+            "description": "Filter products by inventory state. `in_stock` returns products with stock > 0, `out_of_stock` returns products with stock = 0, `all` (default) returns everything.",
+            "in": "query",
+            "name": "stock_status",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "description": "Filter products by inventory state. `in_stock` returns products with stock > 0, `out_of_stock` returns products with stock = 0, `all` (default) returns everything.",
+              "enum": [
+                "in_stock",
+                "out_of_stock",
+                "all"
+              ],
+              "title": "Stock Status",
+              "type": "string"
+            }
+          },
+          {
             "in": "query",
             "name": "skip",
             "required": false,
@@ -11737,7 +11754,7 @@
     },
     "/shops/{shop_id}/products/with_attributes": {
       "get": {
-        "description": "Fetch a list of products along with their associated attributes.\n\nYou can filter the results using one of the following mutually exclusive attribute filters:\n\n* `option_id` array[UUID]: Filter by one or multiple attribute option UUIDs.\n* `attribute_id` UUID: Filter by attribute UUID.\n* `option_value_key` array[str]: Filter by option value (e.g., 'Red', 'XL').\n* `attribute_name` array[str]: Filter by one or multiple attribute names (e.g., 'Color', 'Size').\n\nOnly one attribute filter can be used at a time.",
+        "description": "Fetch a list of products along with their associated attributes.\n\nYou can filter the results using one of the following mutually exclusive attribute filters:\n\n* `option_id` array[UUID]: Filter by one or multiple attribute option UUIDs.\n* `attribute_id` UUID: Filter by attribute UUID.\n* `option_value_key` array[str]: Filter by option value (e.g., 'Red', 'XL').\n* `attribute_name` array[str]: Filter by one or multiple attribute names (e.g., 'Color', 'Size').\n\nOnly one attribute filter can be used at a time.\n\nYou can additionally narrow results by inventory state with `stock_status`:\n`in_stock` (stock > 0), `out_of_stock` (stock = 0), or `all` (default).",
         "operationId": "get_multi_with_attributes_shops__shop_id__products_with_attributes_get",
         "parameters": [
           {
@@ -11791,6 +11808,23 @@
             "required": false,
             "schema": {
               "title": "Attribute Name",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter products by inventory state. `in_stock` returns products with stock > 0, `out_of_stock` returns products with stock = 0, `all` (default) returns everything.",
+            "in": "query",
+            "name": "stock_status",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "description": "Filter products by inventory state. `in_stock` returns products with stock > 0, `out_of_stock` returns products with stock = 0, `all` (default) returns everything.",
+              "enum": [
+                "in_stock",
+                "out_of_stock",
+                "all"
+              ],
+              "title": "Stock Status",
               "type": "string"
             }
           },


### PR DESCRIPTION
## Summary
- New `?stock_status=in_stock|out_of_stock|all` query parameter on `GET /shops/{shop_id}/products/` and `GET /shops/{shop_id}/products/with_attributes`, letting shop owners filter the admin list by inventory state.
- Implemented as an explicit FastAPI `Literal` query parameter rather than threading through the generic `filter=key:value` mechanism — `stock` is a real column on `ProductTable`, so the generic path would have triggered `cast(stock, String).ilike("%in_stock%")` and silently returned zero rows.
- Strict semantics: `in_stock` ⇔ `stock > 0`, `out_of_stock` ⇔ `stock = 0`. Default `all` is fully backward compatible — omitting the parameter returns the same response as before.
- The unrelated `enable_stock_on_products` shop toggle is intentionally **not** consulted by this admin filter; a shop owner asking for `out_of_stock` wants those rows precisely to restock them.
- Bumps `APP_VERSION` 0.2.9 → 0.2.10 and regenerates `tests/unit_tests/openapi_snapshot.json`.

## Test plan
- [x] `PYTHONPATH=. pytest tests/unit_tests/api/test_products.py -v` — 16 passed (5 new tests: in_stock, out_of_stock, default-is-all, invalid-value-422, with_attributes cross-check).
- [x] `PYTHONPATH=. pytest tests/unit_tests/test_openapi_version.py -v` — snapshot-in-sync + version-bumped guards both green.
- [x] `PYTHONPATH=. pytest tests/unit_tests` — 157 passed.
- [x] `isort -c . && black --check .` — clean.
- [ ] Manual smoke against a dev shop with mixed stock: `?stock_status=in_stock`, `=out_of_stock`, omitted, and `=bogus` (→ 422). Verify `Content-Range` reflects filtered totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)