### PR TITLE
Pluggable payment providers (Mollie first) with webhook-driven order completion

### DIFF
--- a/docs/api/email-notifications.md
+++ b/docs/api/email-notifications.md
@@ -10,11 +10,13 @@ Transactional email is rendered with Jinja2 and sent via SMTP.
 
 ## Order confirmation flow
 
-When an order transitions to "completed" (commit `8dbfd02`), the order endpoint calls:
+When an order transitions to "complete", `server/services/order_lifecycle.py` calls:
 
 ```python
 send_order_confirmation_emails(order, shop, account)
 ```
+
+There are two paths into that transition: the orders PATCH endpoint (admin / legacy frontend) and a paid [payment webhook or status sync](payments.md). Both funnel through the same idempotent `complete_order()` / `notify_order_complete()` service, so the mails are sent exactly once regardless of which path wins.
 
 This renders and sends two mails:
 
@@ -24,7 +26,7 @@ This renders and sends two mails:
 ```mermaid
 sequenceDiagram
     autonumber
-    participant EP as orders endpoint<br/>(complete order)
+    participant EP as complete_order()<br/>(orders PATCH or payment webhook)
     participant Mail as mail.py
     participant J2 as Jinja2 env
     participant SMTP as SMTP server

--- a/docs/api/payments.md
+++ b/docs/api/payments.md
@@ -1,0 +1,132 @@
+# Payments (provider-agnostic)
+
+Checkout payments go through a pluggable provider layer: each shop selects a payment service provider (PSP) via `ShopTable.payment_provider`, and the frontend talks only to provider-agnostic endpoints. **Mollie** and **Stripe** are implemented; adding another PSP means implementing one class.
+
+This supersedes the direct [Stripe endpoints](stripe.md) (`/shops/{shop_id}/stripe/*`), which remain in place for the legacy checkout but are deprecated for one-off payments.
+
+## Design in one paragraph
+
+A `PaymentProvider` turns a `(shop, order)` pair into a normalized `PaymentSession` that tells the frontend what to do next, and turns provider webhooks/polls into normalized `PaymentEvent`s. Payments are first-class rows in the `payments` table (an order can have several attempts — a failed iDEAL payment followed by a successful retry is two rows). Order completion is **owned by the backend**: a verified webhook (or the poll-time sync fallback) marks the payment `paid` and runs the idempotent `complete_order()` service. The frontend never marks an order complete.
+
+## The files
+
+| File | Role |
+|------|------|
+| `server/payments/base.py` | `PaymentProvider` ABC + `PaymentSession` / `PaymentEvent` / `PaymentStatus`. |
+| `server/payments/registry.py` | `get_provider(shop)` — resolves `shop.payment_provider` to a provider instance. |
+| `server/payments/mollie.py` | Mollie (hosted checkout, redirect flow). |
+| `server/payments/stripe.py` | Stripe (PaymentIntents, in-page confirmation flow). |
+| `server/payments/processing.py` | `apply_payment_event()` — the single funnel from provider events to payment/order state. |
+| `server/services/order_lifecycle.py` | Idempotent `complete_order()` + the completion side effects (stock, Discord, emails, cache). |
+| `server/api/endpoints/shop_endpoints/payments.py` | `POST` / `GET` payment endpoints. |
+| `server/api/endpoints/webhooks.py` | Public `POST /webhooks/payments/{provider}/{shop_id}`. |
+| `server/db/models.py` → `PaymentTable` | Payment attempts: provider, `provider_payment_id`, amount, status, raw PSP payload. |
+
+## Endpoints
+
+| Route | Auth | Purpose |
+|-------|------|---------|
+| `POST /shops/{shop_id}/payments/` | none (storefront) | Body `{order_id, return_url}`. Creates the payment at the shop's PSP and returns a `PaymentSession`. The amount is derived **server-side** from `order.total` — never from client input. Only `pending` orders are payable (`409` otherwise). |
+| `GET /shops/{shop_id}/payments/{payment_id}` | none (storefront) | Status poll for the return page. Syncs from the PSP while the payment is non-terminal, so it doubles as the **webhook fallback** (local dev, missed/late webhooks). Returns `{status, order_status, ...}`. |
+| `POST /webhooks/payments/{provider}/{shop_id}` | none (PSPs call it) | Verifies the event per provider, persists the status, and completes the order on `paid`. |
+
+### The `PaymentSession` response
+
+```json
+{
+  "payment_id": "…",
+  "order_id": "…",
+  "provider": "mollie",
+  "status": "pending",
+  "amount": 12.5,
+  "currency": "EUR",
+  "flow": "redirect",
+  "redirect_url": "https://www.mollie.com/checkout/…",
+  "client_secret": null,
+  "publishable_key": null
+}
+```
+
+`flow` is the only thing the frontend branches on:
+
+- **`redirect`** (Mollie) — send the browser to `redirect_url`. No SDK, no keys.
+- **`client_confirmation`** (Stripe) — confirm in-page with Stripe Elements using `client_secret` + `publishable_key`.
+
+## Checkout flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant FE as Storefront
+    participant API as Backend
+    participant PSP as PSP (Mollie/Stripe)
+
+    FE->>API: POST /orders/  (order created, status=pending)
+    FE->>API: POST /shops/{id}/payments/ {order_id, return_url}
+    API->>PSP: create payment (amount = order.total)
+    PSP-->>API: payment id + checkout details
+    API-->>FE: PaymentSession {flow, redirect_url | client_secret}
+    FE->>PSP: customer pays (redirect or Elements)
+    PSP->>API: POST /webhooks/payments/{provider}/{shop_id}
+    API->>PSP: verify (fetch-back / signature check)
+    API->>API: payment → paid, complete_order() (stock, mails, Discord)
+    PSP-->>FE: browser lands on return_url
+    FE->>API: GET /shops/{id}/payments/{payment_id}  (poll until terminal)
+    API-->>FE: {status: "paid", order_status: "complete"}
+```
+
+The poll in the last step also *syncs* status from the PSP, so the flow completes even when the webhook hasn't arrived (yet).
+
+## Payment status lifecycle
+
+`created → pending → paid | failed | canceled | expired`
+
+Provider-native statuses are mapped onto this in each provider module (`MOLLIE_STATUS_MAP`, `STRIPE_INTENT_STATUS_MAP`). Terminal states stop the poll-time sync. A failed/canceled/expired attempt does not block checkout — the frontend can create a fresh payment for the same order.
+
+## Webhook verification
+
+Both webhook routes are deliberately unauthenticated; safety comes from provider-specific verification:
+
+- **Mollie** sends unsigned webhooks containing only a payment id. Verification = fetching that payment back from the Mollie API with the shop's key and trusting **only** the API response — never the webhook body.
+- **Stripe** events must carry a valid `Stripe-Signature`, checked against `payment_config["stripe"]["webhook_secret"]`. Without a configured secret the webhook is rejected.
+
+`complete_order()` is idempotent, so PSP webhook retries — and a racing legacy frontend status PATCH — are harmless: whichever arrives second is a no-op.
+
+## Per-shop configuration
+
+| Column | Meaning |
+|--------|---------|
+| `shops.payment_provider` | `"stripe"` (default) or `"mollie"`. |
+| `shops.payment_config` | JSONB, keyed by provider id. |
+
+```json
+{
+  "mollie": {"api_key": "live_…"},
+  "stripe": {"webhook_secret": "whsec_…"}
+}
+```
+
+The Stripe provider keeps reading the legacy `stripe_secret_key` / `stripe_public_key` columns, so existing shops work without any migration. Switching a shop to Mollie is a data change, not a deploy:
+
+```sql
+UPDATE shops
+SET payment_provider = 'mollie',
+    payment_config = '{"mollie": {"api_key": "live_…"}}'
+WHERE id = '…';
+```
+
+## Local development with Mollie
+
+Mollie refuses non-public webhook URLs, so when `PUBLIC_BASE_URL` points at `localhost` the `webhookUrl` is omitted from payment creation and statuses move via the poll-time sync instead. To exercise real webhooks locally, expose the dev server (e.g. ngrok) and set `PUBLIC_BASE_URL` accordingly. Use a Mollie **test** API key (`test_…`) on the shop; Mollie's test mode lets you pick the outcome (paid/failed/expired) on the hosted checkout page.
+
+## Adding a provider
+
+1. Implement `PaymentProvider` (three methods: `create_payment`, `handle_webhook`, `get_status`) in `server/payments/<name>.py`, mapping native statuses to `PaymentStatus`.
+2. Register an instance in `PROVIDERS` in `server/payments/registry.py`.
+3. Document the expected `payment_config["<name>"]` keys.
+4. Fake the PSP client at its seam in `tests/unit_tests/api/test_payments.py` (the Mollie tests are the template — they fake `MollieProvider._get_client` with real SDK objects).
+
+## What stays Stripe-only (for now)
+
+- **Subscriptions** — `/shops/{shop_id}/stripe/subscription*` is untouched; Mollie's recurring model (first payment + merchant-initiated charges) is a different shape and deliberately out of scope.
+- **Stripe customer auto-creation** during order creation (`orders.py`) — harmless for Mollie shops (it only runs when a Stripe key is configured).

--- a/docs/api/shop-scoped.md
+++ b/docs/api/shop-scoped.md
@@ -26,6 +26,7 @@ The files under `server/api/endpoints/shop_endpoints/`:
 | File | Resource |
 |------|----------|
 | `orders.py` | Orders — create, complete, list, email confirmation on completion. |
+| `payments.py` | Provider-agnostic checkout payments (Mollie, Stripe) — see [Payments](payments.md). |
 | `products.py` | Products (public router split out for unauthenticated catalog browsing). |
 | `categories.py` | Categories (public router split out similarly). |
 | `tags.py` | Tags. |
@@ -35,7 +36,7 @@ The files under `server/api/endpoints/shop_endpoints/`:
 | `products_to_tags.py` | Product ↔ tag links. |
 | `prices.py` | Price management. |
 | `accounts.py` | Shop-level customer/vendor accounts. |
-| `stripe.py` | Stripe integration (payment intents, webhooks). |
+| `stripe.py` | Legacy Stripe routes (payment intents, subscriptions) — deprecated for one-off payments in favour of `payments.py`. |
 | `category_images.py` | Category image uploads. |
 | `images.py` | Generic shop image uploads. |
 | `info_request.py` | Incoming info requests. |

--- a/docs/api/stripe.md
+++ b/docs/api/stripe.md
@@ -1,5 +1,8 @@
 # Stripe integration
 
+!!! warning "Partially superseded by the provider-agnostic payments API"
+    One-off checkout payments now go through the pluggable provider layer — see [Payments](payments.md). The `/shops/{shop_id}/stripe/` payment-intent route is kept for the legacy frontend but deprecated; `server/payments/stripe.py` wraps the same Stripe machinery behind the `PaymentProvider` interface. Subscriptions and the admin customer tooling described below remain Stripe-only.
+
 The backend supports per-shop Stripe accounts: every `ShopTable` row carries its own `stripe_secret_key` and `stripe_public_key`. There is no global Stripe key — every API call has to pick the right one for the shop being acted on.
 
 ## The helper: `server/services/stripe_client.py`
@@ -26,8 +29,9 @@ The helper does **not** translate `stripe.error.StripeError` into HTTP errors �
 ## Where it's used
 
 - `server/api/endpoints/admin_accounts.py` — superuser sync + read-through (see [Admin accounts](admin-accounts.md)).
-- `server/api/endpoints/shop_endpoints/stripe.py` — payment intents, subscription create/cancel.
+- `server/api/endpoints/shop_endpoints/stripe.py` — legacy payment intents, subscription create/cancel.
 - `server/api/endpoints/shop_endpoints/orders.py` — auto-creates a Stripe customer when a new account first appears in checkout.
+- `server/payments/stripe.py` — the `StripeProvider` behind the [provider-agnostic payments API](payments.md).
 
 ## Why module-level, not a `StripeClient` instance
 
@@ -35,6 +39,6 @@ The Stripe SDK supports both styles. The codebase has historically used the modu
 
 ## Known follow-ups
 
-- **No webhook handlers yet.** Payment / subscription state changes have to be reconciled via the admin sync endpoints. Adding a `/stripe/webhook` route is the next obvious step.
+- ~~**No webhook handlers yet.**~~ Resolved for payments: `POST /webhooks/payments/stripe/{shop_id}` verifies signed `payment_intent.*` events (see [Payments](payments.md)). Subscription events still have no webhook and are reconciled via the admin sync endpoints.
 - **`/shops/{shop_id}/stripe/*` routes are unauthenticated.** Public access is currently required by the frontend checkout flow; revisit once the checkout is reworked to carry a token.
-- **`shop_endpoints/stripe.py` swallows exceptions** with `except Exception: return e`, which then mishandles the response. Tracked separately.
+- **`shop_endpoints/stripe.py` swallows exceptions** with `except Exception: return e`, which then mishandles the response. Tracked separately. (The provider-based payments endpoints translate provider errors into proper `400`/`502` responses.)

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -22,7 +22,7 @@ The main tables and what they hold:
 |-------|---------|
 | `UserTable` | Authenticated users (email, username, password hash). |
 | `RoleTable` / `RoleUserTable` | Role definitions and user ↔ role links. |
-| `ShopTable` | Shops: name, config, Stripe keys, VAT rates, webhooks. |
+| `ShopTable` | Shops: name, config, payment provider + config, Stripe keys, VAT rates, webhooks. |
 | `ShopUserTable` | User ↔ shop links. |
 | `ProductTable` | Products: price, tax category, stock, image URLs 1–6, featured/new flags, optional recurring pricing. |
 | `ProductTranslationTable` | Per-language product name and description. |
@@ -33,6 +33,7 @@ The main tables and what they hold:
 | `AttributeOptionTable` | Values of an attribute (e.g. "Small", "Red"). |
 | `ProductAttributeValueTable` | Product-specific attribute assignments. |
 | `OrderTable` | Orders: customer order id, order info JSON, status, completion tracking. |
+| `PaymentTable` | Payment attempts at a PSP: provider, provider payment id, amount, normalized status, raw payload (see [Payments](../api/payments.md)). |
 | `Account` | Shop customer/vendor accounts (`hash_name` supports anonymisation). |
 | `License` | Recurring licence records. |
 | `EarlyAccessTable` | Early-access sign-ups. |
@@ -60,6 +61,7 @@ erDiagram
     ProductTable ||--o{ ProductAttributeValueTable : "has values"
     AttributeOptionTable ||--o{ ProductAttributeValueTable : "value of"
     OrderTable }o--|| Account : "belongs to"
+    OrderTable ||--o{ PaymentTable : "paid via"
 ```
 
 The diagram is illustrative — consult `server/db/models.py` for exact column definitions, nullability, and cascade rules.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -25,7 +25,8 @@ Almost every resource is scoped to a shop. Shop-scoped endpoints live under `/sh
 - `/shops/{shop_id}/attributes`
 - `/shops/{shop_id}/prices`
 - `/shops/{shop_id}/accounts`
-- `/shops/{shop_id}/stripe`
+- `/shops/{shop_id}/payments`
+- `/shops/{shop_id}/stripe` (legacy)
 - …
 
 See [Shop-scoped endpoints](../api/shop-scoped.md) for the pattern and the full list.
@@ -43,7 +44,7 @@ Four domain tables have companion translation tables that carry per-language nam
 
 ## External integrations
 
-- **Payments:** Stripe (`server/api/endpoints/shop_endpoints/stripe.py`).
+- **Payments:** pluggable providers — Mollie and Stripe (`server/payments/`, see [Payments](../api/payments.md)); legacy direct Stripe routes in `server/api/endpoints/shop_endpoints/stripe.py`.
 - **Auth:** AWS Cognito (`fastapi-cognito`) — see [Authentication](../api/authentication.md).
 - **Error tracking:** Sentry (`SentryAsgiMiddleware` in `server/main.py`).
 - **Email:** SMTP, configured via `SMTP_*` env vars; templates under `server/mail_templates/`.

--- a/migrations/versions/schema/2026-06-12_e7a1c9d2f3b4_add_payments_table_and_shop_payment_.py
+++ b/migrations/versions/schema/2026-06-12_e7a1c9d2f3b4_add_payments_table_and_shop_payment_.py
@@ -1,0 +1,77 @@
+"""add payments table and shop payment provider columns.
+
+Revision ID: e7a1c9d2f3b4
+Revises: c1a2b3d4e5f6
+Create Date: 2026-06-12 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from server.db.models import UtcTimestamp
+
+# revision identifiers, used by Alembic.
+revision = "e7a1c9d2f3b4"
+down_revision = "c1a2b3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "shops",
+        sa.Column("payment_provider", sa.String(length=32), server_default="stripe", nullable=False),
+    )
+    op.add_column(
+        "shops",
+        sa.Column("payment_config", postgresql.JSONB(), server_default="{}", nullable=False),
+    )
+    op.create_table(
+        "payments",
+        sa.Column(
+            "id",
+            sqlalchemy_utils.types.uuid.UUIDType(),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+        sa.Column("shop_id", sqlalchemy_utils.types.uuid.UUIDType(), nullable=False),
+        sa.Column("order_id", sqlalchemy_utils.types.uuid.UUIDType(), nullable=False),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("provider_payment_id", sa.String(length=255), nullable=True),
+        sa.Column("amount", sa.Numeric(12, 2), nullable=False),
+        sa.Column("currency", sa.String(length=3), server_default="EUR", nullable=False),
+        sa.Column("status", sa.String(length=16), server_default="created", nullable=False),
+        sa.Column("raw", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            UtcTimestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=True,
+        ),
+        sa.Column(
+            "modified_at",
+            UtcTimestamp(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(["shop_id"], ["shops.id"]),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_payments_id"), "payments", ["id"], unique=False)
+    op.create_index(op.f("ix_payments_shop_id"), "payments", ["shop_id"], unique=False)
+    op.create_index(op.f("ix_payments_order_id"), "payments", ["order_id"], unique=False)
+    op.create_index(op.f("ix_payments_provider_payment_id"), "payments", ["provider_payment_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_payments_provider_payment_id"), table_name="payments")
+    op.drop_index(op.f("ix_payments_order_id"), table_name="payments")
+    op.drop_index(op.f("ix_payments_shop_id"), table_name="payments")
+    op.drop_index(op.f("ix_payments_id"), table_name="payments")
+    op.drop_table("payments")
+    op.drop_column("shops", "payment_config")
+    op.drop_column("shops", "payment_provider")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
       - Authentication: api/authentication.md
       - MCP server: api/mcp.md
       - Admin accounts: api/admin-accounts.md
+      - Payments: api/payments.md
       - Stripe: api/stripe.md
       - Email notifications: api/email-notifications.md
   - Development:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,6 +30,7 @@ pydantic-settings>=2.5.2
 python-multipart==0.0.12
 wheel
 stripe==10.7.0
+mollie-api-python==4.0.0
 phonenumbers==8.13.45
 pydantic_extra_types==2.9.0
 httpx

--- a/server/api/api.py
+++ b/server/api/api.py
@@ -32,6 +32,7 @@ from server.api.endpoints import (
     shops,
     test_forms,
     users,
+    webhooks,
 )
 from server.api.endpoints.shop_endpoints import (
     accounts,
@@ -42,6 +43,7 @@ from server.api.endpoints.shop_endpoints import (
     category_images,
     info_request,
     orders,
+    payments,
     prices,
     product_attribute_values,
     products,
@@ -193,6 +195,18 @@ api_router.include_router(
     prefix="/shops/{shop_id}/stripe",
     tags=["stripe"],
     # dependencies=[Depends(deps.get_current_active_superuser)],
+)
+# Provider-agnostic checkout payments; deprecates the /stripe routes above.
+api_router.include_router(
+    payments.router,
+    prefix="/shops/{shop_id}/payments",
+    tags=["payments"],
+)
+# Public PSP webhooks (Mollie, Stripe); verification happens per provider.
+api_router.include_router(
+    webhooks.router,
+    prefix="/webhooks/payments",
+    tags=["payments", "webhooks"],
 )
 
 api_router.include_router(

--- a/server/api/endpoints/shop_endpoints/orders.py
+++ b/server/api/endpoints/shop_endpoints/orders.py
@@ -15,25 +15,22 @@ from starlette.responses import Response
 from server.api import deps
 from server.api.deps import common_parameters
 from server.api.error_handling import raise_status
-from server.api.helpers import _query_with_filters, invalidateCompletedOrdersCache, invalidatePendingOrdersCache, load
+from server.api.helpers import invalidateCompletedOrdersCache, invalidatePendingOrdersCache
 from server.api.utils import is_ip_allowed, validate_uuid4
 from server.crud.crud_account import account_crud
 from server.crud.crud_order import order_crud
 from server.crud.crud_product import product_crud
 from server.crud.crud_shop import shop_crud
-from server.db.models import Account, OrderTable, ShopTable, UserTable
-from server.mail import send_order_confirmation_emails
-from server.schemas import ProductUpdate
+from server.db.models import Account, OrderTable, UserTable
 from server.schemas.account import AccountCreate
 from server.schemas.base import quantize_money
 from server.schemas.order import OrderBase, OrderCreate, OrderCreated, OrderSchema, OrderUpdate, OrderUpdated
 from server.schemas.product import ProductTranslationBase
 from server.security import auth_required
 from server.services import stripe_client
+from server.services.order_lifecycle import deduct_stock_for_order, notify_order_complete
 from server.services.shipping import compute_shipping_for_cart
 from server.services.stripe_client import StripeNotConfigured
-from server.settings import mail_settings
-from server.utils.discord.discord import post_discord_order_complete
 
 logger = structlog.get_logger(__name__)
 
@@ -387,55 +384,10 @@ def patch(
 
     # The following is fixed by the early exit from before `order.status == item_in.status`:
     # `item_in.status == "complete"` is not enough because it doesn't account for the order's current status, this means that the stock gets updated even though the order might not have been changed
-    if shop.config["toggles"]["enable_stock_on_products"] and item_in.status == "complete":
-        for order_product in order.order_info:
-            product = product_crud.get_id_by_shop_id(shop_id, order_product["product_id"])
-
-            logger.info(
-                f"Updating stock for order {product.id} , old stock: {product.stock}, new stock: {product.stock - order_product['quantity']}"
-            )
-
-            new_product = ProductUpdate(
-                shop_id=product.shop_id,
-                category_id=product.category_id,
-                max_one=product.max_one,
-                shippable=product.shippable,
-                featured=product.featured,
-                new_product=product.new_product,
-                tax_category=product.tax_category,
-                stock=product.stock - order_product["quantity"],
-                translation=product.translation,
-                image_1=product.image_1,
-                image_2=product.image_2,
-                image_3=product.image_3,
-                image_4=product.image_4,
-                image_5=product.image_5,
-                image_6=product.image_6,
-            )
-            product_crud.update(db_obj=product, obj_in=new_product)
-
-    # Fetch account once for Discord and email notifications
-    account = account_crud.get(updated_order.account_id) if updated_order.account_id else None
-
-    try:
-        shop = load(ShopTable, updated_order.shop_id)
-        if shop.discord_webhook is not None and account:
-            post_discord_order_complete(
-                f"New order from {account.name}",
-                botname=shop.name,
-                webhook=shop.discord_webhook,
-                order=updated_order,
-                email=account.name,
-            )
-    except Exception as e:
-        logger.error("Failed to post to Discord: ", error=str(e))
-
-    # Send order confirmation emails
-    if mail_settings.SHOP_MAIL_ENABLED and item_in.status == "complete" and account:
-        try:
-            send_order_confirmation_emails(order=order, shop=shop, account=account)
-        except Exception as e:
-            logger.error("Failed to send order confirmation email", error=str(e))
+    if item_in.status == "complete":
+        deduct_stock_for_order(order, shop)
+        account = account_crud.get(updated_order.account_id) if updated_order.account_id else None
+        notify_order_complete(order, shop, account)
 
     invalidateCompletedOrdersCache(updated_order.id)
     return updated_order

--- a/server/api/endpoints/shop_endpoints/payments.py
+++ b/server/api/endpoints/shop_endpoints/payments.py
@@ -1,0 +1,128 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Provider-agnostic checkout payments.
+
+The frontend never talks to a PSP-specific endpoint: it POSTs an order id
+here, gets back a :class:`PaymentSessionSchema` telling it what to do
+(redirect vs in-page confirmation), and polls the GET endpoint after the
+customer returns. Order completion itself is driven by webhooks (or the
+poll-time sync fallback) — never by the frontend.
+"""
+
+from http import HTTPStatus
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, HTTPException
+from fastapi.param_functions import Body
+
+from server.api.error_handling import raise_status
+from server.crud.crud_order import order_crud
+from server.crud.crud_payment import payment_crud
+from server.crud.crud_shop import shop_crud
+from server.db import db
+from server.payments.base import PaymentProviderError, PaymentProviderNotConfigured, PaymentStatus
+from server.payments.processing import apply_payment_event
+from server.payments.registry import get_provider
+from server.schemas.payment import PaymentCreate, PaymentSessionSchema, PaymentStatusSchema
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+@router.post("/", response_model=PaymentSessionSchema, status_code=HTTPStatus.CREATED)
+def create_payment(shop_id: UUID, data: PaymentCreate = Body(...)) -> PaymentSessionSchema:
+    shop = shop_crud.get(shop_id)
+    if not shop:
+        raise_status(HTTPStatus.NOT_FOUND, f"Shop with id {shop_id} not found")
+
+    order = order_crud.get(data.order_id)
+    if not order or order.shop_id != shop_id:
+        raise_status(HTTPStatus.NOT_FOUND, f"Order with id {data.order_id} not found")
+    if order.status != "pending":
+        raise_status(HTTPStatus.CONFLICT, f"ORDER_NOT_PAYABLE: order status is '{order.status}'")
+
+    try:
+        provider = get_provider(shop)
+    except PaymentProviderNotConfigured as e:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))
+
+    payment = payment_crud.create_for_order(order=order, provider=provider.id)
+    try:
+        session = provider.create_payment(shop=shop, order=order, payment=payment, return_url=data.return_url)
+    except PaymentProviderNotConfigured as e:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.error(
+            "Payment creation failed at provider",
+            provider=provider.id,
+            payment_id=str(payment.id),
+            error=str(e),
+        )
+        payment.status = PaymentStatus.FAILED.value
+        db.session.add(payment)
+        db.session.commit()
+        raise HTTPException(status_code=HTTPStatus.BAD_GATEWAY, detail="PAYMENT_PROVIDER_ERROR")
+
+    payment.provider_payment_id = session.provider_payment_id
+    payment.status = session.status.value
+    payment.raw = session.raw
+    db.session.add(payment)
+    db.session.commit()
+
+    return PaymentSessionSchema(
+        payment_id=payment.id,
+        order_id=order.id,
+        provider=provider.id,
+        status=payment.status,
+        amount=payment.amount,
+        currency=payment.currency,
+        flow=session.flow,
+        redirect_url=session.redirect_url,
+        client_secret=session.client_secret,
+        publishable_key=session.publishable_key,
+    )
+
+
+@router.get("/{payment_id}", response_model=PaymentStatusSchema)
+def get_payment(shop_id: UUID, payment_id: UUID) -> PaymentStatusSchema:
+    """Current payment status, freshly synced from the provider.
+
+    The sync makes this endpoint double as the webhook fallback: when the
+    customer lands on the return page before (or without) a webhook arriving,
+    polling here still moves the payment — and on 'paid', the order — forward.
+    """
+    payment = payment_crud.get_id_by_shop_id(shop_id, payment_id)
+    if not payment:
+        raise_status(HTTPStatus.NOT_FOUND, f"Payment with id {payment_id} not found")
+    shop = shop_crud.get(shop_id)
+
+    current_status = PaymentStatus(payment.status)
+    if payment.provider_payment_id and not current_status.is_terminal:
+        try:
+            provider = get_provider(shop, payment.provider)
+            event = provider.get_status(shop=shop, provider_payment_id=payment.provider_payment_id)
+            payment = apply_payment_event(payment=payment, event=event, shop=shop)
+        except PaymentProviderError as e:
+            # Return the stored status rather than failing the poll.
+            logger.warning("Payment status sync failed", payment_id=str(payment.id), error=str(e))
+
+    order = order_crud.get(payment.order_id)
+    return PaymentStatusSchema(
+        payment_id=payment.id,
+        order_id=payment.order_id,
+        provider=payment.provider,
+        status=payment.status,
+        order_status=order.status if order else "unknown",
+    )

--- a/server/api/endpoints/webhooks.py
+++ b/server/api/endpoints/webhooks.py
@@ -1,0 +1,70 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Public payment webhooks, one route per (provider, shop).
+
+Unauthenticated by necessity — PSPs call these. Safety comes from each
+provider's own verification: Mollie events are confirmed by fetching the
+payment back from the Mollie API; Stripe events must carry a valid signature.
+Order completion happens here (via ``apply_payment_event``), making the
+backend — not the frontend — the authority on whether an order was paid.
+"""
+
+from http import HTTPStatus
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, HTTPException, Request
+
+from server.crud.crud_payment import payment_crud
+from server.crud.crud_shop import shop_crud
+from server.payments.base import PaymentProviderNotConfigured, PaymentWebhookInvalid
+from server.payments.processing import apply_payment_event
+from server.payments.registry import get_provider
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+@router.post("/{provider_id}/{shop_id}")
+async def payment_webhook(provider_id: str, shop_id: UUID, request: Request) -> dict:
+    shop = shop_crud.get(shop_id)
+    if not shop:
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Shop not found")
+
+    try:
+        provider = get_provider(shop, provider_id)
+    except PaymentProviderNotConfigured:
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Unknown payment provider")
+
+    try:
+        event = await provider.handle_webhook(shop=shop, request=request)
+    except PaymentWebhookInvalid as e:
+        logger.warning("Rejected payment webhook", provider=provider_id, shop_id=str(shop_id), error=str(e))
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Invalid webhook")
+    except PaymentProviderNotConfigured as e:
+        logger.warning("Webhook for unconfigured provider", provider=provider_id, shop_id=str(shop_id), error=str(e))
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))
+
+    if event is None:
+        # Verified but not something we act on (e.g. unhandled Stripe event type).
+        return {"status": "ignored"}
+
+    payment = payment_crud.get_by_provider_payment_id(shop_id=shop_id, provider_payment_id=event.provider_payment_id)
+    if not payment:
+        # Unknown payment id: 404 so the PSP retries later (or gives up) —
+        # this can happen if a webhook outraces our own commit.
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Payment not found")
+
+    apply_payment_event(payment=payment, event=event, shop=shop)
+    return {"status": "ok"}

--- a/server/crud/crud_payment.py
+++ b/server/crud/crud_payment.py
@@ -1,0 +1,49 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Optional
+from uuid import UUID
+
+from server.crud.base import CRUDBase
+from server.db import db
+from server.db.models import OrderTable, PaymentTable
+from server.schemas.payment import PaymentCreate
+
+
+class CRUDPayment(CRUDBase[PaymentTable, PaymentCreate, PaymentCreate]):
+    def create_for_order(self, *, order: OrderTable, provider: str, currency: str = "EUR") -> PaymentTable:
+        """Persist a new payment attempt for an order, amount taken from the order."""
+        payment = PaymentTable(
+            shop_id=order.shop_id,
+            order_id=order.id,
+            provider=provider,
+            amount=order.total,
+            currency=currency,
+            status="created",
+        )
+        db.session.add(payment)
+        db.session.commit()
+        db.session.refresh(payment)
+        return payment
+
+    def get_by_provider_payment_id(self, *, shop_id: UUID, provider_payment_id: str) -> Optional[PaymentTable]:
+        return (
+            db.session.query(PaymentTable)
+            .filter(
+                PaymentTable.shop_id == shop_id,
+                PaymentTable.provider_payment_id == provider_payment_id,
+            )
+            .first()
+        )
+
+
+payment_crud = CRUDPayment(PaymentTable)

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -175,6 +175,12 @@ class ShopTable(BaseModel):
     config_version = Column(Integer, nullable=False, server_default="1")
     stripe_secret_key = Column(String(255), nullable=True)
     stripe_public_key = Column(String(255), nullable=True)
+    # Which payment provider handles checkout for this shop ("stripe", "mollie").
+    # Provider-specific credentials live in payment_config, keyed by provider id,
+    # e.g. {"mollie": {"api_key": "live_..."}}. The legacy stripe_* columns above
+    # remain the source of truth for the stripe provider.
+    payment_provider = Column(String(32), nullable=False, server_default="stripe")
+    payment_config = Column(postgresql.JSONB(), nullable=False, server_default="{}")
     vat_standard = Column(Numeric(5, 2), default=Decimal("21.00"))
     vat_lower_1 = Column(Numeric(5, 2), default=Decimal("10.00"))
     vat_lower_2 = Column(Numeric(5, 2), default=Decimal("5.00"))
@@ -317,6 +323,45 @@ class OrderTable(BaseModel):
 
     def __repr__(self):
         return "<Order for shop: %s with total: %s>" % (self.shop.name, self.total)
+
+
+class PaymentTable(BaseModel):
+    """A payment attempt for an order at an external payment provider.
+
+    Orders and payments are deliberately separate: one order can have several
+    payment attempts (e.g. a failed iDEAL payment followed by a successful
+    retry creates two rows). ``status`` follows the normalized lifecycle from
+    ``server.payments.base.PaymentStatus``; provider-native payloads are kept
+    verbatim in ``raw`` for debugging/auditing.
+    """
+
+    __tablename__ = "payments"
+    id = Column(
+        UUIDType,
+        server_default=text("uuid_generate_v4()"),
+        primary_key=True,
+        index=True,
+    )
+    shop_id = Column(UUIDType, ForeignKey("shops.id"), nullable=False, index=True)
+    order_id = Column(UUIDType, ForeignKey("orders.id", ondelete="CASCADE"), nullable=False, index=True)
+    provider = Column(String(32), nullable=False)
+    provider_payment_id = Column(String(255), nullable=True, index=True)
+    amount = Column(Numeric(12, 2), nullable=False)
+    currency = Column(String(3), nullable=False, server_default="EUR")
+    status = Column(String(16), nullable=False, server_default="created")
+    raw = Column(postgresql.JSONB(), nullable=True)
+    created_at = Column(UtcTimestamp, server_default=text("CURRENT_TIMESTAMP"))
+    modified_at = Column(
+        UtcTimestamp,
+        server_default=text("CURRENT_TIMESTAMP"),
+        server_onupdate=text("CURRENT_TIMESTAMP"),
+    )
+
+    shop = relationship("ShopTable", lazy=True)
+    order = relationship("OrderTable", backref=backref("payments", uselist=True))
+
+    def __repr__(self):
+        return f"<Payment {self.provider}:{self.provider_payment_id} {self.status} for order {self.order_id}>"
 
 
 class ProductTable(BaseModel):

--- a/server/main.py
+++ b/server/main.py
@@ -74,7 +74,7 @@ async def lifespan(app_: FastAPI):
         yield
 
 
-APP_VERSION = "0.3.2"
+APP_VERSION = "0.4.0"
 
 # Assigned after the api_router is included if MCP_ENABLED. The lifespan
 # closure above references it.

--- a/server/payments/__init__.py
+++ b/server/payments/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pluggable payment providers.
+
+A provider turns a (shop, order) pair into a normalized ``PaymentSession``
+the frontend can act on without knowing which PSP is behind it, and turns
+provider webhooks/polls into normalized ``PaymentEvent``s that drive the
+order lifecycle. Select a provider per shop via ``ShopTable.payment_provider``
+and resolve it with :func:`server.payments.registry.get_provider`.
+"""

--- a/server/payments/base.py
+++ b/server/payments/base.py
@@ -1,0 +1,111 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Payment provider interface and the normalized objects providers speak in."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Literal, Optional
+
+from fastapi import Request
+
+from server.db.models import OrderTable, PaymentTable, ShopTable
+
+
+class PaymentProviderError(Exception):
+    """Base for everything a provider can raise; endpoints map it to HTTP errors."""
+
+
+class PaymentProviderNotConfigured(PaymentProviderError):
+    """The shop lacks the credentials/config needed by the selected provider."""
+
+
+class PaymentWebhookInvalid(PaymentProviderError):
+    """The webhook request failed verification (bad signature, garbled payload)."""
+
+
+class PaymentStatus(str, Enum):
+    """Normalized payment lifecycle every provider's native statuses map onto."""
+
+    CREATED = "created"
+    PENDING = "pending"
+    PAID = "paid"
+    FAILED = "failed"
+    CANCELED = "canceled"
+    EXPIRED = "expired"
+
+    @property
+    def is_terminal(self) -> bool:
+        return self in (PaymentStatus.PAID, PaymentStatus.FAILED, PaymentStatus.CANCELED, PaymentStatus.EXPIRED)
+
+
+PaymentFlow = Literal["redirect", "client_confirmation"]
+
+
+@dataclass
+class PaymentSession:
+    """What the frontend needs to take a freshly created payment further.
+
+    ``flow`` tells it how: ``redirect`` means send the browser to
+    ``redirect_url`` (hosted checkout — Mollie); ``client_confirmation`` means
+    confirm in-page with ``client_secret``/``publishable_key`` (Stripe
+    Elements).
+    """
+
+    provider_payment_id: str
+    status: PaymentStatus
+    flow: PaymentFlow
+    redirect_url: Optional[str] = None
+    client_secret: Optional[str] = None
+    publishable_key: Optional[str] = None
+    raw: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class PaymentEvent:
+    """A verified, normalized status report about one provider payment."""
+
+    provider_payment_id: str
+    status: PaymentStatus
+    raw: Optional[Dict[str, Any]] = None
+
+
+class PaymentProvider(ABC):
+    """One PSP integration. Stateless: per-shop credentials are resolved per call."""
+
+    id: str
+
+    @abstractmethod
+    def create_payment(
+        self, *, shop: ShopTable, order: OrderTable, payment: PaymentTable, return_url: str
+    ) -> PaymentSession:
+        """Create the payment at the PSP for ``order.total``.
+
+        ``payment`` is our already-persisted PaymentTable row; providers put
+        its id (and the order id) in PSP metadata so webhooks can be matched
+        back. Raises :class:`PaymentProviderNotConfigured` when the shop has
+        no usable credentials.
+        """
+
+    @abstractmethod
+    async def handle_webhook(self, *, shop: ShopTable, request: Request) -> Optional[PaymentEvent]:
+        """Verify an incoming webhook and normalize it.
+
+        Returns ``None`` for events that are valid but irrelevant (e.g. a
+        Stripe event type we don't act on). Raises
+        :class:`PaymentWebhookInvalid` when verification fails.
+        """
+
+    @abstractmethod
+    def get_status(self, *, shop: ShopTable, provider_payment_id: str) -> PaymentEvent:
+        """Fetch the current status from the PSP (poll-time sync / webhook fallback)."""

--- a/server/payments/mollie.py
+++ b/server/payments/mollie.py
@@ -1,0 +1,115 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Mollie payment provider (hosted checkout, redirect flow).
+
+Shop config lives in ``shop.payment_config["mollie"]``:
+
+    {"mollie": {"api_key": "live_..."}}
+
+Mollie webhooks are unsigned by design: the webhook body only carries the
+payment id, and verification consists of fetching that payment back from the
+Mollie API with the shop's key and trusting only the API response.
+"""
+
+from decimal import Decimal
+from typing import Optional
+
+import structlog
+from fastapi import Request
+from mollie.api.client import Client
+
+from server.db.models import OrderTable, PaymentTable, ShopTable
+from server.payments.base import (
+    PaymentEvent,
+    PaymentProvider,
+    PaymentProviderNotConfigured,
+    PaymentSession,
+    PaymentStatus,
+    PaymentWebhookInvalid,
+)
+from server.settings import app_settings
+
+logger = structlog.get_logger(__name__)
+
+# https://docs.mollie.com/payments/status-changes
+MOLLIE_STATUS_MAP = {
+    "open": PaymentStatus.PENDING,
+    "pending": PaymentStatus.PENDING,
+    "authorized": PaymentStatus.PENDING,
+    "paid": PaymentStatus.PAID,
+    "failed": PaymentStatus.FAILED,
+    "canceled": PaymentStatus.CANCELED,
+    "expired": PaymentStatus.EXPIRED,
+}
+
+
+class MollieProvider(PaymentProvider):
+    id = "mollie"
+
+    def _get_client(self, shop: ShopTable) -> Client:
+        api_key = ((shop.payment_config or {}).get("mollie") or {}).get("api_key")
+        if not api_key:
+            raise PaymentProviderNotConfigured(
+                f"Shop {shop.id} has no Mollie api_key in payment_config['mollie']['api_key']"
+            )
+        client = Client()
+        client.set_api_key(api_key)
+        return client
+
+    def _webhook_url(self, shop: ShopTable) -> Optional[str]:
+        base = app_settings.PUBLIC_BASE_URL.rstrip("/")
+        if "localhost" in base or "127.0.0.1" in base:
+            # Mollie refuses non-public webhook URLs. In local dev the
+            # poll-time sync in GET /payments/{id} keeps statuses moving.
+            return None
+        return f"{base}/webhooks/payments/{self.id}/{shop.id}"
+
+    def create_payment(
+        self, *, shop: ShopTable, order: OrderTable, payment: PaymentTable, return_url: str
+    ) -> PaymentSession:
+        client = self._get_client(shop)
+        payload = {
+            "amount": {"currency": payment.currency, "value": f"{Decimal(payment.amount):.2f}"},
+            "description": f"Order #{order.customer_order_id} - {shop.name}",
+            "redirectUrl": return_url,
+            "metadata": {"order_id": str(order.id), "payment_id": str(payment.id)},
+        }
+        webhook_url = self._webhook_url(shop)
+        if webhook_url:
+            payload["webhookUrl"] = webhook_url
+
+        mollie_payment = client.payments.create(payload)
+        return PaymentSession(
+            provider_payment_id=mollie_payment.id,
+            status=MOLLIE_STATUS_MAP.get(mollie_payment.status, PaymentStatus.PENDING),
+            flow="redirect",
+            redirect_url=mollie_payment.checkout_url,
+            raw=dict(mollie_payment),
+        )
+
+    async def handle_webhook(self, *, shop: ShopTable, request: Request) -> Optional[PaymentEvent]:
+        form = await request.form()
+        provider_payment_id = form.get("id")
+        if not provider_payment_id or not str(provider_payment_id).startswith("tr_"):
+            raise PaymentWebhookInvalid("Mollie webhook without a payment id")
+        # Fetch-back is the verification — never trust the webhook body itself.
+        return self.get_status(shop=shop, provider_payment_id=str(provider_payment_id))
+
+    def get_status(self, *, shop: ShopTable, provider_payment_id: str) -> PaymentEvent:
+        client = self._get_client(shop)
+        mollie_payment = client.payments.get(provider_payment_id)
+        return PaymentEvent(
+            provider_payment_id=provider_payment_id,
+            status=MOLLIE_STATUS_MAP.get(mollie_payment.status, PaymentStatus.PENDING),
+            raw=dict(mollie_payment),
+        )

--- a/server/payments/processing.py
+++ b/server/payments/processing.py
@@ -1,0 +1,58 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Apply normalized payment events to our payment + order state.
+
+This is the single funnel between providers and the order lifecycle: both
+webhook delivery and poll-time status sync end up here, so completion
+semantics (idempotency included) exist exactly once.
+"""
+
+import structlog
+
+from server.db import db
+from server.db.models import OrderTable, PaymentTable, ShopTable
+from server.payments.base import PaymentEvent, PaymentStatus
+from server.services.order_lifecycle import complete_order
+
+logger = structlog.get_logger(__name__)
+
+
+def apply_payment_event(*, payment: PaymentTable, event: PaymentEvent, shop: ShopTable) -> PaymentTable:
+    """Persist a payment status change and complete the order when paid.
+
+    Idempotent: replays of the same event (Mollie retries webhooks) find the
+    payment already in its target status and the order already complete.
+    """
+    old_status = payment.status
+    payment.status = event.status.value
+    if event.raw is not None:
+        payment.raw = event.raw
+    db.session.add(payment)
+    db.session.commit()
+
+    if old_status != payment.status:
+        logger.info(
+            "Payment status changed",
+            payment_id=str(payment.id),
+            provider=payment.provider,
+            provider_payment_id=payment.provider_payment_id,
+            old_status=old_status,
+            new_status=payment.status,
+        )
+
+    if event.status == PaymentStatus.PAID:
+        order = db.session.get(OrderTable, payment.order_id)
+        if order is not None:
+            complete_order(order, shop)
+
+    return payment

--- a/server/payments/registry.py
+++ b/server/payments/registry.py
@@ -1,0 +1,37 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Resolve the payment provider for a shop."""
+
+from typing import Dict, Optional
+
+from server.db.models import ShopTable
+from server.payments.base import PaymentProvider, PaymentProviderNotConfigured
+from server.payments.mollie import MollieProvider
+from server.payments.stripe import StripeProvider
+
+PROVIDERS: Dict[str, PaymentProvider] = {provider.id: provider for provider in (StripeProvider(), MollieProvider())}
+
+
+def get_provider(shop: ShopTable, provider_id: Optional[str] = None) -> PaymentProvider:
+    """Return the provider for ``shop``, or the explicitly named one.
+
+    ``provider_id`` is used by webhook routes, where the provider is part of
+    the URL and must not depend on the shop's (possibly since-changed)
+    configuration. Raises :class:`PaymentProviderNotConfigured` for unknown
+    provider names; credential errors surface later, on first provider call.
+    """
+    name = provider_id or getattr(shop, "payment_provider", None) or "stripe"
+    provider = PROVIDERS.get(name)
+    if provider is None:
+        raise PaymentProviderNotConfigured(f"Unknown payment provider '{name}'")
+    return provider

--- a/server/payments/stripe.py
+++ b/server/payments/stripe.py
@@ -1,0 +1,131 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Stripe payment provider (PaymentIntents, in-page confirmation flow).
+
+Credentials come from the legacy per-shop columns ``stripe_secret_key`` /
+``stripe_public_key`` (kept for backwards compatibility). The optional
+webhook signing secret lives in ``shop.payment_config["stripe"]["webhook_secret"]``.
+"""
+
+from decimal import Decimal
+from typing import Optional
+
+import stripe as stripe_sdk
+import structlog
+from fastapi import Request
+
+from server.crud.crud_account import account_crud
+from server.db.models import OrderTable, PaymentTable, ShopTable
+from server.payments.base import (
+    PaymentEvent,
+    PaymentProvider,
+    PaymentProviderNotConfigured,
+    PaymentSession,
+    PaymentStatus,
+    PaymentWebhookInvalid,
+)
+from server.services import stripe_client
+from server.services.stripe_client import StripeCustomerMissing, StripeNotConfigured
+
+logger = structlog.get_logger(__name__)
+
+# https://docs.stripe.com/payments/paymentintents/lifecycle
+STRIPE_INTENT_STATUS_MAP = {
+    "requires_payment_method": PaymentStatus.PENDING,
+    "requires_confirmation": PaymentStatus.PENDING,
+    "requires_action": PaymentStatus.PENDING,
+    "processing": PaymentStatus.PENDING,
+    "requires_capture": PaymentStatus.PENDING,
+    "succeeded": PaymentStatus.PAID,
+    "canceled": PaymentStatus.CANCELED,
+}
+
+STRIPE_EVENT_STATUS_MAP = {
+    "payment_intent.succeeded": PaymentStatus.PAID,
+    "payment_intent.payment_failed": PaymentStatus.FAILED,
+    "payment_intent.canceled": PaymentStatus.CANCELED,
+}
+
+
+class StripeProvider(PaymentProvider):
+    id = "stripe"
+
+    def _configure(self, shop: ShopTable) -> None:
+        try:
+            stripe_client.configure_for_shop(shop)
+        except StripeNotConfigured as e:
+            raise PaymentProviderNotConfigured(str(e)) from e
+
+    def create_payment(
+        self, *, shop: ShopTable, order: OrderTable, payment: PaymentTable, return_url: str
+    ) -> PaymentSession:
+        self._configure(shop)
+
+        kwargs = {
+            "amount": int(Decimal(payment.amount) * 100),
+            "currency": payment.currency.lower(),
+            "payment_method_types": ["card", "ideal"],
+            "metadata": {"order_id": str(order.id), "payment_id": str(payment.id)},
+        }
+        account = account_crud.get(order.account_id) if order.account_id else None
+        try:
+            kwargs["customer"] = stripe_client.get_customer_id(account)
+            kwargs["setup_future_usage"] = "off_session"
+        except StripeCustomerMissing:
+            # Guest checkout / account never linked to Stripe: a one-off
+            # intent without a customer works fine.
+            pass
+
+        intent = stripe_sdk.PaymentIntent.create(**kwargs)
+        return PaymentSession(
+            provider_payment_id=intent["id"],
+            status=STRIPE_INTENT_STATUS_MAP.get(intent["status"], PaymentStatus.PENDING),
+            flow="client_confirmation",
+            client_secret=intent["client_secret"],
+            publishable_key=shop.stripe_public_key,
+            raw={"id": intent["id"], "status": intent["status"]},
+        )
+
+    async def handle_webhook(self, *, shop: ShopTable, request: Request) -> Optional[PaymentEvent]:
+        webhook_secret = ((shop.payment_config or {}).get("stripe") or {}).get("webhook_secret")
+        if not webhook_secret:
+            raise PaymentProviderNotConfigured(
+                f"Shop {shop.id} has no Stripe webhook secret in payment_config['stripe']['webhook_secret']"
+            )
+
+        payload = await request.body()
+        signature = request.headers.get("stripe-signature", "")
+        try:
+            event = stripe_sdk.Webhook.construct_event(payload, signature, webhook_secret)
+        except (ValueError, stripe_sdk.error.SignatureVerificationError) as e:
+            raise PaymentWebhookInvalid(str(e)) from e
+
+        status = STRIPE_EVENT_STATUS_MAP.get(event["type"])
+        if status is None:
+            return None
+
+        intent = event["data"]["object"]
+        return PaymentEvent(
+            provider_payment_id=intent["id"],
+            status=status,
+            raw={"id": intent["id"], "status": intent["status"], "event_type": event["type"]},
+        )
+
+    def get_status(self, *, shop: ShopTable, provider_payment_id: str) -> PaymentEvent:
+        self._configure(shop)
+        intent = stripe_sdk.PaymentIntent.retrieve(provider_payment_id)
+        return PaymentEvent(
+            provider_payment_id=provider_payment_id,
+            status=STRIPE_INTENT_STATUS_MAP.get(intent["status"], PaymentStatus.PENDING),
+            raw={"id": intent["id"], "status": intent["status"]},
+        )

--- a/server/schemas/payment.py
+++ b/server/schemas/payment.py
@@ -1,0 +1,46 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Literal, Optional
+from uuid import UUID
+
+from server.schemas.base import BoilerplateBaseModel, Money
+
+
+class PaymentCreate(BoilerplateBaseModel):
+    order_id: UUID
+    # Where the PSP (or the frontend itself) sends the browser after the
+    # payment attempt — typically the shop's /checkout/return page.
+    return_url: str
+
+
+class PaymentSessionSchema(BoilerplateBaseModel):
+    """Provider-agnostic 'what to do next' answer for a created payment."""
+
+    payment_id: UUID
+    order_id: UUID
+    provider: str
+    status: str
+    amount: Money
+    currency: str
+    flow: Literal["redirect", "client_confirmation"]
+    redirect_url: Optional[str] = None
+    client_secret: Optional[str] = None
+    publishable_key: Optional[str] = None
+
+
+class PaymentStatusSchema(BoilerplateBaseModel):
+    payment_id: UUID
+    order_id: UUID
+    provider: str
+    status: str
+    order_status: str

--- a/server/services/order_lifecycle.py
+++ b/server/services/order_lifecycle.py
@@ -1,0 +1,127 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Order completion lifecycle, shared by order endpoints and payment webhooks.
+
+Completing an order has side effects (stock deduction, Discord ping,
+confirmation emails, cache invalidation) that historically lived inline in the
+orders PATCH endpoint. Payment webhooks need the exact same behavior, so the
+logic lives here. ``complete_order`` is idempotent: payment providers retry
+webhooks, and during the migration period a legacy frontend may still PATCH
+the order to complete — whichever arrives second is a no-op.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+import structlog
+
+from server.crud.crud_account import account_crud
+from server.crud.crud_product import product_crud
+from server.db import db
+from server.db.models import Account, OrderTable, ShopTable
+from server.mail import send_order_confirmation_emails
+from server.schemas import ProductUpdate
+from server.settings import mail_settings
+from server.utils.discord.discord import post_discord_order_complete
+
+logger = structlog.get_logger(__name__)
+
+
+def deduct_stock_for_order(order: OrderTable, shop: ShopTable) -> None:
+    """Decrease product stock for every order line, if the shop tracks stock."""
+    # Older shop rows may carry a JSON string or empty config instead of a dict.
+    config = shop.config if isinstance(shop.config, dict) else {}
+    toggles = config.get("toggles") or {}
+    if not toggles.get("enable_stock_on_products"):
+        return
+
+    for order_product in order.order_info:
+        product = product_crud.get_id_by_shop_id(shop.id, order_product["product_id"])
+
+        logger.info(
+            f"Updating stock for order {product.id} , old stock: {product.stock}, new stock: {product.stock - order_product['quantity']}"
+        )
+
+        new_product = ProductUpdate(
+            shop_id=product.shop_id,
+            category_id=product.category_id,
+            max_one=product.max_one,
+            shippable=product.shippable,
+            featured=product.featured,
+            new_product=product.new_product,
+            tax_category=product.tax_category,
+            stock=product.stock - order_product["quantity"],
+            translation=product.translation,
+            image_1=product.image_1,
+            image_2=product.image_2,
+            image_3=product.image_3,
+            image_4=product.image_4,
+            image_5=product.image_5,
+            image_6=product.image_6,
+        )
+        product_crud.update(db_obj=product, obj_in=new_product)
+
+
+def notify_order_complete(order: OrderTable, shop: ShopTable, account: Optional[Account]) -> None:
+    """Best-effort notifications for a completed order: Discord + emails.
+
+    Failures are logged, never raised — a flaky Discord webhook or SMTP server
+    must not undo a successful payment.
+    """
+    if shop.discord_webhook is not None and account:
+        try:
+            post_discord_order_complete(
+                f"New order from {account.name}",
+                botname=shop.name,
+                webhook=shop.discord_webhook,
+                order=order,
+                email=account.name,
+            )
+        except Exception as e:
+            logger.error("Failed to post to Discord: ", error=str(e))
+
+    if mail_settings.SHOP_MAIL_ENABLED and account:
+        try:
+            send_order_confirmation_emails(order=order, shop=shop, account=account)
+        except Exception as e:
+            logger.error("Failed to send order confirmation email", error=str(e))
+
+
+def complete_order(order: OrderTable, shop: ShopTable) -> OrderTable:
+    """Idempotently transition an order to ``complete`` and run all side effects.
+
+    Returns the (possibly unchanged) order. Safe to call multiple times: an
+    order that is already complete is returned as-is, so retried webhooks and
+    a racing legacy status PATCH cannot double-deduct stock or double-mail.
+    """
+    if order.status == "complete":
+        logger.info("Order already complete, skipping", order_id=str(order.id))
+        return order
+
+    order.status = "complete"
+    if not order.completed_at:
+        order.completed_at = datetime.now()
+    db.session.add(order)
+    db.session.commit()
+
+    deduct_stock_for_order(order, shop)
+
+    account = account_crud.get(order.account_id) if order.account_id else None
+    notify_order_complete(order, shop, account)
+
+    # Imported here: server.api.helpers pulls in API-layer modules that in
+    # turn import services, so a module-level import would be circular.
+    from server.api.helpers import invalidateCompletedOrdersCache
+
+    invalidateCompletedOrdersCache(order.id)
+    return order

--- a/tests/unit_tests/api/test_authentication.py
+++ b/tests/unit_tests/api/test_authentication.py
@@ -16,6 +16,9 @@ EXCLUDED_ENDPOINTS = [
     {"path": "/orders/", "name": "create", "method": "POST"},
     {"path": "/shops/{shop_id}/stripe/", "name": "create_payment_intent", "method": "POST"},
     {"path": "/shops/{shop_id}/stripe/subscription", "name": "create_subscription_intent", "method": "POST"},
+    # Checkout payments are created by the (anonymous) storefront; order
+    # completion is driven by verified PSP webhooks, not by this endpoint.
+    {"path": "/shops/{shop_id}/payments/", "name": "create_payment", "method": "POST"},
     {"path": "/info-request/", "name": "create_info_request", "method": "POST"},
     {"path": "/sentry/", "name": "trigger_error", "method": "GET"},
     {"path": "/test-forms/", "name": "form", "method": "POST"},

--- a/tests/unit_tests/api/test_payments.py
+++ b/tests/unit_tests/api/test_payments.py
@@ -1,0 +1,282 @@
+"""Tests for the provider-agnostic payments API.
+
+The Mollie SDK is faked at the ``MollieProvider._get_client`` seam with
+objects built from the real ``mollie.api.objects.payment.Payment`` class, so
+the provider code is exercised against the SDK's actual object shape. Stripe
+is faked at the PaymentIntent level.
+"""
+
+from uuid import uuid4
+
+import pytest
+from mollie.api.objects.payment import Payment as MolliePayment
+
+from server.db import db
+from server.db.models import PaymentTable, ShopTable
+from server.payments.mollie import MollieProvider
+from tests.unit_tests.factories.account import make_account
+from tests.unit_tests.factories.order import make_pending_order
+from tests.unit_tests.factories.shop import make_shop
+
+CHECKOUT_URL = "https://www.mollie.com/checkout/select-method/test123"
+
+
+class FakeMolliePayments:
+    """Stand-in for ``client.payments`` backed by an in-memory dict."""
+
+    def __init__(self):
+        self.store = {}
+        self.created_payloads = []
+        self.counter = 0
+
+    def create(self, payload):
+        self.counter += 1
+        self.created_payloads.append(payload)
+        payment_id = f"tr_test{self.counter}"
+        data = {
+            "resource": "payment",
+            "id": payment_id,
+            "mode": "test",
+            "status": "open",
+            "amount": payload["amount"],
+            "description": payload["description"],
+            "metadata": payload.get("metadata"),
+            "redirectUrl": payload.get("redirectUrl"),
+            "webhookUrl": payload.get("webhookUrl"),
+            "_links": {"checkout": {"href": CHECKOUT_URL}},
+        }
+        self.store[payment_id] = data
+        return MolliePayment(data, None)
+
+    def get(self, payment_id):
+        return MolliePayment(self.store[payment_id], None)
+
+    def set_status(self, payment_id, status):
+        self.store[payment_id]["status"] = status
+
+
+class FakeMollieClient:
+    def __init__(self):
+        self.payments = FakeMolliePayments()
+
+
+@pytest.fixture()
+def fake_mollie(monkeypatch):
+    client = FakeMollieClient()
+    monkeypatch.setattr(MollieProvider, "_get_client", lambda self, shop: client)
+    return client
+
+
+@pytest.fixture()
+def mollie_shop():
+    shop_id = make_shop(with_config=False, random_shop_name=True)
+    shop = db.session.get(ShopTable, shop_id)
+    shop.payment_provider = "mollie"
+    shop.payment_config = {"mollie": {"api_key": "test_dummy_key"}}
+    db.session.commit()
+    return shop_id
+
+
+@pytest.fixture()
+def mollie_order(mollie_shop):
+    account_id = make_account(shop_id=mollie_shop, name="payments@test.local")
+    order = make_pending_order(
+        shop_id=mollie_shop,
+        account_id=account_id,
+        product_id_1=uuid4(),
+        product_id_2=uuid4(),
+        total=2.0,
+    )
+    return {"shop_id": mollie_shop, "order_id": order.id}
+
+
+def create_payment(test_client, shop_id, order_id, return_url="https://shop.test/checkout/return"):
+    return test_client.post(
+        f"/shops/{shop_id}/payments/",
+        json={"order_id": str(order_id), "return_url": return_url},
+    )
+
+
+def test_create_mollie_payment_returns_redirect_session(test_client, fake_mollie, mollie_order):
+    response = create_payment(test_client, mollie_order["shop_id"], mollie_order["order_id"])
+    assert response.status_code == 201, response.text
+    session = response.json()
+
+    assert session["provider"] == "mollie"
+    assert session["flow"] == "redirect"
+    assert session["redirect_url"] == CHECKOUT_URL
+    assert session["status"] == "pending"
+    assert session["client_secret"] is None
+    assert float(session["amount"]) == 2.0
+
+    # The amount is derived server-side from the order, never client input.
+    payload = fake_mollie.payments.created_payloads[0]
+    assert payload["amount"] == {"currency": "EUR", "value": "2.00"}
+    assert payload["redirectUrl"] == "https://shop.test/checkout/return"
+    # PUBLIC_BASE_URL is localhost in tests, so no webhookUrl is sent to Mollie.
+    assert "webhookUrl" not in payload
+
+    payment = db.session.get(PaymentTable, session["payment_id"])
+    assert payment.provider_payment_id == "tr_test1"
+    assert payment.status == "pending"
+    assert str(payment.order_id) == str(mollie_order["order_id"])
+
+
+def test_create_mollie_payment_includes_webhook_url_when_public(test_client, fake_mollie, mollie_order, monkeypatch):
+    from server.settings import app_settings
+
+    monkeypatch.setattr(app_settings, "PUBLIC_BASE_URL", "https://api.shopvirge.com")
+    response = create_payment(test_client, mollie_order["shop_id"], mollie_order["order_id"])
+    assert response.status_code == 201, response.text
+
+    payload = fake_mollie.payments.created_payloads[0]
+    assert payload["webhookUrl"] == f"https://api.shopvirge.com/webhooks/payments/mollie/{mollie_order['shop_id']}"
+
+
+def test_mollie_webhook_paid_completes_order(test_client, fake_mollie, mollie_order):
+    session = create_payment(test_client, mollie_order["shop_id"], mollie_order["order_id"]).json()
+
+    fake_mollie.payments.set_status("tr_test1", "paid")
+    response = test_client.post(
+        f"/webhooks/payments/mollie/{mollie_order['shop_id']}",
+        data={"id": "tr_test1"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"status": "ok"}
+
+    payment = db.session.get(PaymentTable, session["payment_id"])
+    assert payment.status == "paid"
+
+    order = test_client.get(f"/orders/{mollie_order['order_id']}").json()
+    assert order["status"] == "complete"
+    assert order["completed_at"] is not None
+
+    # Mollie retries webhooks: a replay must be a harmless no-op.
+    completed_at = order["completed_at"]
+    response = test_client.post(
+        f"/webhooks/payments/mollie/{mollie_order['shop_id']}",
+        data={"id": "tr_test1"},
+    )
+    assert response.status_code == 200
+    order = test_client.get(f"/orders/{mollie_order['order_id']}").json()
+    assert order["status"] == "complete"
+    assert order["completed_at"] == completed_at
+
+
+def test_mollie_webhook_failed_keeps_order_pending(test_client, fake_mollie, mollie_order):
+    session = create_payment(test_client, mollie_order["shop_id"], mollie_order["order_id"]).json()
+
+    fake_mollie.payments.set_status("tr_test1", "failed")
+    response = test_client.post(
+        f"/webhooks/payments/mollie/{mollie_order['shop_id']}",
+        data={"id": "tr_test1"},
+    )
+    assert response.status_code == 200
+
+    payment = db.session.get(PaymentTable, session["payment_id"])
+    assert payment.status == "failed"
+    order = test_client.get(f"/orders/{mollie_order['order_id']}").json()
+    assert order["status"] == "pending"
+
+    # A failed attempt does not block a retry: a fresh payment can be created.
+    retry = create_payment(test_client, mollie_order["shop_id"], mollie_order["order_id"])
+    assert retry.status_code == 201
+    assert retry.json()["payment_id"] != session["payment_id"]
+
+
+def test_get_payment_syncs_status_from_provider(test_client, fake_mollie, mollie_order):
+    """Poll-time sync is the webhook fallback (e.g. local dev, missed webhook)."""
+    session = create_payment(test_client, mollie_order["shop_id"], mollie_order["order_id"]).json()
+
+    fake_mollie.payments.set_status("tr_test1", "paid")
+    response = test_client.get(f"/shops/{mollie_order['shop_id']}/payments/{session['payment_id']}")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "paid"
+    assert body["order_status"] == "complete"
+
+
+def test_mollie_webhook_without_id_is_rejected(test_client, fake_mollie, mollie_order):
+    response = test_client.post(f"/webhooks/payments/mollie/{mollie_order['shop_id']}", data={})
+    assert response.status_code == 400
+
+
+def test_webhook_unknown_payment_returns_404(test_client, fake_mollie, mollie_order):
+    fake_mollie.payments.store["tr_unknown"] = {
+        "resource": "payment",
+        "id": "tr_unknown",
+        "status": "paid",
+        "_links": {},
+    }
+    response = test_client.post(
+        f"/webhooks/payments/mollie/{mollie_order['shop_id']}",
+        data={"id": "tr_unknown"},
+    )
+    assert response.status_code == 404
+
+
+def test_webhook_unknown_provider_returns_404(test_client, mollie_order):
+    response = test_client.post(
+        f"/webhooks/payments/adyen/{mollie_order['shop_id']}",
+        data={"id": "tr_test1"},
+    )
+    assert response.status_code == 404
+
+
+def test_create_payment_for_completed_order_conflicts(test_client, fake_mollie, mollie_order):
+    from server.db.models import OrderTable
+
+    order = db.session.get(OrderTable, mollie_order["order_id"])
+    order.status = "complete"
+    db.session.commit()
+
+    response = create_payment(test_client, mollie_order["shop_id"], mollie_order["order_id"])
+    assert response.status_code == 409
+
+
+def test_create_payment_unconfigured_stripe_shop_is_400(test_client):
+    """Default provider is stripe; a shop without a secret key gets a clean 400."""
+    shop_id = make_shop(with_config=False, random_shop_name=True)
+    account_id = make_account(shop_id=shop_id, name="stripe@test.local")
+    order = make_pending_order(shop_id=shop_id, account_id=account_id, product_id_1=uuid4(), product_id_2=uuid4())
+    response = create_payment(test_client, shop_id, order.id)
+    assert response.status_code == 400
+
+
+def test_create_stripe_payment_returns_client_confirmation_session(test_client, monkeypatch):
+    shop_id = make_shop(with_config=False, random_shop_name=True)
+    shop = db.session.get(ShopTable, shop_id)
+    shop.stripe_secret_key = "sk_test_dummy"
+    shop.stripe_public_key = "pk_test_dummy"
+    db.session.commit()
+
+    account_id = make_account(shop_id=shop_id, name="stripe@test.local")
+    order = make_pending_order(
+        shop_id=shop_id, account_id=account_id, product_id_1=uuid4(), product_id_2=uuid4(), total=2.0
+    )
+
+    created_kwargs = {}
+
+    def fake_intent_create(**kwargs):
+        created_kwargs.update(kwargs)
+        return {"id": "pi_test1", "status": "requires_payment_method", "client_secret": "pi_test1_secret"}
+
+    import stripe as stripe_sdk
+
+    monkeypatch.setattr(stripe_sdk.PaymentIntent, "create", staticmethod(fake_intent_create))
+
+    response = create_payment(test_client, shop_id, order.id)
+    assert response.status_code == 201, response.text
+    session = response.json()
+
+    assert session["provider"] == "stripe"
+    assert session["flow"] == "client_confirmation"
+    assert session["client_secret"] == "pi_test1_secret"
+    assert session["publishable_key"] == "pk_test_dummy"
+    assert session["redirect_url"] is None
+
+    # Amount in cents, derived from the order total — not client input.
+    assert created_kwargs["amount"] == 200
+    assert created_kwargs["currency"] == "eur"
+    # Guest checkout: no stripe customer on the account, so no customer passed.
+    assert "customer" not in created_kwargs

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -3046,6 +3046,143 @@
         "title": "OrderUpdated",
         "type": "object"
       },
+      "PaymentCreate": {
+        "properties": {
+          "order_id": {
+            "format": "uuid",
+            "title": "Order Id",
+            "type": "string"
+          },
+          "return_url": {
+            "title": "Return Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "order_id",
+          "return_url"
+        ],
+        "title": "PaymentCreate",
+        "type": "object"
+      },
+      "PaymentSessionSchema": {
+        "description": "Provider-agnostic 'what to do next' answer for a created payment.",
+        "properties": {
+          "amount": {
+            "title": "Amount",
+            "type": "number"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Secret"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "flow": {
+            "enum": [
+              "redirect",
+              "client_confirmation"
+            ],
+            "title": "Flow",
+            "type": "string"
+          },
+          "order_id": {
+            "format": "uuid",
+            "title": "Order Id",
+            "type": "string"
+          },
+          "payment_id": {
+            "format": "uuid",
+            "title": "Payment Id",
+            "type": "string"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          },
+          "publishable_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Publishable Key"
+          },
+          "redirect_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Redirect Url"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payment_id",
+          "order_id",
+          "provider",
+          "status",
+          "amount",
+          "currency",
+          "flow"
+        ],
+        "title": "PaymentSessionSchema",
+        "type": "object"
+      },
+      "PaymentStatusSchema": {
+        "properties": {
+          "order_id": {
+            "format": "uuid",
+            "title": "Order Id",
+            "type": "string"
+          },
+          "order_status": {
+            "title": "Order Status",
+            "type": "string"
+          },
+          "payment_id": {
+            "format": "uuid",
+            "title": "Payment Id",
+            "type": "string"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payment_id",
+          "order_id",
+          "provider",
+          "status",
+          "order_status"
+        ],
+        "title": "PaymentStatusSchema",
+        "type": "object"
+      },
       "ProductAttributeItem": {
         "description": "Lightweight representation of a product's attribute value used in responses.\n\n- attribute_id: the AttributeTable id\n- attribute_name: translated main_name for display (optional, may be omitted in some endpoints)\n- option_id: the AttributeOptionTable id when the value is an enum option\n- option_value_key: the option key (e.g., \"XS\", \"M\") when applicable",
         "properties": {
@@ -5906,7 +6043,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.3.2"
+    "version": "0.4.0"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -11506,6 +11643,113 @@
         ]
       }
     },
+    "/shops/{shop_id}/payments/": {
+      "post": {
+        "operationId": "create_payment_shops__shop_id__payments__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentSessionSchema"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Payment",
+        "tags": [
+          "payments"
+        ]
+      }
+    },
+    "/shops/{shop_id}/payments/{payment_id}": {
+      "get": {
+        "description": "Current payment status, freshly synced from the provider.\n\nThe sync makes this endpoint double as the webhook fallback: when the\ncustomer lands on the return page before (or without) a webhook arriving,\npolling here still moves the payment \u2014 and on 'paid', the order \u2014 forward.",
+        "operationId": "get_payment_shops__shop_id__payments__payment_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "payment_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Payment Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentStatusSchema"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Payment",
+        "tags": [
+          "payments"
+        ]
+      }
+    },
     "/shops/{shop_id}/prices/": {
       "get": {
         "operationId": "get_products_shops__shop_id__prices__get",
@@ -13983,6 +14227,61 @@
         "summary": "Update",
         "tags": [
           "users"
+        ]
+      }
+    },
+    "/webhooks/payments/{provider_id}/{shop_id}": {
+      "post": {
+        "operationId": "payment_webhook_webhooks_payments__provider_id___shop_id__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider_id",
+            "required": true,
+            "schema": {
+              "title": "Provider Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Payment Webhook Webhooks Payments  Provider Id   Shop Id  Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Payment Webhook",
+        "tags": [
+          "payments",
+          "webhooks"
         ]
       }
     }


### PR DESCRIPTION
Closes #125 — see the issue for the full design discussion.

## What this does

Replaces the hard-coded Stripe checkout with a pluggable payment-provider architecture, proven by a working **Mollie** integration. Order completion is now **webhook-driven and owned by the backend** — the frontend can no longer mark an order complete without a verified payment.

### Provider abstraction (`server/payments/`)

- `PaymentProvider` ABC with three methods: `create_payment`, `handle_webhook`, `get_status`, all speaking normalized `PaymentSession` / `PaymentEvent` / `PaymentStatus` objects.
- `MollieProvider` — hosted checkout (`flow: "redirect"`), unsigned webhooks verified by fetching the payment back from the Mollie API (that *is* Mollie's verification model).
- `StripeProvider` — PaymentIntents (`flow: "client_confirmation"`), signed webhooks via `payment_config["stripe"]["webhook_secret"]`. Reads the existing `stripe_secret_key`/`stripe_public_key` columns, so existing shops need **zero migration**.
- `registry.get_provider(shop)` resolves via the new `ShopTable.payment_provider` column (default `"stripe"`).

### Payments become first-class (`payments` table)

`order_id`, `provider`, `provider_payment_id`, `amount`, `currency`, `status` (`created → pending → paid|failed|canceled|expired`), `raw` JSONB. One order can have multiple attempts (failed iDEAL retry → new payment row).

### New endpoints

| Route | Purpose |
|---|---|
| `POST /shops/{shop_id}/payments/` | `{order_id, return_url}` → PaymentSession. Amount derived **server-side** from `order.total` (the old `/stripe/` route took the price from the client). Only `pending` orders are payable (409 otherwise). |
| `GET /shops/{shop_id}/payments/{id}` | Status poll for the return page; syncs from the provider, so it doubles as the **webhook fallback** (local dev, missed webhooks). |
| `POST /webhooks/payments/{provider}/{shop_id}` | Public PSP webhook; verified per provider, then applies the event and completes the order on `paid`. |

### Idempotent order completion

The side effects inlined in the orders PATCH endpoint (stock deduction, Discord, confirmation emails, cache invalidation) moved to `server/services/order_lifecycle.py`. `complete_order()` is idempotent, so Mollie webhook retries and a racing legacy frontend PATCH are harmless.

## Behavior changes to be aware of

- Orders PATCH: Discord/email notifications now fire only on transitions to `complete` (previously the Discord "New Order!" ping fired on *any* PATCH, including cancellations).
- Stock-toggle lookup is now defensive against shops with empty/string `config` (previously a webhook-completed order for such a shop would have crashed).
- `APP_VERSION` 0.3.2 → 0.4.0, OpenAPI snapshot regenerated.

## Backwards compatibility

- Old `/shops/{shop_id}/stripe/` endpoints untouched — the legacy frontend keeps working as-is.
- Subscriptions stay Stripe-only (out of scope per #125).
- Shops migrate one at a time by setting `payment_provider` + `payment_config`.

## Frontend migration (separate repo — summary)

1. After `POST /orders/`, call `POST /shops/{shop_id}/payments/` with `{order_id, return_url}` instead of the `/stripe/` route.
2. Branch on `flow`: `"redirect"` → `window.location = redirect_url` (entire Mollie integration); `"client_confirmation"` → existing Stripe Elements, with `client_secret`/`publishable_key` from the response.
3. Add a `/checkout/return` page that polls `GET /payments/{id}` until terminal (handle `failed`/`canceled`/`expired` too).
4. **Delete the post-payment order PATCH** — the webhook owns completion now.

## Testing

- 11 new tests in `tests/unit_tests/api/test_payments.py`. Mollie is faked at the `_get_client` seam using the **real SDK `Payment` objects**, so the provider code runs against the SDK's actual object shape; Stripe is faked at the PaymentIntent level.
- Covers: redirect session creation, server-side amount, webhook URL building, paid-webhook → order complete (+ retry idempotency), failed payment + retry attempt, poll-time sync fallback, invalid/unknown webhook handling, 409 on non-pending orders, 400 for unconfigured shops, Stripe client-confirmation flow.
- Full suite: **184 passed**. `isort`/`black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
