### PR TITLE
Add X-Order-Api-Key protection to POST /orders

### DIFF
--- a/docs/api/shop-scoped.md
+++ b/docs/api/shop-scoped.md
@@ -25,7 +25,7 @@ The files under `server/api/endpoints/shop_endpoints/`:
 
 | File | Resource |
 |------|----------|
-| `orders.py` | Orders — checkout-facing order creation and status management. Implemented in `shop_endpoints/`, but mounted at `/orders` instead of `/shops/{shop_id}/orders`. `PATCH /{order_id}` transitions an order to `complete` or `cancelled`: triggers stock deduction (if enabled), a Discord webhook notification, and an order confirmation email. |
+| `orders.py` | Orders — checkout-facing order creation and status management. Implemented in `shop_endpoints/`, but mounted at `/orders` instead of `/shops/{shop_id}/orders`. `PATCH /{order_id}` transitions an order to `complete` or `cancelled`: triggers stock deduction (if enabled), a Discord webhook notification, and an order confirmation email. `POST /orders` is additionally protected by an optional `X-Order-Api-Key` header (set `ORDER_API_KEY` env var to enable; requests without the matching key return 403). |
 | `products.py` | Products (public router split out for unauthenticated catalog browsing). When the shop config toggle `force_unique_product_names` is enabled, `POST` and `PUT` reject duplicate `main_name` values with HTTP 409. Each product also carries a `short_id` (12-char UUID prefix) and an optional `sku` for stable, collision-proof PDP URLs. |
 | `categories.py` | Categories (public router split out similarly). |
 | `tags.py` | Tags. |

--- a/server/api/endpoints/shop_endpoints/orders.py
+++ b/server/api/endpoints/shop_endpoints/orders.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import stripe
 import structlog
 from alembic.util import not_none
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.param_functions import Body, Depends
 from starlette.responses import Response
 
@@ -32,7 +32,7 @@ from server.security import CustomCognitoToken, auth_required
 from server.services import stripe_client
 from server.services.shipping import compute_shipping_for_cart
 from server.services.stripe_client import StripeNotConfigured
-from server.settings import mail_settings
+from server.settings import app_settings, mail_settings
 from server.utils.discord.discord import post_discord_order_complete
 
 logger = structlog.get_logger(__name__)
@@ -204,8 +204,15 @@ def check(
         "A Stripe customer is auto-created for new account names when the shop has Stripe configured."
     ),
 )
-def create(request: Request, data: OrderCreate = Body(...)) -> OrderCreated:
+def create(
+    request: Request,
+    data: OrderCreate = Body(...),
+    x_order_api_key: Optional[str] = Header(None, alias="X-Order-Api-Key"),
+) -> OrderCreated:
     logger.info("Saving order", data=data)
+
+    if app_settings.ORDER_API_KEY and x_order_api_key != app_settings.ORDER_API_KEY:
+        raise_status(HTTPStatus.FORBIDDEN, "Missing or invalid X-Order-Api-Key")
 
     if data.customer_order_id:
         del data.customer_order_id

--- a/server/settings.py
+++ b/server/settings.py
@@ -40,6 +40,9 @@ class AppSettings(BaseSettings):
     TESTING: bool = True
     EMAILS_ENABLED: bool = False
     MCP_ENABLED: bool = False
+    # When set, POST /orders requires a matching X-Order-Api-Key header.
+    # Leave unset in dev; set to a random string in production per deployment.
+    ORDER_API_KEY: Optional[str] = None
     # SESSION_SECRET: str = "".join(secrets.choice(string.ascii_letters) for i in range(16))  # noqa: S311
     SESSION_SECRET: str = "CHANGEME"
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -15,27 +15,6 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.responses import JSONResponse
 
-_JSON_CT = {"Content-Type": "application/json"}
-
-
-class TestClient(_TestClient):
-    """TestClient that auto-sets Content-Type: application/json when content= is used."""
-
-    def _inject_json_ct(self, kwargs: dict) -> dict:
-        if "content" in kwargs and "headers" not in kwargs:
-            return {**kwargs, "headers": _JSON_CT}
-        return kwargs
-
-    def post(self, *args, **kwargs):
-        return super().post(*args, **self._inject_json_ct(kwargs))
-
-    def put(self, *args, **kwargs):
-        return super().put(*args, **self._inject_json_ct(kwargs))
-
-    def patch(self, *args, **kwargs):
-        return super().patch(*args, **self._inject_json_ct(kwargs))
-
-
 from server.api.api import api_router
 from server.api.error_handling import ProblemDetailException
 from server.db import db, init_database
@@ -58,6 +37,26 @@ from tests.unit_tests.factories.order import make_pending_order
 from tests.unit_tests.factories.product import make_product, make_translated_product
 from tests.unit_tests.factories.shop import make_shop
 from tests.unit_tests.factories.tag import make_tag
+
+_JSON_CT = {"Content-Type": "application/json"}
+
+
+class TestClient(_TestClient):
+    """TestClient that auto-sets Content-Type: application/json when content= is used."""
+
+    def _inject_json_ct(self, kwargs: dict) -> dict:
+        if "content" in kwargs and "headers" not in kwargs:
+            return {**kwargs, "headers": _JSON_CT}
+        return kwargs
+
+    def post(self, *args, **kwargs):
+        return super().post(*args, **self._inject_json_ct(kwargs))
+
+    def put(self, *args, **kwargs):
+        return super().put(*args, **self._inject_json_ct(kwargs))
+
+    def patch(self, *args, **kwargs):
+        return super().patch(*args, **self._inject_json_ct(kwargs))
 
 
 def run_migrations(db_uri: str) -> None:

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -7193,6 +7193,24 @@
       "post": {
         "description": "Submit a new customer order. The caller's IP is validated against the shop's allowlist. If stock tracking is enabled the product availability is verified before the order is created. A Stripe customer is auto-created for new account names when the shop has Stripe configured.",
         "operationId": "create_orders__post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Order-Api-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Order-Api-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {


### PR DESCRIPTION
## Summary

- Adds `ORDER_API_KEY` optional setting to `AppSettings`
- `POST /orders` checks for a matching `X-Order-Api-Key` header when the env var is set
- Returns 403 if the key is set but missing/wrong from the request
- Check is skipped entirely when `ORDER_API_KEY` is unset — safe zero-downtime rollout

## Test plan

- [ ] Without `ORDER_API_KEY` set: orders create as before
- [ ] With `ORDER_API_KEY=secret` set: POST /orders without header → 403
- [ ] With `ORDER_API_KEY=secret` set: POST /orders with `X-Order-Api-Key: secret` → 200

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)