### PR TITLE
Add MCP server exposing shop CRUD as LLM tools

### DIFF
--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -22,6 +22,8 @@ run:
       value: "true"
     - name: MAIL_TEST_ENDPOINT_ENABLED
       value: "false"
+    - name: MCP_ENABLED
+      value: "true"
   secrets:
     - name: DATABASE_URI
       value-from: "arn:aws:ssm:eu-central-1:987457788157:parameter/pricelist-backend/DATABASE_URI"

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -4,10 +4,11 @@ Authentication lives in `server/security.py` and is built on [AWS Cognito](https
 
 ## Token model
 
-Two token shapes are accepted:
+Three credential shapes are accepted:
 
 1. **User tokens** — standard Cognito-issued ID/access tokens for interactive users. Validated against the configured Cognito user pool and resolved to a `client_id` / subject.
 2. **M2M (machine-to-machine) tokens** — Cognito client-credentials tokens. Must carry the `/api` scope. Used by server-to-server integrations.
+3. **API keys** — per-shop bearer tokens issued from `/shops/{shop_id}/api-keys/`. Accepted **only** on routes that opt in (currently the MCP-exposed CRUD surface for products / categories / tags / attributes). See the [MCP server](mcp.md) page for issuance and usage.
 
 The `CustomCognitoToken` model wraps the jose-decoded JWT and exposes the subject, scopes, and groups in a uniform shape.
 
@@ -27,6 +28,7 @@ All auth settings come from environment variables loaded by `server/settings.py`
 | `JWT_ALGORITHM` | Default `HS256`. |
 | `ACCESS_TOKEN_EXPIRE_MINUTES` | Default `120`. |
 | `SESSION_SECRET` | Signing key for `SessionMiddleware` cookies. |
+| `MCP_ENABLED` | Default `false`. Mount the [MCP server](mcp.md) at `/mcp`. |
 
 Cognito itself — user pool, app clients, domain, groups — is managed outside this repo.
 
@@ -44,6 +46,19 @@ def protected_route(token = Depends(auth_required)):
 ```
 
 `auth_required` accepts both user and M2M tokens. For M2M-only endpoints, the handler can assert on `token.scopes` inside the body.
+
+For endpoints that should also accept API keys (currently the MCP-exposed shop CRUD routes), use `auth_required_any` instead:
+
+```python
+from server.security import auth_required_any
+
+@router.get("/protected")
+def protected_route(principal = Depends(auth_required_any)):
+    # principal is either a CustomCognitoToken or an ApiKeyTable row.
+    ...
+```
+
+`auth_required_any` resolves `X-API-Key` or `Authorization: Bearer sv_…` first, then falls back to Cognito.
 
 ## Shop access checks
 

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -1,0 +1,160 @@
+# MCP server
+
+ShopVirge exposes a [**Model Context Protocol**](https://modelcontextprotocol.io/) endpoint at `/mcp` so LLM clients (Claude Desktop, Claude Code, MCP Inspector, the OpenAI Agents SDK, etc.) can manage a shop's catalog — products, categories, tags, and attributes — through a typed tool interface.
+
+The integration follows the pattern from [`workfloworchestrator/orchestrator-core` #1620](https://github.com/workfloworchestrator/orchestrator-core/pull/1620): tools are **auto-generated from the FastAPI route table** by [`fastmcp`](https://github.com/jlowin/fastmcp). Every REST route tagged `AgentTag.EXPOSED` becomes an MCP tool whose input/output schema is derived from the route's pydantic models and whose description is the route's docstring.
+
+## What gets exposed
+
+Twenty tools, one per shop CRUD operation. Tool names match the route's `operation_id`:
+
+| Resource | List | Get | Create | Update | Delete |
+|----------|------|-----|--------|--------|--------|
+| Products | `list_products` | `get_product` | `create_product` | `update_product` | `delete_product` |
+| Categories | `list_categories` | `get_category` | `create_category` | `update_category` | `delete_category` |
+| Tags | `list_tags` | `get_tag` | `create_tag` | `update_tag` | `delete_tag` |
+| Attributes | `list_attributes` | `get_attribute` | `create_attribute` | `update_attribute` | `delete_attribute` |
+
+List tools also carry `AgentTag.LARGE`, signalling to well-behaved clients that they should filter before calling.
+
+Any route *not* tagged with `AgentTag.EXPOSED` is invisible to MCP — even though it's still served by the same REST API. Orders, accounts, prices, Stripe, shop config etc. are intentionally REST-only.
+
+## Enabling the endpoint
+
+Off by default. Turn it on per environment by setting:
+
+```bash
+MCP_ENABLED=true
+```
+
+When enabled, `server/main.py` calls `mount_mcp(app)` after all routers are included, mounts the sub-app at `/mcp`, and enters its lifespan from the parent FastAPI lifespan (Starlette does not run mounted sub-app lifespans automatically). The transport is **streamable HTTP**.
+
+## Authentication
+
+Two methods are accepted on `/mcp` and on the tagged CRUD endpoints. They are checked in this order:
+
+1. **API key** — `X-API-Key: sv_<prefix>_<rest>` header, *or* `Authorization: Bearer sv_<prefix>_<rest>`. Recommended for headless LLM clients.
+2. **Cognito JWT** — `Authorization: Bearer <jwt>`. Same flow as the regular REST API; useful when a logged-in user drives the agent from a browser.
+
+The dual-auth dependency is `server.security.auth_required_any`. It either resolves the API key against the `api_keys` table (returning the matched row) or delegates to the existing Cognito flow (returning a `CustomCognitoToken`). Endpoints not tagged for MCP still use `auth_required` (Cognito only) — an API key cannot reach the full REST surface.
+
+### Issuing an API key
+
+API key management is **Cognito-only by design** — an API key cannot mint another API key.
+
+Mint a key (one-time plaintext in the response):
+
+```bash
+curl -sX POST https://api.example.com/shops/$SHOP_ID/api-keys/ \
+  -H "Authorization: Bearer $COGNITO_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "claude-desktop"}'
+```
+
+```json
+{
+  "id": "8fd1…",
+  "name": "claude-desktop",
+  "prefix": "Lk3Df-9z",
+  "plaintext": "sv_Lk3Df-9z_xK8nQ…",
+  "created_at": "2026-05-21T08:14:22Z",
+  "last_used_at": null,
+  "revoked_at": null
+}
+```
+
+`plaintext` is returned **exactly once**. Store it somewhere safe; subsequent `GET /shops/{shop_id}/api-keys/` listings only return the prefix. The server stores `sha256(plaintext)` and never the raw value.
+
+List keys:
+
+```bash
+curl -s https://api.example.com/shops/$SHOP_ID/api-keys/ \
+  -H "Authorization: Bearer $COGNITO_ACCESS_TOKEN"
+```
+
+Revoke a key (subsequent requests with it return `401`):
+
+```bash
+curl -X DELETE https://api.example.com/shops/$SHOP_ID/api-keys/$KEY_ID \
+  -H "Authorization: Bearer $COGNITO_ACCESS_TOKEN"
+```
+
+## Connecting an MCP client
+
+### Claude Desktop / Claude Code
+
+Add an entry to the client's MCP config (`~/.claude/mcp.json` or the Claude Desktop UI):
+
+```json
+{
+  "mcpServers": {
+    "shopvirge": {
+      "url": "https://api.example.com/mcp/",
+      "transport": "http",
+      "headers": {
+        "Authorization": "Bearer sv_Lk3Df-9z_xK8nQ…"
+      }
+    }
+  }
+}
+```
+
+### MCP Inspector
+
+```bash
+npx @modelcontextprotocol/inspector https://api.example.com/mcp/ \
+  --header "Authorization=Bearer sv_Lk3Df-9z_xK8nQ…"
+```
+
+### Quick `curl` smoke test
+
+```bash
+curl -X POST https://api.example.com/mcp/ \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H "Authorization: Bearer $SV_API_KEY" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+You should see all 20 tool definitions in the response.
+
+## How auth flows through `from_fastapi`
+
+`FastMCP.from_fastapi(app=…)` invokes the underlying routes via in-process `httpx` over an `ASGITransport`. That means every MCP tool call **goes through the FastAPI middleware and dependency chain** — including `auth_required_any`. The only thing fastmcp does *not* do by default is forward auth headers: its `get_http_headers()` exclude list strips `authorization`.
+
+`server/mcp/server.py` adds a small httpx request hook that re-injects both `Authorization` and `X-API-Key` on every internal call, so per-route auth fires exactly as it would over plain REST.
+
+## Adding a new tool
+
+1. Add `from server.agent_tags import AgentTag` to the endpoint module.
+2. On the route decorator, add:
+   - `tags=[AgentTag.EXPOSED]` (add `AgentTag.LARGE` too for list endpoints).
+   - `operation_id="<short_snake_case>"`. **This becomes the MCP tool name** — treat it like a public API contract.
+3. Switch the router-level dependency to `Depends(auth_required_any)` if you want API-key clients to reach it. (Cognito-only endpoints stay on `auth_required`.)
+4. Bump `APP_VERSION` in `server/main.py` and regenerate `tests/unit_tests/openapi_snapshot.json` (see the OpenAPI drift guard).
+5. Update `EXPECTED_TOOL_NAMES` in `tests/unit_tests/mcp/test_mcp.py`.
+
+The docstring on the handler becomes the tool description — write it for an LLM, not a developer. State the *intent*, list *required* parameters, and call out side effects.
+
+## Architecture notes
+
+- **Pure-ASGI middleware.** `DBSessionMiddleware` in `server/db/database.py` was rewritten from `BaseHTTPMiddleware` to a pure ASGI `__call__(scope, receive, send)`. `BaseHTTPMiddleware` buffers the response body, which breaks the `StreamableHTTPSessionManager` used by `/mcp`. Any new middleware in front of `/mcp` must be pure-ASGI.
+- **Lifespan composition.** `server/main.py` holds a module-level `mcp_app` that is `None` until the MCP mount runs. The parent lifespan enters `mcp_app.router.lifespan_context(app_)` only when it's set, so the boot path with `MCP_ENABLED=false` is unchanged.
+- **Tool surface scoping.** `RouteMap(tags={AgentTag.EXPOSED.value}, mcp_type=MCPType.TOOL)` is followed by `RouteMap(mcp_type=MCPType.EXCLUDE)` so any route the developer forgets to tag is silently excluded — the default is *not* "expose everything."
+
+## Settings
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `MCP_ENABLED` | `false` | Mount `/mcp` and enter its lifespan. |
+
+API keys themselves are stored in the `api_keys` table (migration `c1a2b3d4e5f6`) and need no env config.
+
+## Related files
+
+- `server/mcp/server.py` — `mount_mcp(app)` and the auth-header forwarding hook.
+- `server/agent_tags.py` — the `AgentTag` enum.
+- `server/security.py` — `auth_required_any` dual-auth dependency.
+- `server/crud/crud_api_key.py` — minting, lookup, revocation.
+- `server/api/endpoints/shop_endpoints/api_keys.py` — REST management endpoints.
+- `tests/unit_tests/mcp/test_mcp.py` — verifies tag coverage and `FastMCP.from_fastapi` introspection.

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -63,7 +63,7 @@ curl -sX POST https://api.example.com/shops/$SHOP_ID/api-keys/ \
 }
 ```
 
-`plaintext` is returned **exactly once**. Store it somewhere safe; subsequent `GET /shops/{shop_id}/api-keys/` listings only return the prefix. The server stores `sha256(plaintext)` and never the raw value.
+`plaintext` is returned **exactly once**. Store it somewhere safe; subsequent `GET /shops/{shop_id}/api-keys/` listings only return the prefix. The server stores two derived values and never the raw key: a `sha256` *fingerprint* (indexed for O(1) lookup, safe to leak in logs) and a `bcrypt` hash that the request handler bcrypt-verifies on every call. A DB dump alone cannot yield usable keys.
 
 List keys:
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -34,6 +34,10 @@ All routers are composed in `server/api/api.py` into a single `api_router`, whic
 
     Everything under `/shops/{shop_id}/...` — see [Shop-scoped endpoints](shop-scoped.md) for the full list.
 
+=== "MCP"
+
+    `/mcp` (off by default; set `MCP_ENABLED=true`) exposes shop CRUD operations as Model Context Protocol tools for LLM clients. See [MCP server](mcp.md).
+
 ## FastAPI app metadata
 
 From `server/main.py` (version `0.2.6` at time of writing):

--- a/migrations/versions/schema/2026-05-20_c1a2b3d4e5f6_add_api_keys.py
+++ b/migrations/versions/schema/2026-05-20_c1a2b3d4e5f6_add_api_keys.py
@@ -31,7 +31,8 @@ def upgrade() -> None:
         sa.Column("shop_id", sqlalchemy_utils.types.uuid.UUIDType(), nullable=False),
         sa.Column("name", sa.String(length=120), nullable=False),
         sa.Column("prefix", sa.String(length=16), nullable=False),
-        sa.Column("key_hash", sa.String(length=64), nullable=False),
+        sa.Column("fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("encrypted_key", sa.String(), nullable=False),
         sa.Column("created_by_sub", sa.String(length=64), nullable=True),
         sa.Column(
             "created_at",
@@ -43,14 +44,15 @@ def upgrade() -> None:
         sa.Column("revoked_at", UtcTimestamp(timezone=True), nullable=True),
         sa.ForeignKeyConstraint(["shop_id"], ["shops.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("key_hash"),
     )
     op.create_index(op.f("ix_api_keys_id"), "api_keys", ["id"], unique=False)
     op.create_index(op.f("ix_api_keys_shop_id"), "api_keys", ["shop_id"], unique=False)
     op.create_index(op.f("ix_api_keys_prefix"), "api_keys", ["prefix"], unique=False)
+    op.create_index(op.f("ix_api_keys_fingerprint"), "api_keys", ["fingerprint"], unique=True)
 
 
 def downgrade() -> None:
+    op.drop_index(op.f("ix_api_keys_fingerprint"), table_name="api_keys")
     op.drop_index(op.f("ix_api_keys_prefix"), table_name="api_keys")
     op.drop_index(op.f("ix_api_keys_shop_id"), table_name="api_keys")
     op.drop_index(op.f("ix_api_keys_id"), table_name="api_keys")

--- a/migrations/versions/schema/2026-05-20_c1a2b3d4e5f6_add_api_keys.py
+++ b/migrations/versions/schema/2026-05-20_c1a2b3d4e5f6_add_api_keys.py
@@ -1,0 +1,57 @@
+"""create api_keys table.
+
+Revision ID: c1a2b3d4e5f6
+Revises: 762f0ee89e95
+Create Date: 2026-05-20 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+from alembic import op
+
+from server.db.models import UtcTimestamp
+
+# revision identifiers, used by Alembic.
+revision = "c1a2b3d4e5f6"
+down_revision = "762f0ee89e95"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_keys",
+        sa.Column(
+            "id",
+            sqlalchemy_utils.types.uuid.UUIDType(),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+        sa.Column("shop_id", sqlalchemy_utils.types.uuid.UUIDType(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("prefix", sa.String(length=16), nullable=False),
+        sa.Column("key_hash", sa.String(length=64), nullable=False),
+        sa.Column("created_by_sub", sa.String(length=64), nullable=True),
+        sa.Column(
+            "created_at",
+            UtcTimestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column("last_used_at", UtcTimestamp(timezone=True), nullable=True),
+        sa.Column("revoked_at", UtcTimestamp(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["shop_id"], ["shops.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("key_hash"),
+    )
+    op.create_index(op.f("ix_api_keys_id"), "api_keys", ["id"], unique=False)
+    op.create_index(op.f("ix_api_keys_shop_id"), "api_keys", ["shop_id"], unique=False)
+    op.create_index(op.f("ix_api_keys_prefix"), "api_keys", ["prefix"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_api_keys_prefix"), table_name="api_keys")
+    op.drop_index(op.f("ix_api_keys_shop_id"), table_name="api_keys")
+    op.drop_index(op.f("ix_api_keys_id"), table_name="api_keys")
+    op.drop_table("api_keys")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - Overview: api/overview.md
       - Shop-scoped endpoints: api/shop-scoped.md
       - Authentication: api/authentication.md
+      - MCP server: api/mcp.md
       - Admin accounts: api/admin-accounts.md
       - Stripe: api/stripe.md
       - Email notifications: api/email-notifications.md

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ gunicorn~=20.0.4
 more-itertools==10.2.0
 passlib[bcrypt]==1.7.4
 psycopg2-binary==2.9.9
-pydantic[email]==2.7.1
+pydantic[email]>=2.11.7
 pyjwt==2.1.0  # Todo: Not sure if we need this one
 python-jose[cryptography]==3.2.0
 python-rapidjson==1.17
@@ -23,10 +23,10 @@ SQLAlchemy-Utils
 # SQLAlchemy-Searchable~=1.2.0
 structlog
 #typer-cli==0.0.12
-uvicorn[standard]~=0.29.0
+uvicorn[standard]>=0.35
 itsdangerous
 pydantic-forms
-pydantic-settings~=2.4.0
+pydantic-settings>=2.5.2
 python-multipart==0.0.12
 wheel
 stripe==10.7.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,8 +5,9 @@ deepdiff==5.6.0
 Deprecated~=1.2.12
 emails~=0.6
 email-validator~=2.1.1
-fastapi~=0.110.0
+fastapi~=0.115.0
 fastapi-cognito
+fastmcp~=2.0
 #fastapi-mail~=0.3.5.0
 gunicorn~=20.0.4
 more-itertools==10.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,7 @@ fastmcp~=2.0
 gunicorn~=20.0.4
 more-itertools==10.2.0
 passlib[bcrypt]==1.7.4
+bcrypt<4.1  # passlib 1.7.4's bcrypt backend init fails against bcrypt >=4.1 (uses removed `__about__`)
 psycopg2-binary==2.9.9
 pydantic[email]>=2.11.7
 pyjwt==2.1.0  # Todo: Not sure if we need this one

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,5 +3,5 @@
 pre-commit
 pydocstyle==3.0.0
 watchdog
-typer==0.7.0  # added to speed up
-click==8.1.8
+typer>=0.15.2
+click>=8.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,5 +7,5 @@ pytest-cov
 pytest-xdist
 pytest_benchmark
 httpx
-typer==0.7.0
-click==8.1.8
+typer>=0.15.2
+click>=8.4

--- a/server/agent_tags.py
+++ b/server/agent_tags.py
@@ -1,0 +1,24 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+"""Per-endpoint metadata for LLM agent exposure.
+
+Add these as FastAPI route ``tags=[...]`` to mark endpoints for downstream
+consumers. Each tag is a short kebab-case string that lands unchanged in the
+OpenAPI spec, so any tool reading the spec can filter/branch on it.
+"""
+
+from enum import Enum
+
+
+class AgentTag(str, Enum):
+    """Per-endpoint metadata for LLM agent exposure."""
+
+    EXPOSED = "agent-exposed"
+    """Gate: if absent, the endpoint is not exposed to any LLM agent surface."""
+
+    LARGE = "agent-large"
+    """Signal: may return many records; agent should narrow before calling."""

--- a/server/api/api.py
+++ b/server/api/api.py
@@ -34,6 +34,7 @@ from server.api.endpoints import (
 )
 from server.api.endpoints.shop_endpoints import (
     accounts,
+    api_keys,
     attribute_options,
     attributes,
     categories,
@@ -49,7 +50,7 @@ from server.api.endpoints.shop_endpoints import (
     tags,
 )
 from server.api.endpoints.shop_endpoints.images import router as shop_image_router
-from server.security import auth_required
+from server.security import auth_required, auth_required_any
 from server.settings import mail_settings
 
 api_router = APIRouter()
@@ -101,7 +102,7 @@ api_router.include_router(
     categories.router,
     prefix="/shops/{shop_id}/categories",
     tags=["categories"],
-    dependencies=[Depends(auth_required)],
+    dependencies=[Depends(auth_required_any)],
 )
 api_router.include_router(
     categories.public_router,
@@ -131,7 +132,7 @@ api_router.include_router(
     products.router,
     prefix="/shops/{shop_id}/products",
     tags=["shops", "products"],
-    dependencies=[Depends(auth_required)],
+    dependencies=[Depends(auth_required_any)],
 )
 api_router.include_router(
     products.public_router,
@@ -148,13 +149,18 @@ api_router.include_router(
     tags.router,
     prefix="/shops/{shop_id}/tags",
     tags=["shops", "products"],
-    dependencies=[Depends(auth_required)],
+    dependencies=[Depends(auth_required_any)],
 )
 api_router.include_router(
     attributes.router,
     prefix="/shops/{shop_id}/attributes",
     tags=["shops", "attributes"],
-    dependencies=[Depends(auth_required)],
+    dependencies=[Depends(auth_required_any)],
+)
+api_router.include_router(
+    api_keys.router,
+    prefix="/shops/{shop_id}/api-keys",
+    tags=["shops", "api-keys"],
 )
 api_router.include_router(
     attribute_options.router,

--- a/server/api/endpoints/shop_endpoints/api_keys.py
+++ b/server/api/endpoints/shop_endpoints/api_keys.py
@@ -1,0 +1,86 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+"""Per-shop API key management.
+
+These endpoints are Cognito-only (``auth_required``) by design — an API key
+must not be able to mint another API key. Keys returned from ``POST`` carry
+a one-time ``plaintext`` field; subsequent ``GET`` listings expose only the
+prefix.
+"""
+
+from http import HTTPStatus
+from typing import List
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Body, Depends, HTTPException
+
+from server.crud.crud_api_key import api_key_crud
+from server.schemas.api_key import ApiKeyCreate, ApiKeyCreated, ApiKeyRead
+from server.security import CustomCognitoToken, auth_required
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+@router.post(
+    "/",
+    response_model=ApiKeyCreated,
+    status_code=HTTPStatus.CREATED,
+    summary="Mint a new API key for the shop",
+)
+def mint(
+    shop_id: UUID,
+    data: ApiKeyCreate = Body(...),
+    token: CustomCognitoToken = Depends(auth_required),
+) -> ApiKeyCreated:
+    """Mint a new API key. The plaintext is returned exactly once.
+
+    Store it somewhere safe — it cannot be retrieved again. If lost, revoke
+    and mint a new one.
+    """
+    created_by_sub = getattr(token, "cognito_id", None)
+    row, plaintext = api_key_crud.mint(shop_id=shop_id, name=data.name, created_by_sub=created_by_sub)
+    return ApiKeyCreated(
+        id=row.id,
+        name=row.name,
+        prefix=row.prefix,
+        created_at=row.created_at,
+        last_used_at=row.last_used_at,
+        revoked_at=row.revoked_at,
+        plaintext=plaintext,
+    )
+
+
+@router.get(
+    "/",
+    response_model=List[ApiKeyRead],
+    summary="List API keys for the shop",
+)
+def list_keys(
+    shop_id: UUID,
+    _: CustomCognitoToken = Depends(auth_required),
+) -> List[ApiKeyRead]:
+    rows = api_key_crud.list_by_shop(shop_id)
+    return [ApiKeyRead.model_validate(r) for r in rows]
+
+
+@router.delete(
+    "/{key_id}",
+    status_code=HTTPStatus.NO_CONTENT,
+    summary="Revoke an API key",
+)
+def revoke(
+    shop_id: UUID,
+    key_id: UUID,
+    _: CustomCognitoToken = Depends(auth_required),
+) -> None:
+    row = api_key_crud.revoke(shop_id=shop_id, key_id=key_id)
+    if row is None:
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="API key not found")
+    return None

--- a/server/api/endpoints/shop_endpoints/attributes.py
+++ b/server/api/endpoints/shop_endpoints/attributes.py
@@ -8,6 +8,7 @@ from fastapi.param_functions import Body, Depends
 from sqlalchemy.exc import IntegrityError
 from starlette.responses import Response
 
+from server.agent_tags import AgentTag
 from server.api.deps import common_parameters
 from server.api.error_handling import raise_status
 from server.crud.base import NotFound
@@ -89,6 +90,8 @@ def get_with_options(
     response_model=List[AttributeSchema],
     summary="List shop attributes",
     description="Retrieve a paginated list of all attributes defined for a specific shop. This list does not include options.",
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    operation_id="list_attributes",
 )
 def get_multi(shop_id: UUID, response: Response, common: dict = Depends(common_parameters)) -> List[AttributeSchema]:
     """List attributes for a shop."""
@@ -126,6 +129,8 @@ def get_by_id_with_options(attribute_id: UUID, shop_id: UUID) -> AttributeWithOp
     response_model=AttributeSchema,
     summary="Get attribute by ID",
     description="Retrieve the details of a specific attribute using its unique ID.",
+    tags=[AgentTag.EXPOSED],
+    operation_id="get_attribute",
 )
 def get_by_id(attribute_id: UUID, shop_id: UUID) -> AttributeSchema:
     """Get a single attribute for a shop by its ID."""
@@ -155,6 +160,8 @@ def get_by_name(name: str, shop_id: UUID) -> AttributeSchema:
     status_code=HTTPStatus.CREATED,
     summary="Create attribute",
     description="Create a new attribute for a shop. This also initializes a translation record with the provided name.",
+    tags=[AgentTag.EXPOSED],
+    operation_id="create_attribute",
 )
 def create(shop_id: UUID, data: AttributeCreate = Body(...)) -> AttributeSchema:
     """
@@ -179,6 +186,8 @@ def create(shop_id: UUID, data: AttributeCreate = Body(...)) -> AttributeSchema:
     response_model=AttributeSchema,
     summary="Update attribute",
     description="Update the details of an existing attribute, such as its name or unit.",
+    tags=[AgentTag.EXPOSED],
+    operation_id="update_attribute",
 )
 def update(attribute_id: UUID, shop_id: UUID, data: AttributeUpdate = Body(...)) -> AttributeSchema:
     """Update an attribute for a shop."""
@@ -198,6 +207,8 @@ def update(attribute_id: UUID, shop_id: UUID, data: AttributeUpdate = Body(...))
     status_code=HTTPStatus.NO_CONTENT,
     summary="Delete attribute",
     description="Remove an attribute from a shop. This will fail if the attribute is currently in use by any products.",
+    tags=[AgentTag.EXPOSED],
+    operation_id="delete_attribute",
 )
 def delete(attribute_id: UUID, shop_id: UUID) -> None:
     """Delete an attribute for a shop."""

--- a/server/api/endpoints/shop_endpoints/categories.py
+++ b/server/api/endpoints/shop_endpoints/categories.py
@@ -10,6 +10,7 @@ from fastapi.param_functions import Body, Depends
 from sqlalchemy import func
 from starlette.responses import Response
 
+from server.agent_tags import AgentTag
 from server.api.deps import common_parameters
 from server.api.error_handling import raise_status
 from server.api.helpers import invalidateShopCache
@@ -59,7 +60,12 @@ def get_shop(shop_id: UUID):
     return shop
 
 
-@router.get("/", response_model=List[CategorySchema])
+@router.get(
+    "/",
+    response_model=List[CategorySchema],
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    operation_id="list_categories",
+)
 def get_multi(shop_id: UUID, response: Response, common: dict = Depends(common_parameters)) -> List[CategorySchema]:
     # shop = get_shop(shop_id)
     categories, header_range = category_crud.get_multi_by_shop_id(
@@ -73,7 +79,12 @@ def get_multi(shop_id: UUID, response: Response, common: dict = Depends(common_p
     return categories
 
 
-@router.get("/{category_id}", response_model=CategorySchema)
+@router.get(
+    "/{category_id}",
+    response_model=CategorySchema,
+    tags=[AgentTag.EXPOSED],
+    operation_id="get_category",
+)
 def get_by_id(shop_id: UUID, category_id: UUID) -> CategorySchema:
     category = category_crud.get_id_by_shop_id(shop_id, category_id)
     if not category:
@@ -99,7 +110,13 @@ def get_by_name(name: str, shop_id: UUID) -> CategorySchema:
     return category
 
 
-@router.post("/", response_model=None, status_code=HTTPStatus.CREATED)
+@router.post(
+    "/",
+    response_model=None,
+    status_code=HTTPStatus.CREATED,
+    tags=[AgentTag.EXPOSED],
+    operation_id="create_category",
+)
 def create(shop_id: UUID, data: CategoryCreate = Body(...)) -> None:
     category = CategoryTable.query.filter_by(shop_id=shop_id).order_by(CategoryTable.order_number.desc()).first()
     data.order_number = (category.order_number + 1) if category is not None else 0
@@ -108,7 +125,13 @@ def create(shop_id: UUID, data: CategoryCreate = Body(...)) -> None:
     return category_crud.create_by_shop_id(obj_in=data, shop_id=shop_id)
 
 
-@router.put("/{category_id}", response_model=None, status_code=HTTPStatus.CREATED)
+@router.put(
+    "/{category_id}",
+    response_model=None,
+    status_code=HTTPStatus.CREATED,
+    tags=[AgentTag.EXPOSED],
+    operation_id="update_category",
+)
 def update(*, category_id: UUID, shop_id: UUID, item_in: CategoryUpdate) -> Any:
     category = category_crud.get_id_by_shop_id(shop_id, category_id)
     logger.info("Updating category", data=category)
@@ -158,7 +181,13 @@ def swap(shop_id: UUID, category_id: UUID, move_up: bool):
     return HTTPStatus.CREATED
 
 
-@router.delete("/{category_id}", response_model=None, status_code=HTTPStatus.NO_CONTENT)
+@router.delete(
+    "/{category_id}",
+    response_model=None,
+    status_code=HTTPStatus.NO_CONTENT,
+    tags=[AgentTag.EXPOSED],
+    operation_id="delete_category",
+)
 def delete(category_id: UUID, shop_id: UUID) -> None:
     return category_crud.delete_by_shop_id(shop_id=shop_id, id=category_id)
 

--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -8,6 +8,7 @@ import structlog
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from starlette.responses import Response
 
+from server.agent_tags import AgentTag
 from server.api import deps
 from server.api.deps import common_parameters
 from server.api.error_handling import raise_status
@@ -39,7 +40,12 @@ def get_shop(shop_id: UUID):
     return shop
 
 
-@router.get("/", response_model=List[ProductWithDefaultPrice])
+@router.get(
+    "/",
+    response_model=List[ProductWithDefaultPrice],
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    operation_id="list_products",
+)
 def get_multi(
     shop_id: UUID,
     response: Response,
@@ -224,7 +230,12 @@ def get_by_id_with_attributes(product_id: UUID, shop_id: UUID) -> ProductWithAtt
     return ProductWithAttributes(product=prod_schema, attributes=attrs)
 
 
-@public_router.get("/{product_id}", response_model=ProductWithDetailsAndPrices)
+@public_router.get(
+    "/{product_id}",
+    response_model=ProductWithDetailsAndPrices,
+    tags=[AgentTag.EXPOSED],
+    operation_id="get_product",
+)
 def get_by_id(product_id: UUID, shop_id: UUID) -> ProductWithDetailsAndPrices:
     product = product_crud.get_id_by_shop_id(shop_id, product_id)
     if not product:
@@ -259,7 +270,13 @@ def get_by_id(product_id: UUID, shop_id: UUID) -> ProductWithDetailsAndPrices:
     return product
 
 
-@router.post("/", response_model=None, status_code=HTTPStatus.CREATED)
+@router.post(
+    "/",
+    response_model=None,
+    status_code=HTTPStatus.CREATED,
+    tags=[AgentTag.EXPOSED],
+    operation_id="create_product",
+)
 def create(shop_id: UUID, data: ProductCreate = Body(...)) -> None:
     product = (
         ProductTable.query.filter_by(shop_id=shop_id)
@@ -274,7 +291,13 @@ def create(shop_id: UUID, data: ProductCreate = Body(...)) -> None:
     return product
 
 
-@router.put("/{product_id}", response_model=None, status_code=HTTPStatus.CREATED)
+@router.put(
+    "/{product_id}",
+    response_model=None,
+    status_code=HTTPStatus.CREATED,
+    tags=[AgentTag.EXPOSED],
+    operation_id="update_product",
+)
 def update(*, product_id: UUID, shop_id: UUID, item_in: ProductUpdate) -> Any:
     product = product_crud.get_id_by_shop_id(shop_id, product_id)
     logger.info("Updating product", data=product)
@@ -337,6 +360,12 @@ def swap(shop_id: UUID, product_id: UUID, move_up: bool):
     return HTTPStatus.CREATED
 
 
-@router.delete("/{product_id}", response_model=None, status_code=HTTPStatus.NO_CONTENT)
+@router.delete(
+    "/{product_id}",
+    response_model=None,
+    status_code=HTTPStatus.NO_CONTENT,
+    tags=[AgentTag.EXPOSED],
+    operation_id="delete_product",
+)
 def delete(product_id: UUID, shop_id: UUID) -> None:
     return product_crud.delete_by_shop_id(shop_id=shop_id, id=product_id)

--- a/server/api/endpoints/shop_endpoints/tags.py
+++ b/server/api/endpoints/shop_endpoints/tags.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException
 from fastapi.param_functions import Body, Depends
 from starlette.responses import Response
 
+from server.agent_tags import AgentTag
 from server.api.deps import common_parameters
 from server.api.error_handling import raise_status
 from server.crud.crud_tag import tag_crud
@@ -17,7 +18,12 @@ logger = structlog.get_logger(__name__)
 router = APIRouter()
 
 
-@router.get("/", response_model=List[TagSchema])
+@router.get(
+    "/",
+    response_model=List[TagSchema],
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    operation_id="list_tags",
+)
 def get_multi(shop_id: UUID, response: Response, common: dict = Depends(common_parameters)) -> List[TagSchema]:
     tags, header_range = tag_crud.get_multi_by_shop_id(
         shop_id=shop_id,
@@ -30,7 +36,12 @@ def get_multi(shop_id: UUID, response: Response, common: dict = Depends(common_p
     return tags
 
 
-@router.get("/{tag_id}", response_model=TagSchema)
+@router.get(
+    "/{tag_id}",
+    response_model=TagSchema,
+    tags=[AgentTag.EXPOSED],
+    operation_id="get_tag",
+)
 def get_by_id(tag_id: UUID, shop_id: UUID) -> TagSchema:
     tag = tag_crud.get_id_by_shop_id(shop_id, tag_id)
     if not tag:
@@ -47,14 +58,26 @@ def get_by_name(name: str, shop_id: UUID) -> TagSchema:
     return tag
 
 
-@router.post("/", response_model=None, status_code=HTTPStatus.CREATED)
+@router.post(
+    "/",
+    response_model=None,
+    status_code=HTTPStatus.CREATED,
+    tags=[AgentTag.EXPOSED],
+    operation_id="create_tag",
+)
 def create(shop_id: UUID, data: TagCreate = Body(...)) -> None:
     logger.info("Saving tag", data=data)
     tag = tag_crud.create_by_shop_id(shop_id=shop_id, obj_in=data)
     return tag
 
 
-@router.put("/{tag_id}", response_model=None, status_code=HTTPStatus.CREATED)
+@router.put(
+    "/{tag_id}",
+    response_model=None,
+    status_code=HTTPStatus.CREATED,
+    tags=[AgentTag.EXPOSED],
+    operation_id="update_tag",
+)
 def update(*, tag_id: UUID, shop_id: UUID, item_in: TagUpdate) -> Any:
     tag = tag_crud.get_id_by_shop_id(shop_id, tag_id)
     logger.info("Updating tag", data=tag)
@@ -68,7 +91,13 @@ def update(*, tag_id: UUID, shop_id: UUID, item_in: TagUpdate) -> Any:
     return tag
 
 
-@router.delete("/{tag_id}", response_model=None, status_code=HTTPStatus.NO_CONTENT)
+@router.delete(
+    "/{tag_id}",
+    response_model=None,
+    status_code=HTTPStatus.NO_CONTENT,
+    tags=[AgentTag.EXPOSED],
+    operation_id="delete_tag",
+)
 def delete(tag_id: UUID, shop_id: UUID) -> None:
     try:
         tag_crud.delete_by_shop_id(shop_id=shop_id, id=tag_id)

--- a/server/crud/crud_api_key.py
+++ b/server/crud/crud_api_key.py
@@ -6,9 +6,13 @@
 #    http://www.apache.org/licenses/LICENSE-2.0
 """CRUD for ApiKeyTable.
 
-Keys are stored as ``sha256`` of the plaintext; the plaintext leaves the
-server exactly once, in the response from :meth:`CRUDApiKey.mint`. Listing
-endpoints only ever surface the ``prefix`` so users can identify a key.
+Two-layer storage: sha256 fingerprint for indexed lookup, bcrypt hash for
+verification. A DB dump alone cannot yield usable keys — even if SHA256 is
+weakened, the bcrypt round still has to be brute-forced per row.
+
+The plaintext leaves the server exactly once, in the response from
+:meth:`CRUDApiKey.mint`. Listing endpoints surface only the ``prefix`` so
+users can identify a key.
 """
 
 from __future__ import annotations
@@ -19,21 +23,25 @@ from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 from uuid import UUID
 
+from passlib.context import CryptContext
+
 from server.db import db
 from server.db.models import ApiKeyTable
 
 KEY_PLAINTEXT_PREFIX = "sv"
 PREFIX_LEN = 8
 
+_pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-def _hash(plaintext: str) -> str:
+
+def _fingerprint(plaintext: str) -> str:
     return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
 
 
 def _generate_plaintext() -> Tuple[str, str]:
     """Return ``(plaintext, prefix)``. Prefix is the leading ``PREFIX_LEN`` chars
-    of the random body — stored alongside the hash so users can identify a key
-    in listings without exposing the full secret."""
+    of the random body — stored alongside so users can identify a key in
+    listings without exposing the full secret."""
     body = secrets.token_urlsafe(32)
     prefix = body[:PREFIX_LEN]
     plaintext = f"{KEY_PLAINTEXT_PREFIX}_{prefix}_{body[PREFIX_LEN:]}"
@@ -47,7 +55,8 @@ class CRUDApiKey:
             shop_id=shop_id,
             name=name,
             prefix=prefix,
-            key_hash=_hash(plaintext),
+            fingerprint=_fingerprint(plaintext),
+            encrypted_key=_pwd_context.hash(plaintext),
             created_by_sub=created_by_sub,
         )
         db.session.add(api_key)
@@ -58,13 +67,15 @@ class CRUDApiKey:
     def lookup_by_plaintext(self, plaintext: str) -> Optional[ApiKeyTable]:
         """Return the key row iff the plaintext matches an active (non-revoked) key.
 
-        Bumps ``last_used_at`` as a side effect.
+        Sha256 fingerprint narrows the lookup to one row; bcrypt-verify
+        confirms the plaintext. Bumps ``last_used_at`` as a side effect.
         """
         if not plaintext or not plaintext.startswith(f"{KEY_PLAINTEXT_PREFIX}_"):
             return None
-        key_hash = _hash(plaintext)
-        row = db.session.query(ApiKeyTable).filter(ApiKeyTable.key_hash == key_hash).first()
+        row = db.session.query(ApiKeyTable).filter(ApiKeyTable.fingerprint == _fingerprint(plaintext)).first()
         if row is None or row.revoked_at is not None:
+            return None
+        if not _pwd_context.verify(plaintext, row.encrypted_key):
             return None
         row.last_used_at = datetime.now(timezone.utc)
         db.session.commit()

--- a/server/crud/crud_api_key.py
+++ b/server/crud/crud_api_key.py
@@ -1,0 +1,91 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+"""CRUD for ApiKeyTable.
+
+Keys are stored as ``sha256`` of the plaintext; the plaintext leaves the
+server exactly once, in the response from :meth:`CRUDApiKey.mint`. Listing
+endpoints only ever surface the ``prefix`` so users can identify a key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+from uuid import UUID
+
+from server.db import db
+from server.db.models import ApiKeyTable
+
+KEY_PLAINTEXT_PREFIX = "sv"
+PREFIX_LEN = 8
+
+
+def _hash(plaintext: str) -> str:
+    return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
+
+
+def _generate_plaintext() -> Tuple[str, str]:
+    """Return ``(plaintext, prefix)``. Prefix is the leading ``PREFIX_LEN`` chars
+    of the random body — stored alongside the hash so users can identify a key
+    in listings without exposing the full secret."""
+    body = secrets.token_urlsafe(32)
+    prefix = body[:PREFIX_LEN]
+    plaintext = f"{KEY_PLAINTEXT_PREFIX}_{prefix}_{body[PREFIX_LEN:]}"
+    return plaintext, prefix
+
+
+class CRUDApiKey:
+    def mint(self, *, shop_id: UUID, name: str, created_by_sub: Optional[str] = None) -> Tuple[ApiKeyTable, str]:
+        plaintext, prefix = _generate_plaintext()
+        api_key = ApiKeyTable(
+            shop_id=shop_id,
+            name=name,
+            prefix=prefix,
+            key_hash=_hash(plaintext),
+            created_by_sub=created_by_sub,
+        )
+        db.session.add(api_key)
+        db.session.commit()
+        db.session.refresh(api_key)
+        return api_key, plaintext
+
+    def lookup_by_plaintext(self, plaintext: str) -> Optional[ApiKeyTable]:
+        """Return the key row iff the plaintext matches an active (non-revoked) key.
+
+        Bumps ``last_used_at`` as a side effect.
+        """
+        if not plaintext or not plaintext.startswith(f"{KEY_PLAINTEXT_PREFIX}_"):
+            return None
+        key_hash = _hash(plaintext)
+        row = db.session.query(ApiKeyTable).filter(ApiKeyTable.key_hash == key_hash).first()
+        if row is None or row.revoked_at is not None:
+            return None
+        row.last_used_at = datetime.now(timezone.utc)
+        db.session.commit()
+        return row
+
+    def list_by_shop(self, shop_id: UUID) -> List[ApiKeyTable]:
+        return (
+            db.session.query(ApiKeyTable)
+            .filter(ApiKeyTable.shop_id == shop_id)
+            .order_by(ApiKeyTable.created_at.desc())
+            .all()
+        )
+
+    def revoke(self, *, shop_id: UUID, key_id: UUID) -> Optional[ApiKeyTable]:
+        row = db.session.query(ApiKeyTable).filter(ApiKeyTable.shop_id == shop_id, ApiKeyTable.id == key_id).first()
+        if row is None:
+            return None
+        if row.revoked_at is None:
+            row.revoked_at = datetime.now(timezone.utc)
+            db.session.commit()
+        return row
+
+
+api_key_crud = CRUDApiKey()

--- a/server/db/database.py
+++ b/server/db/database.py
@@ -23,10 +23,7 @@ from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.orm import Query, Session, as_declarative, scoped_session, sessionmaker
 from sqlalchemy.sql.schema import MetaData
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-from starlette.requests import Request
-from starlette.responses import Response
-from starlette.types import ASGIApp
+from starlette.types import ASGIApp, Receive, Scope, Send
 from structlog.stdlib import BoundLogger
 
 from server.utils.json import json_dumps, json_loads
@@ -219,15 +216,25 @@ class Database:
             self.request_context.reset(token)
 
 
-class DBSessionMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app: ASGIApp, database: Database, commit_on_exit: bool = False):
-        super().__init__(app)
+class DBSessionMiddleware:
+    """Pure-ASGI middleware that opens a scoped database session per request.
+
+    Rewritten from BaseHTTPMiddleware because BaseHTTPMiddleware buffers the
+    response body, which breaks streaming responses (notably the MCP sub-app
+    mounted at /mcp, which uses StreamableHTTPSessionManager).
+    """
+
+    def __init__(self, app: ASGIApp, database: Database, commit_on_exit: bool = False) -> None:
+        self.app = app
         self.commit_on_exit = commit_on_exit
         self.database = database
 
-    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
         with self.database.database_scope():
-            return await call_next(request)
+            await self.app(scope, receive, send)
 
 
 @contextmanager

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -608,7 +608,14 @@ class ApiKeyTable(BaseModel):
     shop_id = Column("shop_id", UUIDType, ForeignKey("shops.id", ondelete="CASCADE"), nullable=False, index=True)
     name = Column(String(120), nullable=False)
     prefix = Column(String(16), nullable=False, index=True)
-    key_hash = Column(String(64), nullable=False, unique=True)
+    # sha256 of the plaintext key — indexed for O(1) lookup. Plaintext is
+    # opaque (32 random bytes), so the SHA pre-image space is effectively
+    # infinite; the fingerprint is safe to leak in logs.
+    fingerprint = Column(String(64), nullable=False, unique=True, index=True)
+    # bcrypt hash of the plaintext key — verified after the fingerprint
+    # lookup so a leaked DB doesn't immediately yield usable keys even if
+    # SHA256 is ever weakened.
+    encrypted_key = Column(String, nullable=False)
     created_by_sub = Column(String(64), nullable=True)
     created_at = Column(UtcTimestamp, nullable=False, server_default=text("CURRENT_TIMESTAMP"))
     last_used_at = Column(UtcTimestamp, nullable=True)

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -599,3 +599,19 @@ class ProductAttributeValueTable(BaseModel):
             name="uq_pav_product_attribute_option_value",
         ),
     )
+
+
+class ApiKeyTable(BaseModel):
+    __tablename__ = "api_keys"
+
+    id = Column(UUIDType, server_default=text("uuid_generate_v4()"), primary_key=True, index=True)
+    shop_id = Column("shop_id", UUIDType, ForeignKey("shops.id", ondelete="CASCADE"), nullable=False, index=True)
+    name = Column(String(120), nullable=False)
+    prefix = Column(String(16), nullable=False, index=True)
+    key_hash = Column(String(64), nullable=False, unique=True)
+    created_by_sub = Column(String(64), nullable=True)
+    created_at = Column(UtcTimestamp, nullable=False, server_default=text("CURRENT_TIMESTAMP"))
+    last_used_at = Column(UtcTimestamp, nullable=True)
+    revoked_at = Column(UtcTimestamp, nullable=True)
+
+    shop = relationship("ShopTable", lazy=True)

--- a/server/main.py
+++ b/server/main.py
@@ -33,6 +33,7 @@ from server.api.error_handling import ProblemDetailException
 from server.db import db, init_database
 from server.db.database import DBSessionMiddleware
 from server.exception_handlers.generic_exception_handlers import problem_detail_handler
+from server.mcp import mount_mcp
 from server.settings import app_settings
 
 # from server.version import GIT_COMMIT_HASH
@@ -64,10 +65,20 @@ def run_migrations():
 async def lifespan(app_: FastAPI):
     logger.info("run alembic upgrade head...")
     run_migrations()
-    yield
+    if mcp_app is not None:
+        # Starlette does NOT run mounted sub-app lifespans; we enter the MCP
+        # sub-app's StreamableHTTPSessionManager lifespan from the parent.
+        async with mcp_app.router.lifespan_context(app_):
+            yield
+    else:
+        yield
 
 
-APP_VERSION = "0.2.10"
+APP_VERSION = "0.3.0"
+
+# Assigned after the api_router is included if MCP_ENABLED. The lifespan
+# closure above references it.
+mcp_app = None
 
 app = FastAPI(
     title="ShopVirge API",
@@ -94,6 +105,12 @@ sentry_sdk.init(
 init_database(app_settings)
 
 app.include_router(api_router)
+
+if app_settings.MCP_ENABLED:
+    # Mount AFTER all routers are included so FastMCP.from_fastapi scans the
+    # full route table. Auto-generates an MCP tool for every route tagged
+    # AgentTag.EXPOSED; everything else is excluded.
+    mcp_app = mount_mcp(app)
 
 app.add_middleware(SessionMiddleware, secret_key=app_settings.SESSION_SECRET)
 app.add_middleware(DBSessionMiddleware, database=db)

--- a/server/mcp/__init__.py
+++ b/server/mcp/__init__.py
@@ -1,0 +1,3 @@
+from server.mcp.server import MCP_MOUNT_PATH, mount_mcp
+
+__all__ = ["MCP_MOUNT_PATH", "mount_mcp"]

--- a/server/mcp/server.py
+++ b/server/mcp/server.py
@@ -1,0 +1,91 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+"""MCP (Model Context Protocol) server exposing shop-backend operations as tools.
+
+Mounted into the FastAPI app at ``/mcp`` when ``MCP_ENABLED=True`` (see
+``server/main.py``).
+
+Tools are **auto-generated from the FastAPI app's routes** via ``fastmcp``'s
+``FastMCP.from_fastapi(app=...)``. Every REST operation tagged
+``AgentTag.EXPOSED`` becomes an MCP tool with a typed parameter schema
+derived from the route's pydantic models, plus the route's docstring as the
+tool description.
+
+Auth: ``from_fastapi`` invokes routes via in-process ``httpx`` over
+``ASGITransport``, which goes through the FastAPI middleware + dependency
+chain so the existing ``Depends(auth_required_any)`` on each route fires
+normally when the LLM calls the corresponding MCP tool. We just need to
+forward the incoming MCP request's auth headers (``Authorization`` for
+Cognito JWT or API key, ``X-API-Key`` for the API key alternative) into
+that inner httpx call, which fastmcp does NOT do by default — its
+``get_http_headers()`` default exclude list strips ``authorization``.
+
+Transport: streamable HTTP.
+
+Pattern adapted from ``workfloworchestrator/orchestrator-core`` PR #1620.
+"""
+
+from typing import TYPE_CHECKING
+
+import httpx
+from fastapi import FastAPI
+
+from server.agent_tags import AgentTag
+
+if TYPE_CHECKING:
+    from starlette.applications import Starlette
+
+MCP_MOUNT_PATH = "/mcp"
+
+_FORWARDED_AUTH_HEADERS = ("authorization", "x-api-key")
+
+
+async def _forward_auth_header(request: httpx.Request) -> None:
+    """Httpx request hook: forward the incoming MCP request's auth headers.
+
+    fastmcp's ``OpenAPITool.run`` already auto-forwards request headers, but
+    its default exclude list strips ``authorization`` (see
+    ``fastmcp.server.dependencies.get_http_headers``). We re-add it — plus
+    ``X-API-Key`` — so the route's ``Depends(auth_required_any)`` can
+    validate either a bearer token or an API key.
+    """
+    from fastmcp.server.dependencies import get_http_headers
+
+    auth_headers = get_http_headers(include=set(_FORWARDED_AUTH_HEADERS))
+    for key, value in auth_headers.items():
+        if key not in request.headers:
+            request.headers[key] = value
+
+
+def mount_mcp(app: FastAPI) -> "Starlette":
+    """Auto-generate MCP tools from ``app``'s routes, mount at ``/mcp``, return the sub-app.
+
+    Only routes tagged with ``AgentTag.EXPOSED`` are surfaced; all other
+    routes are excluded (otherwise fastmcp's default would expose every
+    route in the app as a tool).
+
+    The returned sub-app carries its own ASGI lifespan that the parent must
+    enter — Starlette does not invoke a mounted sub-app's lifespan. Use
+    ``mcp_app.router.lifespan_context(parent)`` from inside the parent's
+    own lifespan context manager.
+    """
+    from fastmcp import FastMCP
+    from fastmcp.server.openapi import MCPType, RouteMap
+
+    mcp = FastMCP.from_fastapi(
+        app=app,
+        name="shopvirge-mcp",
+        route_maps=[
+            RouteMap(tags={AgentTag.EXPOSED.value}, mcp_type=MCPType.TOOL),
+            RouteMap(mcp_type=MCPType.EXCLUDE),
+        ],
+        httpx_client_kwargs={"event_hooks": {"request": [_forward_auth_header]}},
+    )
+
+    mcp_app = mcp.http_app(path="/", transport="http")
+    app.mount(MCP_MOUNT_PATH, mcp_app)
+    return mcp_app

--- a/server/schemas/api_key.py
+++ b/server/schemas/api_key.py
@@ -1,0 +1,33 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from server.schemas.base import BoilerplateBaseModel
+
+
+class ApiKeyCreate(BoilerplateBaseModel):
+    name: str
+
+
+class ApiKeyRead(BoilerplateBaseModel):
+    id: UUID
+    name: str
+    prefix: str
+    created_at: datetime
+    last_used_at: Optional[datetime] = None
+    revoked_at: Optional[datetime] = None
+
+    class Config:
+        from_attributes = True
+
+
+class ApiKeyCreated(ApiKeyRead):
+    """Response from minting a key. ``plaintext`` is shown ONCE — never again."""
+
+    plaintext: str

--- a/server/security.py
+++ b/server/security.py
@@ -13,7 +13,7 @@
 from datetime import datetime, timedelta
 from typing import Any, List, Optional, Union
 
-from fastapi import HTTPException
+from fastapi import Header, HTTPException, Request
 from fastapi.param_functions import Depends
 from fastapi_cognito import CognitoAuth, CognitoSettings, CognitoToken
 from jose import jwt
@@ -61,6 +61,45 @@ def auth_required(token: CognitoToken = Depends(cognito_eu.auth_required)):
         return token
 
     raise HTTPException(status_code=401, detail="Invalid OAuth2 scope")
+
+
+async def auth_required_any(
+    request: Request,
+    x_api_key: Optional[str] = Header(default=None, alias="X-API-Key"),
+):
+    """Accept either a Cognito JWT or a per-shop API key.
+
+    Resolution order:
+        1. ``X-API-Key`` header, if present.
+        2. ``Authorization: Bearer <token>`` where ``<token>`` starts with the
+           API-key prefix (``sv_``).
+        3. Otherwise fall back to the standard Cognito flow.
+
+    Returns an :class:`server.db.models.ApiKeyTable` row on API-key auth, or a
+    :class:`CustomCognitoToken` on Cognito auth. Endpoints downstream of this
+    dep don't typically inspect the return value (shop ownership comes from
+    the path param), so the union is intentional.
+    """
+    # Lazy import — avoids a CRUD<->security cycle.
+    from server.crud.crud_api_key import KEY_PLAINTEXT_PREFIX, api_key_crud
+
+    plaintext: Optional[str] = x_api_key
+    if plaintext is None:
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.lower().startswith("bearer "):
+            candidate = auth_header[7:].strip()
+            if candidate.startswith(f"{KEY_PLAINTEXT_PREFIX}_"):
+                plaintext = candidate
+
+    if plaintext is not None and plaintext.startswith(f"{KEY_PLAINTEXT_PREFIX}_"):
+        row = api_key_crud.lookup_by_plaintext(plaintext)
+        if row is None:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+        return row
+
+    # No API key supplied — defer to Cognito.
+    token = await cognito_eu.auth_required(request)
+    return auth_required(token)
 
 
 def admin_required(token: CognitoToken = Depends(auth_required)):

--- a/server/settings.py
+++ b/server/settings.py
@@ -39,6 +39,7 @@ class AppSettings(BaseSettings):
     PROJECT_NAME: str = "Prijslijst backend"
     TESTING: bool = True
     EMAILS_ENABLED: bool = False
+    MCP_ENABLED: bool = False
     # SESSION_SECRET: str = "".join(secrets.choice(string.ascii_letters) for i in range(16))  # noqa: S311
     SESSION_SECRET: str = "CHANGEME"
 

--- a/tests/unit_tests/api/test_api_keys.py
+++ b/tests/unit_tests/api/test_api_keys.py
@@ -1,0 +1,70 @@
+"""Tests for /shops/{shop_id}/api-keys endpoints + the dual auth dependency."""
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from server.crud.crud_api_key import api_key_crud
+from tests.unit_tests.factories.shop import make_shop
+
+
+def test_mint_returns_plaintext_once(test_client):
+    shop_id = make_shop()
+    resp = test_client.post(f"/shops/{shop_id}/api-keys/", json={"name": "ci-bot"})
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["name"] == "ci-bot"
+    assert body["plaintext"].startswith("sv_")
+    assert body["prefix"] in body["plaintext"]
+
+    # Listing must not return the plaintext.
+    list_resp = test_client.get(f"/shops/{shop_id}/api-keys/")
+    assert list_resp.status_code == 200
+    keys = list_resp.json()
+    assert len(keys) == 1
+    assert "plaintext" not in keys[0]
+    assert keys[0]["prefix"] == body["prefix"]
+
+
+def test_revoked_key_cannot_authenticate(test_client, fastapi_app):
+    """An API key validated via the dual auth dep stops working once revoked."""
+    shop_id = make_shop()
+    # Mint via CRUD so we control the plaintext.
+    row, plaintext = api_key_crud.mint(shop_id=shop_id, name="will-be-revoked")
+
+    # Sanity: looking up an active key works.
+    assert api_key_crud.lookup_by_plaintext(plaintext) is not None
+
+    # Now revoke and confirm lookup refuses it.
+    api_key_crud.revoke(shop_id=shop_id, key_id=row.id)
+    assert api_key_crud.lookup_by_plaintext(plaintext) is None
+
+
+def test_revoke_unknown_key_returns_404(test_client):
+    shop_id = make_shop()
+    resp = test_client.delete(f"/shops/{shop_id}/api-keys/{uuid4()}")
+    assert resp.status_code == 404
+
+
+def test_revoke_existing_key_returns_204(test_client):
+    shop_id = make_shop()
+    create = test_client.post(f"/shops/{shop_id}/api-keys/", json={"name": "to-revoke"})
+    key_id = create.json()["id"]
+    resp = test_client.delete(f"/shops/{shop_id}/api-keys/{key_id}")
+    assert resp.status_code == 204
+
+    # Listing still shows it, but with revoked_at populated.
+    keys = test_client.get(f"/shops/{shop_id}/api-keys/").json()
+    [revoked] = keys
+    assert revoked["revoked_at"] is not None
+
+
+def test_mint_requires_auth(fastapi_app_not_authenticated):
+    """The mint endpoint stays Cognito-only — an API key cannot create one."""
+    client = TestClient(fastapi_app_not_authenticated)
+    shop_id = make_shop()
+    resp = client.post(
+        f"/shops/{shop_id}/api-keys/",
+        json={"name": "should-fail"},
+    )
+    assert resp.status_code == 401

--- a/tests/unit_tests/api/test_api_keys.py
+++ b/tests/unit_tests/api/test_api_keys.py
@@ -2,10 +2,28 @@
 
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 
 from server.crud.crud_api_key import api_key_crud
+from server.security import auth_required_any
+from tests.unit_tests.factories.api_key import make_api_key
 from tests.unit_tests.factories.shop import make_shop
+
+
+@pytest.fixture
+def real_auth_client(fastapi_app):
+    """A TestClient whose ``auth_required_any`` override is removed so the
+    real dual-auth dep runs (validates X-API-Key / Bearer headers against the
+    DB). Other overrides — including the ``auth_required`` Cognito stub used
+    by the api-key management endpoints — stay intact so we can still mint
+    keys from the test."""
+    override = fastapi_app.dependency_overrides.pop(auth_required_any, None)
+    try:
+        yield TestClient(fastapi_app)
+    finally:
+        if override is not None:
+            fastapi_app.dependency_overrides[auth_required_any] = override
 
 
 def test_mint_returns_plaintext_once(test_client):
@@ -68,3 +86,48 @@ def test_mint_requires_auth(fastapi_app_not_authenticated):
         json={"name": "should-fail"},
     )
     assert resp.status_code == 401
+
+
+def test_api_key_opens_tagged_endpoint(real_auth_client):
+    """End-to-end: a valid API key in X-API-Key opens an MCP-tagged route."""
+    shop_id = make_shop()
+    _, plaintext = make_api_key(shop_id, name="e2e")
+
+    resp = real_auth_client.get(
+        f"/shops/{shop_id}/tags/",
+        headers={"X-API-Key": plaintext},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_api_key_via_bearer_opens_tagged_endpoint(real_auth_client):
+    """The dual-auth dep also accepts ``Authorization: Bearer sv_...``."""
+    shop_id = make_shop()
+    _, plaintext = make_api_key(shop_id, name="e2e-bearer")
+
+    resp = real_auth_client.get(
+        f"/shops/{shop_id}/tags/",
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_bad_api_key_is_rejected(real_auth_client):
+    shop_id = make_shop()
+    resp = real_auth_client.get(
+        f"/shops/{shop_id}/tags/",
+        headers={"X-API-Key": "sv_deadbeef_thisisnotvalid"},
+    )
+    assert resp.status_code == 401
+
+
+def test_revoked_api_key_stops_opening_endpoints(real_auth_client):
+    """A key that authenticates first then gets revoked must stop working."""
+    shop_id = make_shop()
+    row, plaintext = make_api_key(shop_id, name="will-revoke")
+
+    headers = {"X-API-Key": plaintext}
+    assert real_auth_client.get(f"/shops/{shop_id}/tags/", headers=headers).status_code == 200
+
+    api_key_crud.revoke(shop_id=shop_id, key_id=row.id)
+    assert real_auth_client.get(f"/shops/{shop_id}/tags/", headers=headers).status_code == 401

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -30,7 +30,7 @@ from server.db.database import (
 )
 from server.db.models import ProductTable, UserTable
 from server.exception_handlers.generic_exception_handlers import problem_detail_handler
-from server.security import CustomCognitoToken, auth_required
+from server.security import CustomCognitoToken, auth_required, auth_required_any
 from server.settings import app_settings
 from tests.unit_tests.factories.account import make_account
 from tests.unit_tests.factories.attribute import make_attribute, make_attribute_with_translation, make_option, make_pav
@@ -213,6 +213,7 @@ def fastapi_app(database, db_uri):
         )
 
     app.dependency_overrides[auth_required] = get_current_active_superuser_override
+    app.dependency_overrides[auth_required_any] = get_current_active_superuser_override
 
     # Admin endpoints (e.g. /admin/accounts) gate on get_current_active_superuser
     # which validates a real JWT and inspects role membership. Tests don't
@@ -267,6 +268,7 @@ def fastapi_app_not_authenticated(database, db_uri):
         raise HTTPException(status_code=401, detail="Not authenticated")
 
     app.dependency_overrides[auth_required] = get_current_active_superuser_override
+    app.dependency_overrides[auth_required_any] = get_current_active_superuser_override
 
     return app
 

--- a/tests/unit_tests/factories/api_key.py
+++ b/tests/unit_tests/factories/api_key.py
@@ -1,0 +1,19 @@
+from typing import Tuple
+from uuid import UUID
+
+from server.crud.crud_api_key import api_key_crud
+from server.db.models import ApiKeyTable
+
+
+def make_api_key(
+    shop_id: UUID,
+    *,
+    name: str = "test-key",
+    created_by_sub: str = "test-user",
+) -> Tuple[ApiKeyTable, str]:
+    """Mint an API key for ``shop_id`` and return ``(row, plaintext)``.
+
+    Plaintext is only available from the return value — the DB stores only
+    the bcrypt hash + sha256 fingerprint.
+    """
+    return api_key_crud.mint(shop_id=shop_id, name=name, created_by_sub=created_by_sub)

--- a/tests/unit_tests/mcp/test_mcp.py
+++ b/tests/unit_tests/mcp/test_mcp.py
@@ -1,0 +1,112 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+"""Tests for the MCP (Model Context Protocol) server integration.
+
+These tests verify that:
+
+1. The agent-tagged shop CRUD routes carry ``AgentTag.EXPOSED`` and have
+   stable ``operation_id`` values that map 1:1 to the MCP tool names.
+2. ``FastMCP.from_fastapi`` introspects the FastAPI app's routes, derives
+   input schemas from their pydantic models, and produces exactly the tools
+   we expect via ``RouteMap`` tag-based filtering.
+
+Pattern adapted from ``workfloworchestrator/orchestrator-core`` PR #1620.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+
+from server.agent_tags import AgentTag
+
+# All tool names must match the ``operation_id`` on each tagged route.
+EXPECTED_TOOL_NAMES = {
+    # products
+    "list_products",
+    "get_product",
+    "create_product",
+    "update_product",
+    "delete_product",
+    # categories
+    "list_categories",
+    "get_category",
+    "create_category",
+    "update_category",
+    "delete_category",
+    # tags
+    "list_tags",
+    "get_tag",
+    "create_tag",
+    "update_tag",
+    "delete_tag",
+    # attributes
+    "list_attributes",
+    "get_attribute",
+    "create_attribute",
+    "update_attribute",
+    "delete_attribute",
+}
+
+
+def _agent_tagged_routes(app: FastAPI) -> dict[str, str]:
+    """Return ``{operation_id: path}`` for every route tagged ``AgentTag.EXPOSED``."""
+    out: dict[str, str] = {}
+    for route in app.routes:
+        tags = getattr(route, "tags", None) or []
+        if AgentTag.EXPOSED.value in tags or AgentTag.EXPOSED in tags:
+            op_id = getattr(route, "operation_id", None)
+            path = getattr(route, "path", "")
+            assert op_id, f"agent-exposed route {path!r} is missing operation_id"
+            out[op_id] = path
+    return out
+
+
+def test_all_expected_routes_carry_agent_tag(fastapi_app: FastAPI) -> None:
+    """Every expected MCP tool name has a route tagged ``AgentTag.EXPOSED``."""
+    found = _agent_tagged_routes(fastapi_app)
+    assert (
+        set(found) == EXPECTED_TOOL_NAMES
+    ), f"missing: {EXPECTED_TOOL_NAMES - set(found)}, extra: {set(found) - EXPECTED_TOOL_NAMES}"
+
+
+def test_fastmcp_introspects_all_expected_tools(fastapi_app: FastAPI) -> None:
+    """``FastMCP.from_fastapi`` produces exactly the expected tools from the tagged routes."""
+    pytest.importorskip("fastmcp")
+    from fastmcp import FastMCP
+
+    from server.mcp.server import mount_mcp  # noqa: F401 — sanity import
+
+    try:
+        from fastmcp.server.openapi import MCPType, RouteMap
+    except ImportError:  # pragma: no cover — older fastmcp module path
+        from fastmcp.server.providers.openapi import MCPType, RouteMap  # type: ignore[no-redef]
+
+    mcp = FastMCP.from_fastapi(
+        app=fastapi_app,
+        name="shopvirge-mcp-test",
+        route_maps=[
+            RouteMap(tags={AgentTag.EXPOSED.value}, mcp_type=MCPType.TOOL),
+            RouteMap(mcp_type=MCPType.EXCLUDE),
+        ],
+    )
+
+    tools = asyncio.run(mcp.get_tools())
+    tool_names = set(tools.keys())
+    assert (
+        tool_names == EXPECTED_TOOL_NAMES
+    ), f"missing: {EXPECTED_TOOL_NAMES - tool_names}, extra: {tool_names - EXPECTED_TOOL_NAMES}"
+
+
+def test_mount_mcp_is_importable() -> None:
+    """The mount_mcp helper imports cleanly (catches dotted-path drift in fastmcp)."""
+    pytest.importorskip("fastmcp")
+    from server.mcp import mount_mcp
+
+    assert callable(mount_mcp)

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -4,6 +4,7 @@
       "AccountCreate": {
         "properties": {
           "details": {
+            "additionalProperties": true,
             "title": "Details",
             "type": "object"
           },
@@ -28,6 +29,7 @@
       "AccountSchema": {
         "properties": {
           "details": {
+            "additionalProperties": true,
             "title": "Details",
             "type": "object"
           },
@@ -58,6 +60,7 @@
       "AccountUpdate": {
         "properties": {
           "details": {
+            "additionalProperties": true,
             "title": "Details",
             "type": "object"
           },
@@ -84,6 +87,7 @@
           "details": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -170,6 +174,133 @@
           "id"
         ],
         "title": "AdminAccountSchema",
+        "type": "object"
+      },
+      "ApiKeyCreate": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "ApiKeyCreate",
+        "type": "object"
+      },
+      "ApiKeyCreated": {
+        "description": "Response from minting a key. ``plaintext`` is shown ONCE \u2014 never again.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "plaintext": {
+            "title": "Plaintext",
+            "type": "string"
+          },
+          "prefix": {
+            "title": "Prefix",
+            "type": "string"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "prefix",
+          "created_at",
+          "plaintext"
+        ],
+        "title": "ApiKeyCreated",
+        "type": "object"
+      },
+      "ApiKeyRead": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "prefix": {
+            "title": "Prefix",
+            "type": "string"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "prefix",
+          "created_at"
+        ],
+        "title": "ApiKeyRead",
         "type": "object"
       },
       "AttributeCreate": {
@@ -530,12 +661,13 @@
                 "type": "null"
               }
             ],
+            "format": "password",
             "title": "Client Secret"
           },
           "grant_type": {
             "anyOf": [
               {
-                "pattern": "password",
+                "pattern": "^password$",
                 "type": "string"
               },
               {
@@ -545,6 +677,7 @@
             "title": "Grant Type"
           },
           "password": {
+            "format": "password",
             "title": "Password",
             "type": "string"
           },
@@ -624,6 +757,7 @@
           "alt1_image": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -638,6 +772,7 @@
           "alt2_image": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -667,6 +802,7 @@
           "main_image": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -727,6 +863,7 @@
           "alt1_image": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -741,6 +878,7 @@
           "alt2_image": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -775,6 +913,7 @@
           "main_image": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -885,6 +1024,7 @@
           "alt1_image": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -899,6 +1039,7 @@
           "alt2_image": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -928,6 +1069,7 @@
           "main_image": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -1200,39 +1342,7 @@
         "title": "ConfigurationLanguageFields",
         "type": "object"
       },
-      "ConfigurationLanguages-Input": {
-        "properties": {
-          "alt1": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ConfigurationLanguageFields"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "alt2": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ConfigurationLanguageFields"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "main": {
-            "$ref": "#/components/schemas/ConfigurationLanguageFields"
-          }
-        },
-        "required": [
-          "main"
-        ],
-        "title": "ConfigurationLanguages",
-        "type": "object"
-      },
-      "ConfigurationLanguages-Output": {
+      "ConfigurationLanguages": {
         "properties": {
           "alt1": {
             "anyOf": [
@@ -1305,6 +1415,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -1317,6 +1428,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -1350,12 +1462,12 @@
             "type": "boolean"
           },
           "fixed_fee": {
-            "default": "0",
+            "default": 0.0,
             "title": "Fixed Fee",
             "type": "number"
           },
           "free_shipping_above_amount": {
-            "default": "0",
+            "default": 0.0,
             "title": "Free Shipping Above Amount",
             "type": "number"
           },
@@ -1422,7 +1534,7 @@
             "type": "integer"
           },
           "languages": {
-            "$ref": "#/components/schemas/ConfigurationLanguages-Input"
+            "$ref": "#/components/schemas/ConfigurationLanguages"
           },
           "legal": {
             "anyOf": [
@@ -1515,7 +1627,7 @@
             "type": "integer"
           },
           "languages": {
-            "$ref": "#/components/schemas/ConfigurationLanguages-Output"
+            "$ref": "#/components/schemas/ConfigurationLanguages"
           },
           "legal": {
             "anyOf": [
@@ -2109,6 +2221,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -2134,6 +2247,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -2224,6 +2338,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -2254,6 +2369,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -2408,6 +2524,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -2692,6 +2809,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -2722,6 +2840,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -3034,6 +3153,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -3061,6 +3181,7 @@
           "image_1": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3075,6 +3196,7 @@
           "image_2": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3089,6 +3211,7 @@
           "image_3": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3103,6 +3226,7 @@
           "image_4": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3117,6 +3241,7 @@
           "image_5": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3131,6 +3256,7 @@
           "image_6": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3167,6 +3293,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -3181,6 +3308,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -3195,6 +3323,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -3716,6 +3845,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -3743,6 +3873,7 @@
           "image_1": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3757,6 +3888,7 @@
           "image_2": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3771,6 +3903,7 @@
           "image_3": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3785,6 +3918,7 @@
           "image_4": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3799,6 +3933,7 @@
           "image_5": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3813,6 +3948,7 @@
           "image_6": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3861,6 +3997,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -3875,6 +4012,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -3889,6 +4027,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               },
               {
@@ -4043,6 +4182,7 @@
           "image_1": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4057,6 +4197,7 @@
           "image_2": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4071,6 +4212,7 @@
           "image_3": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4085,6 +4227,7 @@
           "image_4": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4099,6 +4242,7 @@
           "image_5": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4113,6 +4257,7 @@
           "image_6": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4330,6 +4475,7 @@
           "image_1": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4344,6 +4490,7 @@
           "image_2": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4358,6 +4505,7 @@
           "image_3": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4372,6 +4520,7 @@
           "image_4": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4386,6 +4535,7 @@
           "image_5": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4400,6 +4550,7 @@
           "image_6": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -4461,6 +4612,7 @@
           "prices": {
             "default": [],
             "items": {
+              "additionalProperties": true,
               "type": "object"
             },
             "title": "Prices",
@@ -4776,6 +4928,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -4787,6 +4940,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -4798,6 +4952,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -4809,6 +4964,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -4820,6 +4976,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -4831,6 +4988,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -5095,6 +5253,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -5106,6 +5265,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -5117,6 +5277,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -5128,6 +5289,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -5139,6 +5301,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -5150,6 +5313,7 @@
                 "type": "number"
               },
               {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                 "type": "string"
               }
             ],
@@ -5254,6 +5418,7 @@
             "type": "string"
           },
           "stripe_customer": {
+            "additionalProperties": true,
             "title": "Stripe Customer",
             "type": "object"
           },
@@ -5655,7 +5820,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.2.10"
+    "version": "0.3.0"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -5917,6 +6082,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "title": "Response Get Stripe Customer Admin Accounts  Id  Stripe Customer Get",
                   "type": "object"
                 }
@@ -6464,6 +6630,7 @@
             "application/json": {
               "schema": {
                 "items": {
+                  "additionalProperties": true,
                   "type": "object"
                 },
                 "title": "Json Data",
@@ -6478,6 +6645,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "title": "Response New Form Forms  Form Key  Post",
                   "type": "object"
                 }
@@ -6633,6 +6801,7 @@
               "schema": {
                 "default": [],
                 "items": {
+                  "additionalProperties": true,
                   "type": "object"
                 },
                 "title": "Form Data",
@@ -8701,6 +8870,154 @@
         ]
       }
     },
+    "/shops/{shop_id}/api-keys/": {
+      "get": {
+        "operationId": "list_keys_shops__shop_id__api_keys__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ApiKeyRead"
+                  },
+                  "title": "Response List Keys Shops  Shop Id  Api Keys  Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List API keys for the shop",
+        "tags": [
+          "shops",
+          "api-keys"
+        ]
+      },
+      "post": {
+        "description": "Mint a new API key. The plaintext is returned exactly once.\n\nStore it somewhere safe \u2014 it cannot be retrieved again. If lost, revoke\nand mint a new one.",
+        "operationId": "mint_shops__shop_id__api_keys__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiKeyCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyCreated"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mint a new API key for the shop",
+        "tags": [
+          "shops",
+          "api-keys"
+        ]
+      }
+    },
+    "/shops/{shop_id}/api-keys/{key_id}": {
+      "delete": {
+        "operationId": "revoke_shops__shop_id__api_keys__key_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Revoke an API key",
+        "tags": [
+          "shops",
+          "api-keys"
+        ]
+      }
+    },
     "/shops/{shop_id}/attribute-options/": {
       "get": {
         "description": "Retrieve a paginated list of all attribute options (e.g., 'Small', 'XL') across all attributes within a shop.",
@@ -9018,7 +9335,7 @@
     "/shops/{shop_id}/attributes/": {
       "get": {
         "description": "Retrieve a paginated list of all attributes defined for a specific shop. This list does not include options.",
-        "operationId": "get_multi_shops__shop_id__attributes__get",
+        "operationId": "list_attributes",
         "parameters": [
           {
             "in": "path",
@@ -9077,6 +9394,22 @@
               "title": "Sort",
               "type": "array"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
           }
         ],
         "responses": {
@@ -9087,7 +9420,7 @@
                   "items": {
                     "$ref": "#/components/schemas/AttributeSchema"
                   },
-                  "title": "Response Get Multi Shops  Shop Id  Attributes  Get",
+                  "title": "Response List Attributes",
                   "type": "array"
                 }
               }
@@ -9108,12 +9441,14 @@
         "summary": "List shop attributes",
         "tags": [
           "shops",
-          "attributes"
+          "attributes",
+          "agent-exposed",
+          "agent-large"
         ]
       },
       "post": {
         "description": "Create a new attribute for a shop. This also initializes a translation record with the provided name.",
-        "operationId": "create_shops__shop_id__attributes__post",
+        "operationId": "create_attribute",
         "parameters": [
           {
             "in": "path",
@@ -9123,6 +9458,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -9161,14 +9512,15 @@
         "summary": "Create attribute",
         "tags": [
           "shops",
-          "attributes"
+          "attributes",
+          "agent-exposed"
         ]
       }
     },
     "/shops/{shop_id}/attributes/id/{attribute_id}": {
       "get": {
         "description": "Retrieve the details of a specific attribute using its unique ID.",
-        "operationId": "get_by_id_shops__shop_id__attributes_id__attribute_id__get",
+        "operationId": "get_attribute",
         "parameters": [
           {
             "in": "path",
@@ -9188,6 +9540,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -9216,7 +9584,8 @@
         "summary": "Get attribute by ID",
         "tags": [
           "shops",
-          "attributes"
+          "attributes",
+          "agent-exposed"
         ]
       }
     },
@@ -9243,6 +9612,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -9297,6 +9682,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -9391,6 +9792,22 @@
               "title": "Sort",
               "type": "array"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
           }
         ],
         "responses": {
@@ -9429,7 +9846,7 @@
     "/shops/{shop_id}/attributes/{attribute_id}": {
       "delete": {
         "description": "Remove an attribute from a shop. This will fail if the attribute is currently in use by any products.",
-        "operationId": "delete_shops__shop_id__attributes__attribute_id__delete",
+        "operationId": "delete_attribute",
         "parameters": [
           {
             "in": "path",
@@ -9449,6 +9866,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -9470,12 +9903,13 @@
         "summary": "Delete attribute",
         "tags": [
           "shops",
-          "attributes"
+          "attributes",
+          "agent-exposed"
         ]
       },
       "put": {
         "description": "Update the details of an existing attribute, such as its name or unit.",
-        "operationId": "update_shops__shop_id__attributes__attribute_id__put",
+        "operationId": "update_attribute",
         "parameters": [
           {
             "in": "path",
@@ -9495,6 +9929,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -9533,7 +9983,8 @@
         "summary": "Update attribute",
         "tags": [
           "shops",
-          "attributes"
+          "attributes",
+          "agent-exposed"
         ]
       }
     },
@@ -9674,6 +10125,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "additionalProperties": true,
                 "title": "Data",
                 "type": "object"
               }
@@ -9856,6 +10308,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -10115,7 +10583,7 @@
     },
     "/shops/{shop_id}/categories/": {
       "get": {
-        "operationId": "get_multi_shops__shop_id__categories__get",
+        "operationId": "list_categories",
         "parameters": [
           {
             "in": "path",
@@ -10174,6 +10642,22 @@
               "title": "Sort",
               "type": "array"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
           }
         ],
         "responses": {
@@ -10184,7 +10668,7 @@
                   "items": {
                     "$ref": "#/components/schemas/CategorySchema"
                   },
-                  "title": "Response Get Multi Shops  Shop Id  Categories  Get",
+                  "title": "Response List Categories",
                   "type": "array"
                 }
               }
@@ -10204,11 +10688,13 @@
         },
         "summary": "Get Multi",
         "tags": [
-          "categories"
+          "categories",
+          "agent-exposed",
+          "agent-large"
         ]
       },
       "post": {
-        "operationId": "create_shops__shop_id__categories__post",
+        "operationId": "create_category",
         "parameters": [
           {
             "in": "path",
@@ -10218,6 +10704,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -10253,7 +10755,8 @@
         },
         "summary": "Create",
         "tags": [
-          "categories"
+          "categories",
+          "agent-exposed"
         ]
       }
     },
@@ -10278,6 +10781,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -10311,7 +10830,7 @@
     },
     "/shops/{shop_id}/categories/{category_id}": {
       "delete": {
-        "operationId": "delete_shops__shop_id__categories__category_id__delete",
+        "operationId": "delete_category",
         "parameters": [
           {
             "in": "path",
@@ -10331,6 +10850,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -10351,11 +10886,12 @@
         },
         "summary": "Delete",
         "tags": [
-          "categories"
+          "categories",
+          "agent-exposed"
         ]
       },
       "get": {
-        "operationId": "get_by_id_shops__shop_id__categories__category_id__get",
+        "operationId": "get_category",
         "parameters": [
           {
             "in": "path",
@@ -10375,6 +10911,22 @@
               "format": "uuid",
               "title": "Category Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -10402,11 +10954,12 @@
         },
         "summary": "Get By Id",
         "tags": [
-          "categories"
+          "categories",
+          "agent-exposed"
         ]
       },
       "put": {
-        "operationId": "update_shops__shop_id__categories__category_id__put",
+        "operationId": "update_category",
         "parameters": [
           {
             "in": "path",
@@ -10426,6 +10979,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -10461,7 +11030,8 @@
         },
         "summary": "Update",
         "tags": [
-          "categories"
+          "categories",
+          "agent-exposed"
         ]
       }
     },
@@ -10718,6 +11288,22 @@
             "schema": {
               "title": "Move Up",
               "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -11591,7 +12177,7 @@
     },
     "/shops/{shop_id}/products/": {
       "get": {
-        "operationId": "get_multi_shops__shop_id__products__get",
+        "operationId": "list_products",
         "parameters": [
           {
             "in": "path",
@@ -11667,6 +12253,22 @@
               "title": "Sort",
               "type": "array"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
           }
         ],
         "responses": {
@@ -11677,7 +12279,7 @@
                   "items": {
                     "$ref": "#/components/schemas/ProductWithDefaultPrice"
                   },
-                  "title": "Response Get Multi Shops  Shop Id  Products  Get",
+                  "title": "Response List Products",
                   "type": "array"
                 }
               }
@@ -11698,11 +12300,13 @@
         "summary": "Get Multi",
         "tags": [
           "shops",
-          "products"
+          "products",
+          "agent-exposed",
+          "agent-large"
         ]
       },
       "post": {
-        "operationId": "create_shops__shop_id__products__post",
+        "operationId": "create_product",
         "parameters": [
           {
             "in": "path",
@@ -11712,6 +12316,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -11748,7 +12368,8 @@
         "summary": "Create",
         "tags": [
           "shops",
-          "products"
+          "products",
+          "agent-exposed"
         ]
       }
     },
@@ -11875,6 +12496,22 @@
               "title": "Sort",
               "type": "array"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
           }
         ],
         "responses": {
@@ -11912,7 +12549,7 @@
     },
     "/shops/{shop_id}/products/{product_id}": {
       "delete": {
-        "operationId": "delete_shops__shop_id__products__product_id__delete",
+        "operationId": "delete_product",
         "parameters": [
           {
             "in": "path",
@@ -11932,6 +12569,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -11953,11 +12606,12 @@
         "summary": "Delete",
         "tags": [
           "shops",
-          "products"
+          "products",
+          "agent-exposed"
         ]
       },
       "get": {
-        "operationId": "get_by_id_shops__shop_id__products__product_id__get",
+        "operationId": "get_product",
         "parameters": [
           {
             "in": "path",
@@ -12005,11 +12659,12 @@
         "summary": "Get By Id",
         "tags": [
           "shops",
-          "products"
+          "products",
+          "agent-exposed"
         ]
       },
       "put": {
-        "operationId": "update_shops__shop_id__products__product_id__put",
+        "operationId": "update_product",
         "parameters": [
           {
             "in": "path",
@@ -12029,6 +12684,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -12065,7 +12736,8 @@
         "summary": "Update",
         "tags": [
           "shops",
-          "products"
+          "products",
+          "agent-exposed"
         ]
       }
     },
@@ -12100,6 +12772,22 @@
             "schema": {
               "title": "Move Up",
               "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -12367,7 +13055,7 @@
     },
     "/shops/{shop_id}/tags/": {
       "get": {
-        "operationId": "get_multi_shops__shop_id__tags__get",
+        "operationId": "list_tags",
         "parameters": [
           {
             "in": "path",
@@ -12426,6 +13114,22 @@
               "title": "Sort",
               "type": "array"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
           }
         ],
         "responses": {
@@ -12436,7 +13140,7 @@
                   "items": {
                     "$ref": "#/components/schemas/TagSchema"
                   },
-                  "title": "Response Get Multi Shops  Shop Id  Tags  Get",
+                  "title": "Response List Tags",
                   "type": "array"
                 }
               }
@@ -12457,11 +13161,13 @@
         "summary": "Get Multi",
         "tags": [
           "shops",
-          "products"
+          "products",
+          "agent-exposed",
+          "agent-large"
         ]
       },
       "post": {
-        "operationId": "create_shops__shop_id__tags__post",
+        "operationId": "create_tag",
         "parameters": [
           {
             "in": "path",
@@ -12471,6 +13177,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -12507,7 +13229,8 @@
         "summary": "Create",
         "tags": [
           "shops",
-          "products"
+          "products",
+          "agent-exposed"
         ]
       }
     },
@@ -12532,6 +13255,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -12566,7 +13305,7 @@
     },
     "/shops/{shop_id}/tags/{tag_id}": {
       "delete": {
-        "operationId": "delete_shops__shop_id__tags__tag_id__delete",
+        "operationId": "delete_tag",
         "parameters": [
           {
             "in": "path",
@@ -12586,6 +13325,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -12607,11 +13362,12 @@
         "summary": "Delete",
         "tags": [
           "shops",
-          "products"
+          "products",
+          "agent-exposed"
         ]
       },
       "get": {
-        "operationId": "get_by_id_shops__shop_id__tags__tag_id__get",
+        "operationId": "get_tag",
         "parameters": [
           {
             "in": "path",
@@ -12631,6 +13387,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -12659,11 +13431,12 @@
         "summary": "Get By Id",
         "tags": [
           "shops",
-          "products"
+          "products",
+          "agent-exposed"
         ]
       },
       "put": {
-        "operationId": "update_shops__shop_id__tags__tag_id__put",
+        "operationId": "update_tag",
         "parameters": [
           {
             "in": "path",
@@ -12683,6 +13456,22 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
             }
           }
         ],
@@ -12719,7 +13508,8 @@
         "summary": "Update",
         "tags": [
           "shops",
-          "products"
+          "products",
+          "agent-exposed"
         ]
       }
     },
@@ -12732,6 +13522,7 @@
               "schema": {
                 "default": [],
                 "items": {
+                  "additionalProperties": true,
                   "type": "object"
                 },
                 "title": "Form Data",
@@ -12931,12 +13722,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/Body_update_user_me_users_me_put"
-                  }
-                ],
-                "title": "Body"
+                "$ref": "#/components/schemas/Body_update_user_me_users_me_put"
               }
             }
           }


### PR DESCRIPTION
## Summary

Mounts a [Model Context Protocol](https://modelcontextprotocol.io/) endpoint at `/mcp` so LLM clients (Claude Desktop, Claude Code, MCP Inspector, etc.) can manage a shop's catalog — products, categories, tags, attributes — through a typed tool interface. Off by default; opt-in via `MCP_ENABLED=true` (turned on for App Runner in `apprunner.yaml`).

Pattern adapted from [`workfloworchestrator/orchestrator-core` #1620](https://github.com/workfloworchestrator/orchestrator-core/pull/1620): `FastMCP.from_fastapi(app)` derives the tool catalog from the FastAPI route table. Every route tagged `AgentTag.EXPOSED` becomes an MCP tool with input/output schemas built from its pydantic models and the docstring as the description. **20 tools** total — list/get/create/update/delete × 4 resources.

Auth flows through the normal FastAPI dependency chain via an in-process `httpx` `ASGITransport`. We just re-inject `Authorization` and `X-API-Key` on every internal call (fastmcp's default exclude list strips them).

## Changes

- **MCP module** (`server/mcp/server.py`, `server/agent_tags.py`) — `mount_mcp(app)` builder with EXPOSED/EXCLUDE `RouteMap` pair so any untagged route is silently excluded (the default is *not* "expose everything").
- **Pure-ASGI `DBSessionMiddleware`** — rewritten from `BaseHTTPMiddleware`, which buffers response bodies and breaks the streamable-HTTP transport `/mcp` needs.
- **Lifespan composition** — module-level `mcp_app` is `None` until the MCP mount runs; parent lifespan enters `mcp_app.router.lifespan_context(app_)` only when set, so the boot path with `MCP_ENABLED=false` is unchanged.
- **API keys** — new `api_keys` table (migration `c1a2b3d4e5f6`), `ApiKeyTable` model, `crud_api_key` with two-layer storage (sha256 fingerprint for O(1) lookup + bcrypt-verify per request, adopted from #44), management endpoints at `/shops/{shop_id}/api-keys/` gated by Cognito-only `auth_required` (an API key cannot mint another API key).
- **Dual auth** — new `auth_required_any` dep accepts either `Authorization: Bearer sv_…` / `X-API-Key` or a Cognito JWT. Applied at the include level to the four resource routers (products, categories, tags, attributes); other shop routers stay Cognito-only.
- **Route tagging** — 20 list/get/create/update/delete routes get `tags=[AgentTag.EXPOSED]` + explicit `operation_id`. Tool names land in LLM prompts, so they're treated like a public API contract.
- **Dependency bumps** — `fastapi ~=0.115`, added `fastmcp~=2.0`. Loosened `pydantic`/`uvicorn`/`pydantic-settings` pins to satisfy fastmcp lower bounds. Pinned `bcrypt<4.1` (passlib 1.7.4's bcrypt backend init reads the removed `__about__` attribute on bcrypt ≥4.1). `APP_VERSION` → `0.3.0`; OpenAPI snapshot regenerated.
- **Tests** — `tests/unit_tests/mcp/test_mcp.py` verifies tag coverage and `FastMCP.from_fastapi` introspection produces exactly the expected 20 tools. `tests/unit_tests/api/test_api_keys.py` covers mint/list/revoke, the dual-auth flow end-to-end (X-API-Key and Bearer both open a tagged endpoint, revoked keys are rejected), and that mint stays Cognito-only. Conftest also overrides `auth_required_any`. New `tests/unit_tests/factories/api_key.py`.
- **Docs** — new `docs/api/mcp.md` (full reference: tool catalog, enabling, auth, key lifecycle, client config, adding new tools, architecture notes). `docs/api/authentication.md` and `docs/api/overview.md` updated; nav wired up in `mkdocs.yml`.
- **Deployment** — `apprunner.yaml` sets `MCP_ENABLED=true` so production exposes `/mcp` immediately on next deploy.

## Backward compatibility / migration notes

Mostly transparent, with two specific changes worth calling out:

1. **OpenAPI `operation_id` renames on 20 routes.** Twenty list/get/create/update/delete routes under `/shops/{shop_id}/{products|categories|tags|attributes}/*` previously had auto-generated names like `create_shops__shop_id__products__post`. They now have explicit names — `list_products`, `get_product`, `create_product`, `update_product`, `delete_product`, and the matching set for the other three resources. **The HTTP surface itself is identical** — paths, methods, request bodies, and response shapes are unchanged. But anyone who generates a client SDK from `/openapi.json` (openapi-generator, NSwag, autorest, openapi-typescript-codegen, …) will see those method names rename and needs to regenerate + update imports. Hand-rolled HTTP clients are unaffected.

2. **`pydantic` 2.7 → ≥2.11.7.** Required by fastmcp 2.x. Pydantic occasionally tightens validation on minor bumps (stricter int/float coercion, etc.). All 169 unit tests pass against the new version locally, but if external integrators round-trip payloads through this server and rely on lax validation, edge cases may now reject.

Everything else is either additive or transparent to API consumers:

- All existing REST paths, methods, request bodies, and response shapes are unchanged.
- Cognito JWT still authenticates everywhere it did before. The four resource routers additionally accept API keys — this is purely additive.
- DB schema: only the new `api_keys` table is added; no changes to existing tables. Migration is forward-only at startup, downgrade-safe.
- `auth_required` and `CustomCognitoToken` keep their existing signatures and return types.
- `DBSessionMiddleware`'s constructor signature is unchanged — only its parent class moves from `BaseHTTPMiddleware` to pure ASGI.
- `MCP_ENABLED` defaults to `false`; redeploys without env changes behave exactly as before. App Runner gets it on via the explicit yaml entry.
- `fastapi 0.110 → 0.115`, `uvicorn 0.29 → 0.35`, etc. are server-side and transparent to API consumers.

## Test plan

- [x] CI passes (`pytest tests/unit_tests` — 169 passing, +12 new)
- [x] `isort -c .` and `black --check .` clean
- [ ] After deploy, hit `GET /openapi.json` and confirm 20 routes carry the `agent-exposed` tag
- [ ] Mint an API key via `POST /shops/{shop_id}/api-keys/` (capture the one-time plaintext)
- [ ] Verify `curl -X POST $HOST/mcp/ -H 'Authorization: Bearer sv_…' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'` returns 20 tools
- [ ] Drive `create_product` / `update_product` / `delete_product` from MCP Inspector or Claude Desktop and verify rows land in the DB
- [ ] Sanity-check streaming endpoints still work (the `DBSessionMiddleware` rewrite is the highest-risk change)
- [ ] If any consumer auto-generates a client SDK from `/openapi.json`, regenerate after deploy (operation_id renames listed above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
