### PR TITLE
MCP OAuth: Managed Login docs, new client_id, revert resource-stripping proxies

### DIFF
--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -25,7 +25,7 @@ run:
     - name: MCP_ENABLED
       value: "true"
     - name: AWS_COGNITO_MCP_CLIENT_ID
-      value: "6m8pss5q1drhph217kn5guu421"
+      value: "3lq6ps78rb2i8pji1b9d4i5bq2"
     - name: PUBLIC_BASE_URL
       value: "https://api.shopvirge.com"
   secrets:

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -161,7 +161,56 @@ End-to-end flow when a user clicks **Authenticate**:
 5. Exchanges code at Cognito's `token_endpoint`
 6. Calls MCP tools with `Authorization: Bearer <cognito-jwt>`
 
-**Pre-registered Cognito app client.** Created once via `aws cognito-idp create-user-pool-client --no-generate-secret --allowed-o-auth-flows code --allowed-o-auth-scopes openid email profile --callback-urls 'http://localhost:7777/callback'`. The `client_id` (non-secret — it appears in every browser URL during auth) is deployed as `AWS_COGNITO_MCP_CLIENT_ID`. To rotate, recreate the client and update the env var.
+### Cognito app client setup
+
+The pre-registered Cognito app client backs the static `client_id` the DCR shim returns. The `client_id` is non-secret (it appears in every browser URL during auth) and is deployed as `AWS_COGNITO_MCP_CLIENT_ID`.
+
+Create it via CLI:
+
+```bash
+aws cognito-idp create-user-pool-client \
+  --region eu-central-1 \
+  --user-pool-id <USERPOOL_ID> \
+  --client-name shopvirge-mcp \
+  --no-generate-secret \
+  --explicit-auth-flows ALLOW_USER_SRP_AUTH ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH \
+  --supported-identity-providers COGNITO \
+  --callback-urls 'http://localhost:7777/callback' 'http://127.0.0.1:7777/callback' \
+  --logout-urls  'http://localhost:7777/callback' 'http://127.0.0.1:7777/callback' \
+  --allowed-o-auth-flows code \
+  --allowed-o-auth-scopes openid email profile \
+  --allowed-o-auth-flows-user-pool-client \
+  --read-attributes email email_verified family_name given_name name preferred_username \
+  --write-attributes email family_name given_name name preferred_username \
+  --prevent-user-existence-errors ENABLED \
+  --enable-token-revocation \
+  --auth-session-validity 3 \
+  --access-token-validity 60 \
+  --id-token-validity 60 \
+  --refresh-token-validity 30 \
+  --token-validity-units 'AccessToken=minutes,IdToken=minutes,RefreshToken=days'
+```
+
+The CLI prints a `ClientId` — copy it into `apprunner.yaml` as `AWS_COGNITO_MCP_CLIENT_ID` and redeploy.
+
+#### ⚠️ Managed Login branding (required step the CLI doesn't cover)
+
+User pools created in 2024-2025 default to **Managed Login** for new app clients. Until you explicitly assign a Managed Login branding style to a new client, its Hosted UI returns `403 "Login pages unavailable"` — even from the console's own "View login page" button. **Older app clients in the same user pool keep working because they still use the legacy Hosted UI.**
+
+There is currently no clean CLI command to assign branding. Do it once per new client via the console:
+
+1. `Cognito → User pool → App integration → Managed login branding versions`.
+2. Open the default style (create one if none exists; empty/default styling is fine).
+3. Scroll to the "App clients" section and add the new MCP client. Save.
+4. Re-test by hitting the "View login page" button on the client — it should now render Cognito's sign-in page instead of "Login pages unavailable".
+
+#### Callback URLs: register both `localhost` and `127.0.0.1`
+
+Claude Code's MCP SDK sends `http://localhost:<port>/callback` as the `redirect_uri`. The Cognito console's "Quick setup" wizard for **Mobile app** / **SPA** presets sometimes rejects `http://localhost:…` at create time but accepts `http://127.0.0.1:…`. To avoid a `redirect_uri mismatch` at sign-in, **whitelist both** variants — the CLI command above does this. If you've already created the client and only registered `127.0.0.1`, update it with `aws cognito-idp update-user-pool-client --callback-urls '<both>'`.
+
+#### Rotation
+
+To rotate the client, run the same `create-user-pool-client` command again with a new name, redo the Managed Login branding step, update `AWS_COGNITO_MCP_CLIENT_ID` in `apprunner.yaml`, deploy, and finally delete the old client with `aws cognito-idp delete-user-pool-client`.
 
 ## Adding a new tool
 

--- a/server/api/endpoints/oauth_discovery.py
+++ b/server/api/endpoints/oauth_discovery.py
@@ -26,13 +26,6 @@ attempts DCR unconditionally even when configured with a static client_id
 * Mounts ``/oauth/register`` as a DCR shim — ignores the request body
   and returns the static MCP client_id, so Claude Code thinks it
   registered and proceeds straight to PKCE.
-* Mounts ``/oauth/authorize`` and ``/oauth/token`` as thin proxies in
-  front of Cognito that strip the RFC 8707 ``resource`` parameter
-  before forwarding. Cognito does not implement Resource Indicators
-  and responds with "Login pages unavailable" instead of ignoring the
-  unknown param (an RFC 6749 §3.1 violation), but the MCP spec requires
-  clients to send it. Tokens are still issued and signed by Cognito,
-  so ``iss`` validation client-side still matches the discovery doc.
 
 The discovery doc's ``issuer`` field intentionally matches Cognito's
 issuer (``https://cognito-idp.<region>.amazonaws.com/<userpool-id>``),
@@ -44,12 +37,10 @@ validation.
 """
 
 import time
-import urllib.parse
 from typing import Any
 
-import httpx
-from fastapi import APIRouter, Body, Request, status
-from fastapi.responses import JSONResponse, RedirectResponse, Response
+from fastapi import APIRouter, Body, status
+from fastapi.responses import JSONResponse
 
 from server.settings import app_settings
 
@@ -126,10 +117,8 @@ def oauth_authorization_server() -> dict[str, Any]:
     hosted = _hosted_ui_base()
     return {
         "issuer": _cognito_issuer(),
-        # authorize/token point at our resource-stripping proxies, not at
-        # Cognito directly. See module docstring.
-        "authorization_endpoint": f"{app_settings.PUBLIC_BASE_URL}/oauth/authorize",
-        "token_endpoint": f"{app_settings.PUBLIC_BASE_URL}/oauth/token",
+        "authorization_endpoint": f"{hosted}/oauth2/authorize",
+        "token_endpoint": f"{hosted}/oauth2/token",
         "jwks_uri": f"{_cognito_issuer()}/.well-known/jwks.json",
         "registration_endpoint": f"{app_settings.PUBLIC_BASE_URL}/oauth/register",
         "response_types_supported": ["code"],
@@ -142,51 +131,6 @@ def oauth_authorization_server() -> dict[str, Any]:
         "revocation_endpoint": f"{hosted}/oauth2/revoke",
         "userinfo_endpoint": f"{hosted}/oauth2/userInfo",
     }
-
-
-@router.get(
-    "/oauth/authorize",
-    include_in_schema=False,
-)
-def oauth_authorize_proxy(request: Request) -> RedirectResponse:
-    """Redirect to Cognito's authorize endpoint, stripping the ``resource`` param.
-
-    MCP clients (Claude Code) include ``resource=<mcp-url>`` per RFC 8707.
-    Cognito rejects authorize requests carrying it with "Login pages
-    unavailable"; dropping it on the way through lets the Hosted UI render.
-    """
-    params = [(k, v) for k, v in request.query_params.multi_items() if k != "resource"]
-    qs = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
-    return RedirectResponse(
-        f"{_hosted_ui_base()}/oauth2/authorize?{qs}",
-        status_code=status.HTTP_302_FOUND,
-    )
-
-
-@router.post(
-    "/oauth/token",
-    include_in_schema=False,
-)
-async def oauth_token_proxy(request: Request) -> Response:
-    """Proxy token-exchange POSTs to Cognito, stripping the ``resource`` param.
-
-    Some MCP clients include ``resource`` on the token request too. Cognito's
-    token endpoint tends to be more permissive than authorize, but stripping
-    keeps behavior consistent with ``oauth_authorize_proxy`` and avoids future
-    surprises. Returns Cognito's response verbatim (status, body, content-type).
-    """
-    form = [(k, v) for k, v in (await request.form()).multi_items() if k != "resource"]
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        upstream = await client.post(
-            f"{_hosted_ui_base()}/oauth2/token",
-            data=form,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-        )
-    return Response(
-        content=upstream.content,
-        status_code=upstream.status_code,
-        media_type=upstream.headers.get("content-type", "application/json"),
-    )
 
 
 @router.post(


### PR DESCRIPTION
## Summary
Three related changes coming out of the live MCP browser-login debug session:

1. **Document Cognito setup gotchas** in `docs/api/mcp.md`:
   - **Managed Login branding** — user pools created in 2024-2025 require each new app client to be explicitly assigned a Managed Login branding style in the console, or Hosted UI returns `403 "Login pages unavailable"`. Older clients in the same user pool keep using the legacy Hosted UI and never hit this. No clean CLI for this step.
   - **Callback URLs** — Claude Code's MCP SDK sends `http://localhost:<port>/callback`, but the Cognito console's Mobile/SPA wizard sometimes rejects that hostname and only accepts `http://127.0.0.1:…`. Whitelist both.

2. **Swap `AWS_COGNITO_MCP_CLIENT_ID`** in `apprunner.yaml` to `3lq6ps78rb2i8pji1b9d4i5bq2` (the new console-created client with Managed Login branding assigned). The original CLI-created `6m8pss5q1drhph217kn5guu421` couldn't be unstuck.

3. **Revert the `/oauth/authorize` and `/oauth/token` proxies from PR #121.** Empirically retested against the working branded client: Cognito accepts requests with the RFC 8707 `resource` parameter fine — it renders the Hosted UI. The original "Login pages unavailable" we attributed to `resource` was actually the Managed Login branding issue manifesting identically. Proxies were dead weight (extra hop per login, extra code). Discovery doc reverts to pointing `authorization_endpoint` / `token_endpoint` directly at Cognito. The `/oauth/register` DCR shim and the two `.well-known` endpoints remain — those are still load-bearing because Cognito doesn't speak DCR.

## Test plan
- [x] Verified the new client_id renders the Hosted UI's login page after Managed Login branding was assigned via the console.
- [x] Smoke-tested the discovery endpoints after proxy removal — `/.well-known/oauth-authorization-server` now points at Cognito directly; `/oauth/authorize` and `/oauth/token` return 404 as intended; `/oauth/register` still returns 201 with the static client_id.
- [x] Confirmed via curl that Cognito returns the Managed Login sign-in page (title `<title>Sign-in</title>`, full JS bundle) for the new branded client both with and without the `resource` query parameter.
- [ ] **After deploy**, run `/mcp` → Authenticate in Claude Code and confirm the full PKCE round-trip completes against the now-direct Cognito endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)