### PR TITLE
Make available-attributes endpoint dynamic

### DIFF
--- a/server/api/endpoints/shop_endpoints/categories.py
+++ b/server/api/endpoints/shop_endpoints/categories.py
@@ -8,6 +8,7 @@ import structlog
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.param_functions import Body, Depends
 from sqlalchemy import func
+from sqlalchemy.orm import aliased
 from starlette.responses import Response
 
 from server.agent_tags import AgentTag
@@ -196,9 +197,13 @@ def delete(category_id: UUID, shop_id: UUID) -> None:
     "/{category_id}/available-attributes",
     response_model=list[AvailableAttributeSchema],
     summary="Get available filter attributes for a category",
-    description="Returns attributes actually used by products in this category, with option counts.",
+    description="Returns attributes actually used by products in this category, with option counts. Pass option_id[] to narrow counts to the already-selected filters (AND logic).",
 )
-def get_available_attributes(shop_id: UUID, category_id: UUID) -> list[AvailableAttributeSchema]:
+def get_available_attributes(
+    shop_id: UUID,
+    category_id: UUID,
+    option_id: List[UUID] = Query(None),
+) -> list[AvailableAttributeSchema]:
     category = category_crud.get_id_by_shop_id(shop_id, category_id)
     if not category:
         raise_status(HTTPStatus.NOT_FOUND, f"Category with id {category_id} not found")
@@ -207,8 +212,26 @@ def get_available_attributes(shop_id: UUID, category_id: UUID) -> list[Available
     if shop and isinstance(shop.config, str):
         shop.config = json.loads(shop.config)
 
-    # Single aggregation query: get attribute+option+count for all used options in this category
-    query = (
+    # Build a subquery of product IDs that match the active filters
+    product_subq = (
+        db.session.query(ProductTable.id)
+        .filter(ProductTable.shop_id == shop_id)
+        .filter(ProductTable.category_id == category_id)
+        .filter(ProductTable.price.isnot(None))
+    )
+    if shop and shop.config.get("toggles", {}).get("enable_stock_on_products"):
+        product_subq = product_subq.filter(ProductTable.stock > 0)
+    # Each selected option_id is ANDed: products must carry all of them
+    if option_id:
+        for opt in option_id:
+            pav_alias = aliased(ProductAttributeValueTable)
+            product_subq = product_subq.join(pav_alias, ProductTable.id == pav_alias.product_id).filter(
+                pav_alias.option_id == opt
+            )
+    product_subq = product_subq.subquery()
+
+    # Aggregation query: count per attribute option across the filtered product set
+    results = (
         db.session.query(
             AttributeTable.id.label("attribute_id"),
             AttributeTable.name.label("attribute_name"),
@@ -218,23 +241,17 @@ def get_available_attributes(shop_id: UUID, category_id: UUID) -> list[Available
             func.count(ProductAttributeValueTable.id).label("product_count"),
         )
         .join(ProductAttributeValueTable, ProductAttributeValueTable.attribute_id == AttributeTable.id)
-        .join(ProductTable, ProductTable.id == ProductAttributeValueTable.product_id)
+        .join(product_subq, product_subq.c.id == ProductAttributeValueTable.product_id)
         .join(AttributeOptionTable, AttributeOptionTable.id == ProductAttributeValueTable.option_id)
-        .filter(ProductTable.shop_id == shop_id)
-        .filter(ProductTable.category_id == category_id)
-        .filter(ProductTable.price.isnot(None))
+        .group_by(
+            AttributeTable.id,
+            AttributeTable.name,
+            AttributeTable.unit,
+            AttributeOptionTable.id,
+            AttributeOptionTable.value_key,
+        )
+        .all()
     )
-
-    if shop and shop.config.get("toggles", {}).get("enable_stock_on_products"):
-        query = query.filter(ProductTable.stock > 0)
-
-    results = query.group_by(
-        AttributeTable.id,
-        AttributeTable.name,
-        AttributeTable.unit,
-        AttributeOptionTable.id,
-        AttributeOptionTable.value_key,
-    ).all()
 
     if not results:
         return []

--- a/server/main.py
+++ b/server/main.py
@@ -74,7 +74,7 @@ async def lifespan(app_: FastAPI):
         yield
 
 
-APP_VERSION = "0.3.0"
+APP_VERSION = "0.3.1"
 
 # Assigned after the api_router is included if MCP_ENABLED. The lifespan
 # closure above references it.

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -5820,7 +5820,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.3.0"
+    "version": "0.3.1"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -11037,7 +11037,7 @@
     },
     "/shops/{shop_id}/categories/{category_id}/available-attributes": {
       "get": {
-        "description": "Returns attributes actually used by products in this category, with option counts.",
+        "description": "Returns attributes actually used by products in this category, with option counts. Pass option_id[] to narrow counts to the already-selected filters (AND logic).",
         "operationId": "get_available_attributes_shops__shop_id__categories__category_id__available_attributes_get",
         "parameters": [
           {
@@ -11058,6 +11058,19 @@
               "format": "uuid",
               "title": "Category Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "option_id",
+            "required": false,
+            "schema": {
+              "items": {
+                "format": "uuid",
+                "type": "string"
+              },
+              "title": "Option Id",
+              "type": "array"
             }
           }
         ],


### PR DESCRIPTION
## Summary

- Adds optional `option_id[]` query parameter to `GET /{category_id}/available-attributes`
- Builds a filtered product-ID subquery (AND logic per option) before computing attribute option counts
- When no filters are passed the endpoint behaves exactly as before
- Stock toggle is applied to the subquery, not the outer aggregation

## How it works

When `?option_id=<white-uuid>&option_id=<large-uuid>` is passed, only products carrying **all** selected options are counted. This gives the frontend live "how many X AND Y" counts as the user applies filters.

## Test plan

- [ ] Call without `option_id` → same counts as before
- [ ] Call with a single `option_id` → counts reduced to products with that option
- [ ] Call with multiple `option_id` values → counts reflect the AND intersection
- [ ] Shop with `enable_stock_on_products` → out-of-stock products excluded from filtered counts

Refs acidjunk/shop-poc#212

🤖 Generated with [Claude Code](https://claude.ai/claude-code)