### PR TITLE
Enable browser-login for MCP via OAuth discovery + DCR shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ Or run a threaded server and auto-apply migrations on launch:
 /bin/server
 ````
 
+## Connecting Claude Code to the MCP server
+
+Prod exposes a Model Context Protocol endpoint at `/mcp`. Claude Code can drive it via Cognito Hosted UI browser-login (recommended for humans) or with a per-shop API key (recommended for scripts). See [`docs/api/mcp.md`](docs/api/mcp.md) for the full reference, including how to mint API keys and add new MCP tools.
+
+**Browser-login (Cognito):**
+
+```bash
+claude mcp add --transport http shopvirge https://api.shopvirge.com/mcp/ \
+  --callback-port 7777
+```
+
+Then `/mcp` inside Claude Code → **Authenticate** → Cognito Hosted UI opens → log in → done. The callback port must match what's whitelisted on the `shopvirge-mcp` Cognito app client (currently `7777`).
+
+**API-key (headless):**
+
+```bash
+claude mcp add --transport http shopvirge https://api.shopvirge.com/mcp/ \
+  --header "X-API-Key: sv_…"
+```
+
 ## Running tests
 ```bash
 PYTHONPATH=. pytest tests/unit_tests

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A backend for serving pricelists.
 
+📖 Full docs: <https://shopvirge.readthedocs.io/>
+
 ## Server
 
 This project only works with Python 3.10 and higher.

--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -24,6 +24,10 @@ run:
       value: "false"
     - name: MCP_ENABLED
       value: "true"
+    - name: AWS_COGNITO_MCP_CLIENT_ID
+      value: "6m8pss5q1drhph217kn5guu421"
+    - name: PUBLIC_BASE_URL
+      value: "https://api.shopvirge.com"
   secrets:
     - name: DATABASE_URI
       value-from: "arn:aws:ssm:eu-central-1:987457788157:parameter/pricelist-backend/DATABASE_URI"

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -31,10 +31,11 @@ When enabled, `server/main.py` calls `mount_mcp(app)` after all routers are incl
 
 ## Authentication
 
-Two methods are accepted on `/mcp` and on the tagged CRUD endpoints. They are checked in this order:
+Three methods are accepted on `/mcp` and on the tagged CRUD endpoints. They are checked in this order:
 
 1. **API key** — `X-API-Key: sv_<prefix>_<rest>` header, *or* `Authorization: Bearer sv_<prefix>_<rest>`. Recommended for headless LLM clients.
-2. **Cognito JWT** — `Authorization: Bearer <jwt>`. Same flow as the regular REST API; useful when a logged-in user drives the agent from a browser.
+2. **Cognito JWT (M2M / service-to-service)** — `Authorization: Bearer <jwt>` with scope ending in `/api`.
+3. **Cognito JWT (interactive user)** — `Authorization: Bearer <jwt>` from the Next.js app client or the MCP browser-login flow. Useful when a logged-in user drives the agent from a browser.
 
 The dual-auth dependency is `server.security.auth_required_any`. It either resolves the API key against the `api_keys` table (returning the matched row) or delegates to the existing Cognito flow (returning a `CustomCognitoToken`). Endpoints not tagged for MCP still use `auth_required` (Cognito only) — an API key cannot reach the full REST surface.
 
@@ -81,7 +82,20 @@ curl -X DELETE https://api.example.com/shops/$SHOP_ID/api-keys/$KEY_ID \
 
 ## Connecting an MCP client
 
-### Claude Desktop / Claude Code
+### Claude Code — browser login (Cognito Hosted UI)
+
+The MCP server publishes OAuth discovery metadata so Claude Code can drive Cognito's Hosted UI directly. Add the server with a fixed callback port (must match the Cognito app client's whitelisted redirect URI — currently `7777`):
+
+```bash
+claude mcp add --transport http shopvirge https://api.shopvirge.com/mcp/ \
+  --callback-port 7777
+```
+
+Inside Claude Code, run `/mcp` → **Authenticate**. Your browser opens the Cognito Hosted UI, you sign in with your normal credentials, and the access token lands back in Claude Code. From there every tool call carries `Authorization: Bearer <cognito-jwt>` automatically.
+
+Three discovery endpoints make this work; see [OAuth discovery](#oauth-discovery-claude-code-browser-login) below for the full chain.
+
+### Claude Desktop / Claude Code — static API key
 
 Add an entry to the client's MCP config (`~/.claude/mcp.json` or the Claude Desktop UI):
 
@@ -120,9 +134,34 @@ You should see all 20 tool definitions in the response.
 
 ## How auth flows through `from_fastapi`
 
-`FastMCP.from_fastapi(app=…)` invokes the underlying routes via in-process `httpx` over an `ASGITransport`. That means every MCP tool call **goes through the FastAPI middleware and dependency chain** — including `auth_required_any`. The only thing fastmcp does *not* do by default is forward auth headers: its `get_http_headers()` exclude list strips `authorization`.
+`FastMCP.from_fastapi(app=…)` invokes the underlying routes via in-process `httpx` over an `ASGITransport`. That means every MCP tool call **goes through the FastAPI middleware and dependency chain** — including `auth_required_any`.
 
-`server/mcp/server.py` adds a small httpx request hook that re-injects both `Authorization` and `X-API-Key` on every internal call, so per-route auth fires exactly as it would over plain REST.
+fastmcp 2.14.x's `OpenAPITool.run` auto-forwards the incoming MCP request's headers into the inner httpx call, and its default exclude list does NOT strip `authorization` or `x-api-key` — so either credential reaches the underlying route's auth dependency without extra plumbing. (Earlier revisions of this module ran a custom forwarding hook for this; it was removed when it turned out to crash the call in 2.14.x — see commit history of `server/mcp/server.py`.)
+
+## OAuth discovery (Claude Code browser-login)
+
+MCP clients that follow the [MCP 2025-06-18](https://modelcontextprotocol.io/) auth spec bootstrap their OAuth flow via RFC 9728 / RFC 8414 / RFC 7591. Cognito covers most of that out of the box but does **not** support Dynamic Client Registration (RFC 7591), which Claude Code's MCP SDK attempts unconditionally even when a static `client_id` is configured ([anthropics/claude-code#26675](https://github.com/anthropics/claude-code/issues/26675)).
+
+To bridge that gap, `server/api/endpoints/oauth_discovery.py` mounts three unauthenticated endpoints at the app root:
+
+| Path | Spec | Purpose |
+|------|------|---------|
+| `GET /.well-known/oauth-protected-resource` | RFC 9728 | Points clients at the authorization server (`PUBLIC_BASE_URL`). |
+| `GET /.well-known/oauth-authorization-server` | RFC 8414 | Cognito's OIDC metadata stitched together with our shim's `registration_endpoint`. `issuer` deliberately matches Cognito's so token-`iss` validation succeeds client-side. |
+| `POST /oauth/register` | RFC 7591 | DCR shim — ignores the body and returns `AWS_COGNITO_MCP_CLIENT_ID` verbatim. Cognito enforces the real redirect-URI allowlist at the authorize step. |
+
+The Hosted UI base URL is resolved once at import time from Cognito's `/.well-known/openid-configuration`, so changing the user pool's Hosted UI domain in the future doesn't require a code edit.
+
+End-to-end flow when a user clicks **Authenticate**:
+
+1. Claude Code GETs `/.well-known/oauth-protected-resource`
+2. Follows to `/.well-known/oauth-authorization-server`
+3. POSTs `/oauth/register` → gets static `AWS_COGNITO_MCP_CLIENT_ID`
+4. Opens Cognito Hosted UI → user signs in → redirect to `http://localhost:<callback-port>/callback`
+5. Exchanges code at Cognito's `token_endpoint`
+6. Calls MCP tools with `Authorization: Bearer <cognito-jwt>`
+
+**Pre-registered Cognito app client.** Created once via `aws cognito-idp create-user-pool-client --no-generate-secret --allowed-o-auth-flows code --allowed-o-auth-scopes openid email profile --callback-urls 'http://localhost:7777/callback'`. The `client_id` (non-secret — it appears in every browser URL during auth) is deployed as `AWS_COGNITO_MCP_CLIENT_ID`. To rotate, recreate the client and update the env var.
 
 ## Adding a new tool
 
@@ -147,14 +186,17 @@ The docstring on the handler becomes the tool description — write it for an LL
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `MCP_ENABLED` | `false` | Mount `/mcp` and enter its lifespan. |
+| `AWS_COGNITO_MCP_CLIENT_ID` | `""` | Pre-registered Cognito public PKCE client returned by the DCR shim. Required for the browser-login flow. Non-secret. |
+| `PUBLIC_BASE_URL` | `http://localhost:8080` | Backend's public origin. Used to build absolute URLs in the OAuth discovery documents (`resource`, `authorization_servers`, `registration_endpoint`). |
 
 API keys themselves are stored in the `api_keys` table (migration `c1a2b3d4e5f6`) and need no env config.
 
 ## Related files
 
-- `server/mcp/server.py` — `mount_mcp(app)` and the auth-header forwarding hook.
+- `server/mcp/server.py` — `mount_mcp(app)`.
 - `server/agent_tags.py` — the `AgentTag` enum.
-- `server/security.py` — `auth_required_any` dual-auth dependency.
+- `server/security.py` — `auth_required` / `auth_required_any` dependencies.
 - `server/crud/crud_api_key.py` — minting, lookup, revocation.
 - `server/api/endpoints/shop_endpoints/api_keys.py` — REST management endpoints.
+- `server/api/endpoints/oauth_discovery.py` — OAuth discovery + DCR shim for the browser-login flow.
 - `tests/unit_tests/mcp/test_mcp.py` — verifies tag coverage and `FastMCP.from_fastapi` introspection.

--- a/server/api/api.py
+++ b/server/api/api.py
@@ -27,6 +27,7 @@ from server.api.endpoints import (
     licenses,
     login,
     mail_test,
+    oauth_discovery,
     sentry_test,
     shops,
     test_forms,
@@ -56,6 +57,7 @@ from server.settings import mail_settings
 api_router = APIRouter()
 
 api_router.include_router(login.router, tags=["login"])
+api_router.include_router(oauth_discovery.router, tags=["oauth"])
 api_router.include_router(health.router, prefix="/health", tags=["system"])
 api_router.include_router(users.router, prefix="/users", tags=["users"])
 api_router.include_router(

--- a/server/api/endpoints/oauth_discovery.py
+++ b/server/api/endpoints/oauth_discovery.py
@@ -1,0 +1,164 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+"""OAuth discovery endpoints + Cognito-compatible DCR shim for the MCP server.
+
+Claude Code's MCP SDK follows the MCP 2025-06-18 / RFC 9728 / RFC 8414 /
+RFC 7591 chain to bootstrap auth against an HTTP MCP server:
+
+1. ``GET  /.well-known/oauth-protected-resource``     -> RFC 9728 metadata
+2. ``GET  /.well-known/oauth-authorization-server``   -> RFC 8414 metadata
+3. ``POST <registration_endpoint>``                   -> RFC 7591 DCR
+4. PKCE authorization-code flow against ``authorization_endpoint`` +
+   ``token_endpoint``
+
+Cognito provides 1 & 4 out of the box (via the user pool's OIDC discovery
+doc and Hosted UI), but it does NOT support RFC 7591 DCR — and Claude Code
+attempts DCR unconditionally even when configured with a static client_id
+(see anthropics/claude-code#26675). This module bridges that gap:
+
+* Mounts the two well-known docs at our backend's root with values
+  stitched from Cognito's OIDC discovery + the pre-registered MCP
+  app-client id (``AWS_COGNITO_MCP_CLIENT_ID``).
+* Mounts ``/oauth/register`` as a DCR shim — ignores the request body
+  and returns the static MCP client_id, so Claude Code thinks it
+  registered and proceeds straight to PKCE.
+
+The discovery doc's ``issuer`` field intentionally matches Cognito's
+issuer (``https://cognito-idp.<region>.amazonaws.com/<userpool-id>``),
+not our backend URL. This violates RFC 8414 §3.3 strictly (the issuer
+should equal the URL where the doc is served), but MCP clients prioritize
+token-``iss`` matching during validation, and Cognito-issued tokens carry
+the Cognito issuer. Without this mismatch, tokens fail client-side
+validation.
+"""
+
+import time
+from typing import Any
+
+from fastapi import APIRouter, Body, status
+from fastapi.responses import JSONResponse
+
+from server.settings import app_settings
+
+router = APIRouter()
+
+# Default scopes the shim hands back in the DCR response. The user pool's
+# Hosted UI must allow these; see ``aws cognito-idp create-user-pool-client
+# --allowed-o-auth-scopes`` in the setup docs.
+_DEFAULT_SCOPES = ("openid", "email", "profile")
+
+
+def _cognito_issuer() -> str:
+    return (
+        f"https://cognito-idp.{app_settings.AWS_COGNITO_REGION}.amazonaws.com/"
+        f"{app_settings.AWS_COGNITO_USERPOOL_ID}"
+    )
+
+
+def _hosted_ui_base() -> str:
+    # The Hosted UI domain is configurable per user pool and cannot be
+    # derived from the userpool id alone. We pull it from Cognito's OIDC
+    # discovery doc once at import time so the values stay in lockstep
+    # with whatever the user pool actually advertises.
+    return _HOSTED_UI_BASE
+
+
+def _fetch_hosted_ui_base() -> str:
+    """Resolve the Hosted UI base URL from Cognito's OIDC discovery doc.
+
+    Pulled once at import time. If the lookup fails (offline tests, no
+    DNS) we fall back to a placeholder — the well-known endpoints will
+    still serve, but the URLs they advertise won't work for a real
+    browser login. Production deployments always have outbound network.
+    """
+    import json
+    import urllib.request
+
+    url = f"{_cognito_issuer()}/.well-known/openid-configuration"
+    try:
+        with urllib.request.urlopen(url, timeout=3) as resp:
+            doc = json.loads(resp.read())
+        return doc["authorization_endpoint"].rsplit("/oauth2/", 1)[0]
+    except Exception:
+        return "https://example.invalid"
+
+
+_HOSTED_UI_BASE = _fetch_hosted_ui_base()
+
+
+@router.get(
+    "/.well-known/oauth-protected-resource",
+    include_in_schema=False,
+)
+def oauth_protected_resource() -> dict[str, Any]:
+    """RFC 9728 — tell MCP clients where to find the authorization server."""
+    return {
+        "resource": f"{app_settings.PUBLIC_BASE_URL}/mcp",
+        "authorization_servers": [app_settings.PUBLIC_BASE_URL],
+        "bearer_methods_supported": ["header"],
+        "scopes_supported": list(_DEFAULT_SCOPES),
+    }
+
+
+@router.get(
+    "/.well-known/oauth-authorization-server",
+    include_in_schema=False,
+)
+def oauth_authorization_server() -> dict[str, Any]:
+    """RFC 8414 — Cognito's OIDC doc, plus our DCR shim's registration endpoint.
+
+    ``issuer`` deliberately matches Cognito's issuer (not our backend host)
+    so token-``iss`` validation succeeds client-side. See module docstring.
+    """
+    hosted = _hosted_ui_base()
+    return {
+        "issuer": _cognito_issuer(),
+        "authorization_endpoint": f"{hosted}/oauth2/authorize",
+        "token_endpoint": f"{hosted}/oauth2/token",
+        "jwks_uri": f"{_cognito_issuer()}/.well-known/jwks.json",
+        "registration_endpoint": f"{app_settings.PUBLIC_BASE_URL}/oauth/register",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "scopes_supported": list(_DEFAULT_SCOPES),
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "revocation_endpoint": f"{hosted}/oauth2/revoke",
+        "userinfo_endpoint": f"{hosted}/oauth2/userInfo",
+    }
+
+
+@router.post(
+    "/oauth/register",
+    status_code=status.HTTP_201_CREATED,
+    include_in_schema=False,
+)
+def oauth_register_shim(body: dict[str, Any] = Body(default_factory=dict)) -> JSONResponse:
+    """RFC 7591 DCR shim — always returns the pre-registered MCP client_id.
+
+    Cognito doesn't support DCR. Claude Code's MCP SDK attempts it
+    unconditionally; we return a fixed registration response so the SDK
+    proceeds to PKCE with our static client.
+
+    The request body is ignored beyond echoing back the client's
+    ``redirect_uris`` (so the SDK sees what it expects). The real
+    redirect-URI allowlist is enforced by Cognito at the
+    ``authorization_endpoint`` step.
+    """
+    redirect_uris = body.get("redirect_uris") or ["http://localhost:7777/callback"]
+    response = {
+        "client_id": app_settings.AWS_COGNITO_MCP_CLIENT_ID,
+        "client_id_issued_at": int(time.time()),
+        "client_name": body.get("client_name", "shopvirge-mcp"),
+        "redirect_uris": redirect_uris,
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+        "scope": " ".join(_DEFAULT_SCOPES),
+    }
+    return JSONResponse(content=response, status_code=status.HTTP_201_CREATED)

--- a/server/security.py
+++ b/server/security.py
@@ -52,7 +52,11 @@ cognito_eu = CognitoAuth(settings=CognitoSettings.from_global_settings(auth_sett
 
 
 def auth_required(token: CognitoToken = Depends(cognito_eu.auth_required)):
-    if token.client_id == app_settings.AWS_COGNITO_CLIENT_ID:
+    user_client_ids = {
+        app_settings.AWS_COGNITO_CLIENT_ID,
+        app_settings.AWS_COGNITO_MCP_CLIENT_ID,
+    } - {""}
+    if token.client_id in user_client_ids:
         # No need to check scopes for user tokens
         return token
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -48,7 +48,16 @@ class AppSettings(BaseSettings):
     AWS_COGNITO_CLIENT_ID: str = "AWS_COGNITO_CLIENT_ID"
     AWS_COGNITO_M2M_CLIENT_ID: str = "AWS_COGNITO_M2M_CLIENT_ID"
     AWS_COGNITO_M2M_CLIENT_SECRET: str = "AWS_COGNITO_M2M_CLIENT_SECRET"
+    # Pre-registered Cognito app client used by MCP clients (Claude Code etc.)
+    # that can't do dynamic client registration. The /oauth/register shim
+    # returns this id verbatim.
+    AWS_COGNITO_MCP_CLIENT_ID: str = ""
     AWS_COGNITO_REGION: str = "eu-central-1"
+
+    # Public base URL of the backend, used to build absolute URLs in the OAuth
+    # discovery documents (issuer-style fields, registration_endpoint, etc.).
+    # Must be set in production; local dev defaults to the dev server URL.
+    PUBLIC_BASE_URL: str = "http://localhost:8080"
 
     # Sentry settings
     SENTRY_DSN: Optional[str] = None
@@ -193,6 +202,7 @@ class AuthSetting(BaseSettings):
             "app_client_id": [
                 app_settings.AWS_COGNITO_CLIENT_ID,
                 app_settings.AWS_COGNITO_M2M_CLIENT_ID,
+                app_settings.AWS_COGNITO_MCP_CLIENT_ID,
             ],
         },
     }


### PR DESCRIPTION
## Summary
- Claude Code's MCP SDK bootstraps auth via RFC 9728 / RFC 8414 / RFC 7591 and **always** attempts Dynamic Client Registration, even with a static `client_id` configured ([anthropics/claude-code#26675](https://github.com/anthropics/claude-code/issues/26675)). Cognito doesn't support DCR, so the SDK gave up before it could drive the Hosted UI login.
- Three new unauthenticated endpoints on the FastAPI app bridge the gap:
  - `/.well-known/oauth-protected-resource` — RFC 9728 pointer
  - `/.well-known/oauth-authorization-server` — RFC 8414 metadata, stitched from Cognito's OIDC discovery + the static MCP client_id. `issuer` deliberately matches Cognito's so token-`iss` validation succeeds client-side.
  - `/oauth/register` — DCR shim that always returns `AWS_COGNITO_MCP_CLIENT_ID`. Cognito enforces the real redirect-URI allowlist at the authorize step regardless.
- `auth_required` accepts tokens from the new MCP app client alongside the Next.js client and M2M scope; the new client_id is added to the fastapi-cognito audience allowlist.
- App Runner config wired with the new public client_id and `PUBLIC_BASE_URL`.

## New env vars (deploy)
- `AWS_COGNITO_MCP_CLIENT_ID` — pre-registered Cognito **public PKCE** app client (no secret; non-sensitive; lives in `apprunner.yaml` as plain env).
- `PUBLIC_BASE_URL` — backend's public origin; used to build absolute URLs in the discovery docs.

## Cognito app client
Created via `aws cognito-idp create-user-pool-client` with:
- `--no-generate-secret` (PKCE only)
- `--allowed-o-auth-flows code`
- `--allowed-o-auth-scopes openid email profile`
- `--callback-urls 'http://localhost:7777/callback'`

## Expected browser-login flow after deploy
1. Claude Code GETs `/.well-known/oauth-protected-resource`
2. Follows to `/.well-known/oauth-authorization-server`
3. POSTs `/oauth/register` -> gets static client_id
4. Opens Cognito Hosted UI -> user signs in -> redirects to `http://localhost:7777/callback`
5. Exchanges code at Cognito token endpoint
6. Calls MCP tools with `Authorization: Bearer <cognito-jwt>`

## Test plan
- [x] Smoke-tested the three endpoints in isolation via `TestClient` — all three return well-formed JSON; Hosted UI base URL resolved from Cognito's OIDC discovery doc at import time.
- [x] Verified `auth_required` accepts tokens from the new MCP client_id while still rejecting unknown user-flow client_ids.
- [ ] **After deploy**: register the server with `claude mcp add --transport http shopvirge https://api.shopvirge.com/mcp/ --callback-port 7777` and confirm the browser login completes.
- [ ] Hit `https://api.shopvirge.com/.well-known/oauth-protected-resource` and `…/oauth-authorization-server` on prod to confirm they 200 with the expected payloads.
- [ ] POST to `https://api.shopvirge.com/oauth/register` with `{"redirect_uris": ["http://localhost:7777/callback"]}` and confirm it returns the static client_id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)