### PR TITLE
Add SKU and short_id to products for stable PDP URLs

### DIFF
--- a/docs/api/email-notifications.md
+++ b/docs/api/email-notifications.md
@@ -21,6 +21,19 @@ This renders and sends two mails:
 1. **Customer confirmation** — `mail_order_confirmation_customer.html.j2`.
 2. **Shop-owner notification** — `mail_order_confirmation_owner.html.j2`.
 
+### Configurable routing (`ConfigurationOrderStatusMails`)
+
+By default the owner notification goes to `shop.config.contact.email`. Since PR #124 this can be overridden per shop via `config.order_status_mails`:
+
+| Field | Default | Effect |
+|-------|---------|--------|
+| `owner_notification_enabled` | `true` | Disable to suppress owner notifications entirely. |
+| `owner_notification_email` | `null` (uses `contact.email`) | Override the recipient for owner notifications. |
+| `copy_enabled` | `false` | Send a BCC-style copy to a second address (support archive). |
+| `copy_email` | `null` | Recipient for the copy; required when `copy_enabled` is `true`. |
+
+If `order_status_mails` is absent from the config the old behaviour is preserved (owner notification to `contact.email`, no copy).
+
 ```mermaid
 sequenceDiagram
     autonumber

--- a/docs/api/email-notifications.md
+++ b/docs/api/email-notifications.md
@@ -23,7 +23,7 @@ This renders and sends two mails:
 
 ### Configurable routing (`ConfigurationOrderStatusMails`)
 
-By default the owner notification goes to `shop.config.contact.email`. Since PR #124 this can be overridden per shop via `config.order_status_mails`:
+By default the owner notification goes to `shop.config.contact.email`. This can be overridden per shop via `config.order_status_mails`:
 
 | Field | Default | Effect |
 |-------|---------|--------|

--- a/docs/api/shop-scoped.md
+++ b/docs/api/shop-scoped.md
@@ -25,7 +25,7 @@ The files under `server/api/endpoints/shop_endpoints/`:
 
 | File | Resource |
 |------|----------|
-| `orders.py` | Orders — checkout-facing order creation and status management. Implemented in `shop_endpoints/`, but mounted at `/orders` instead of `/shops/{shop_id}/orders`. `PATCH /{order_id}` transitions an order to `complete` or `cancelled`: triggers stock deduction (if enabled), a Discord webhook notification, and an order confirmation email. `POST /orders` is additionally protected by an optional `X-Order-Api-Key` header (set `ORDER_API_KEY` env var to enable; requests without the matching key return 403). |
+| `orders.py` | Orders — checkout-facing order creation and status management. Implemented in `shop_endpoints/`, but mounted at `/orders` instead of `/shops/{shop_id}/orders`. `PATCH /{order_id}` transitions an order to `complete` or `cancelled`: triggers stock deduction (if enabled), a Discord webhook notification, and an order confirmation email. |
 | `products.py` | Products (public router split out for unauthenticated catalog browsing). When the shop config toggle `force_unique_product_names` is enabled, `POST` and `PUT` reject duplicate `main_name` values with HTTP 409. Each product also carries a `short_id` (12-char UUID prefix) and an optional `sku` for stable, collision-proof PDP URLs. |
 | `categories.py` | Categories (public router split out similarly). |
 | `tags.py` | Tags. |

--- a/docs/api/shop-scoped.md
+++ b/docs/api/shop-scoped.md
@@ -26,7 +26,7 @@ The files under `server/api/endpoints/shop_endpoints/`:
 | File | Resource |
 |------|----------|
 | `orders.py` | Orders — checkout-facing order creation and status management. Implemented in `shop_endpoints/`, but mounted at `/orders` instead of `/shops/{shop_id}/orders`. `PATCH /{order_id}` transitions an order to `complete` or `cancelled`: triggers stock deduction (if enabled), a Discord webhook notification, and an order confirmation email. |
-| `products.py` | Products (public router split out for unauthenticated catalog browsing). |
+| `products.py` | Products (public router split out for unauthenticated catalog browsing). When the shop config toggle `force_unique_product_names` is enabled, `POST` and `PUT` reject duplicate `main_name` values with HTTP 409. Each product also carries a `short_id` (12-char UUID prefix) and an optional `sku` for stable, collision-proof PDP URLs. |
 | `categories.py` | Categories (public router split out similarly). |
 | `tags.py` | Tags. |
 | `attributes.py` | Attributes (e.g. "size"). |

--- a/docs/api/shop-scoped.md
+++ b/docs/api/shop-scoped.md
@@ -25,11 +25,11 @@ The files under `server/api/endpoints/shop_endpoints/`:
 
 | File | Resource |
 |------|----------|
-| `orders.py` | Orders — checkout-facing order creation and status management. Implemented in `shop_endpoints/`, but mounted at `/orders` instead of `/shops/{shop_id}/orders`. `PATCH /{order_id}` transitions an order to `complete` or `cancelled`: triggers stock deduction (if enabled), a Discord webhook notification, and an order confirmation email. |
+| `orders.py` | Orders — checkout-facing order creation and status management. Implemented in `shop_endpoints/`, but mounted at `/orders` instead of `/shops/{shop_id}/orders`. `PATCH /{order_id}` transitions an order to `complete` or `cancelled`: triggers stock deduction (if enabled), a Discord webhook notification, and an order confirmation email. `POST /orders` is additionally protected by an optional `X-Order-Api-Key` header (set `ORDER_API_KEY` env var to enable; requests without the matching key return 403). |
 | `products.py` | Products (public router split out for unauthenticated catalog browsing). When the shop config toggle `force_unique_product_names` is enabled, `POST` and `PUT` reject duplicate `main_name` values with HTTP 409. Each product also carries a `short_id` (12-char UUID prefix) and an optional `sku` for stable, collision-proof PDP URLs. |
 | `categories.py` | Categories (public router split out similarly). |
 | `tags.py` | Tags. |
-| `attributes.py` | Attributes (e.g. "size"). |
+| `attributes.py` | Attributes (e.g. "size"). `GET /{category_id}/available-attributes` returns option counts for a category; pass `?option_id=<uuid>` (repeatable) to filter counts to products matching all selected options (AND logic). |
 | `attribute_options.py` | Attribute options (e.g. "Small"). |
 | `product_attribute_values.py` | Per-product attribute assignments. |
 | `products_to_tags.py` | Product ↔ tag links. |

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -24,7 +24,7 @@ The main tables and what they hold:
 | `RoleTable` / `RoleUserTable` | Legacy RBAC tables from the pre-Cognito era. Retained in schema only. |
 | `ShopTable` | Shops: name, config, Stripe keys, VAT rates, webhooks. |
 | `ShopUserTable` | Legacy user ↔ shop join table. Shop access is now determined by Cognito group membership, not rows in this table. |
-| `ProductTable` | Products: price, tax category, stock, image URLs 1–6, featured/new flags, optional recurring pricing. |
+| `ProductTable` | Products: price, tax category, stock, image URLs 1–6, featured/new flags, optional recurring pricing. `short_id` (first 12 chars of UUID, globally unique) is backfilled on creation and used as a stable URL identifier. Optional `sku` (VARCHAR 64, unique per shop) can override `short_id` in URLs. |
 | `ProductTranslationTable` | Per-language product name and description. |
 | `CategoryTable` | Product categories with colour, icon, order number, images. |
 | `CategoryTranslationTable` | Per-language category name and description. |

--- a/migrations/versions/schema/2026-06-26_f1a2b3c4d5e6_add_sku_and_short_id_to_products.py
+++ b/migrations/versions/schema/2026-06-26_f1a2b3c4d5e6_add_sku_and_short_id_to_products.py
@@ -1,0 +1,42 @@
+"""Add sku and short_id to products.
+
+Revision ID: f1a2b3c4d5e6
+Revises: c1a2b3d4e5f6
+Create Date: 2026-06-26 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a2b3c4d5e6"
+down_revision = "c1a2b3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("products", sa.Column("sku", sa.String(64), nullable=True))
+    op.add_column("products", sa.Column("short_id", sa.String(12), nullable=True))
+
+    # Backfill short_id from first 12 chars of existing UUIDs
+    conn = op.get_bind()
+    conn.execute(sa.text("UPDATE products SET short_id = LEFT(id::text, 12)"))
+
+    op.alter_column("products", "short_id", nullable=False)
+    op.create_index("uq_products_short_id", "products", ["short_id"], unique=True)
+    op.create_index(
+        "uq_products_shop_sku",
+        "products",
+        ["shop_id", "sku"],
+        unique=True,
+        postgresql_where=sa.text("sku IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_products_shop_sku", table_name="products")
+    op.drop_index("uq_products_short_id", table_name="products")
+    op.drop_column("products", "short_id")
+    op.drop_column("products", "sku")

--- a/server/api/endpoints/shop_endpoints/prices.py
+++ b/server/api/endpoints/shop_endpoints/prices.py
@@ -38,6 +38,8 @@ class Lang(str, Enum):
 
 class ProductResponse(BaseModel):
     id: str
+    short_id: str | None = None
+    sku: str | None = None
     category: str
     category_image: str | None = None
     category_order_number: int
@@ -80,6 +82,8 @@ def to_response_model(product: ProductTable, lang: Lang, shop) -> ProductRespons
     if lang == Lang.MAIN:
         product_response = ProductResponse(
             id=str(product.id),
+            short_id=product.short_id,
+            sku=product.sku,
             category=product.category.translation.main_name,
             category_image=product.category.main_image,
             category_order_number=product.category.order_number,
@@ -99,6 +103,8 @@ def to_response_model(product: ProductTable, lang: Lang, shop) -> ProductRespons
     elif lang == Lang.ALT1:
         product_response = ProductResponse(
             id=str(product.id),
+            short_id=product.short_id,
+            sku=product.sku,
             category=product.category.translation.alt1_name,
             category_image=(
                 product.category.alt1_image if product.category.alt1_image else product.category.main_image
@@ -122,6 +128,8 @@ def to_response_model(product: ProductTable, lang: Lang, shop) -> ProductRespons
     elif lang == Lang.ALT2:
         product_response = ProductResponse(
             id=str(product.id),
+            short_id=product.short_id,
+            sku=product.sku,
             category=product.category.translation.alt2_name,
             category_image=(
                 product.category.alt2_image if product.category.alt2_image else product.category.main_image

--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -14,7 +14,8 @@ from server.api.deps import common_parameters
 from server.api.error_handling import raise_status
 from server.crud import crud_shop
 from server.crud.crud_product import product_crud
-from server.db.models import ProductTable
+from server.db import db
+from server.db.models import ProductTable, ProductTranslationTable
 from server.schemas.product import (
     AttributeFilters,
     ProductCreate,
@@ -26,6 +27,7 @@ from server.schemas.product import (
     ProductWithDetailsAndPrices,
 )
 from server.schemas.product_attribute import ProductAttributeItem
+from server.schemas.shop import ConfigurationV1
 
 logger = structlog.get_logger(__name__)
 
@@ -38,6 +40,18 @@ def get_shop(shop_id: UUID):
     if not shop:
         raise HTTPException(status_code=404, detail="Shop not found")
     return shop
+
+
+def _assert_unique_name(shop_id: UUID, main_name: str, exclude_product_id: UUID | None = None) -> None:
+    query = (
+        db.session.query(ProductTable)
+        .join(ProductTranslationTable, ProductTranslationTable.product_id == ProductTable.id)
+        .filter(ProductTable.shop_id == shop_id, ProductTranslationTable.main_name == main_name)
+    )
+    if exclude_product_id:
+        query = query.filter(ProductTable.id != exclude_product_id)
+    if query.first():
+        raise_status(HTTPStatus.CONFLICT, f"A product named '{main_name}' already exists in this shop")
 
 
 @router.get(
@@ -268,6 +282,11 @@ def get_by_id(product_id: UUID, shop_id: UUID) -> ProductWithDetailsAndPrices:
     description="Add a new product to a shop category. The `order_number` is automatically set to the next available value within the category.",
 )
 def create(shop_id: UUID, data: ProductCreate = Body(...)) -> None:
+    shop = get_shop(shop_id)
+    config = ConfigurationV1.model_validate(shop.config) if shop.config else ConfigurationV1()
+    if config.toggles.force_unique_product_names:
+        _assert_unique_name(shop_id, data.translation.main_name)
+
     product = (
         ProductTable.query.filter_by(shop_id=shop_id)
         .filter_by(category_id=data.category_id)
@@ -295,6 +314,11 @@ def update(*, product_id: UUID, shop_id: UUID, item_in: ProductUpdate) -> Any:
     logger.info("Updating product", data=product)
     if not product:
         raise HTTPException(status_code=404, detail="Product not found")
+
+    shop = get_shop(shop_id)
+    config = ConfigurationV1.model_validate(shop.config) if shop.config else ConfigurationV1()
+    if config.toggles.force_unique_product_names:
+        _assert_unique_name(shop_id, item_in.translation.main_name, exclude_product_id=product_id)
 
     item_in.modified_at = datetime.now(timezone.utc)
 

--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -36,7 +36,7 @@ public_router = APIRouter()
 
 
 def get_shop(shop_id: UUID):
-    shop = crud_shop.get(id=shop_id)
+    shop = crud_shop.shop_crud.get(id=shop_id)
     if not shop:
         raise HTTPException(status_code=404, detail="Shop not found")
     return shop

--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -36,7 +36,7 @@ public_router = APIRouter()
 
 
 def get_shop(shop_id: UUID):
-    shop = crud_shop.get_by_id(id=shop_id)
+    shop = crud_shop.get(id=shop_id)
     if not shop:
         raise HTTPException(status_code=404, detail="Shop not found")
     return shop

--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from http import HTTPStatus
 from textwrap import dedent
@@ -283,7 +284,8 @@ def get_by_id(product_id: UUID, shop_id: UUID) -> ProductWithDetailsAndPrices:
 )
 def create(shop_id: UUID, data: ProductCreate = Body(...)) -> None:
     shop = get_shop(shop_id)
-    config = ConfigurationV1.model_validate(shop.config) if shop.config else ConfigurationV1()
+    raw = json.loads(shop.config) if isinstance(shop.config, str) else shop.config
+    config = ConfigurationV1.model_validate(raw) if raw else ConfigurationV1()
     if config.toggles.force_unique_product_names:
         _assert_unique_name(shop_id, data.translation.main_name)
 
@@ -316,7 +318,8 @@ def update(*, product_id: UUID, shop_id: UUID, item_in: ProductUpdate) -> Any:
         raise HTTPException(status_code=404, detail="Product not found")
 
     shop = get_shop(shop_id)
-    config = ConfigurationV1.model_validate(shop.config) if shop.config else ConfigurationV1()
+    raw = json.loads(shop.config) if isinstance(shop.config, str) else shop.config
+    config = ConfigurationV1.model_validate(raw) if raw else ConfigurationV1()
     if config.toggles.force_unique_product_names:
         _assert_unique_name(shop_id, item_in.translation.main_name, exclude_product_id=product_id)
 

--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 import structlog
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from sqlalchemy.exc import IntegrityError
 from starlette.responses import Response
 
 from server.agent_tags import AgentTag
@@ -28,7 +29,7 @@ from server.schemas.product import (
     ProductWithDetailsAndPrices,
 )
 from server.schemas.product_attribute import ProductAttributeItem
-from server.schemas.shop import ConfigurationV1
+from server.schemas.shop import Toggles
 
 logger = structlog.get_logger(__name__)
 
@@ -284,9 +285,9 @@ def get_by_id(product_id: UUID, shop_id: UUID) -> ProductWithDetailsAndPrices:
 )
 def create(shop_id: UUID, data: ProductCreate = Body(...)) -> None:
     shop = get_shop(shop_id)
-    raw = json.loads(shop.config) if isinstance(shop.config, str) else shop.config
-    config = ConfigurationV1.model_validate(raw) if raw else ConfigurationV1()
-    if config.toggles.force_unique_product_names:
+    raw = json.loads(shop.config) if isinstance(shop.config, str) else (shop.config or {})
+    toggles = Toggles.model_validate(raw.get("toggles", {}) if isinstance(raw, dict) else {})
+    if toggles.force_unique_product_names:
         _assert_unique_name(shop_id, data.translation.main_name)
 
     product = (
@@ -298,7 +299,11 @@ def create(shop_id: UUID, data: ProductCreate = Body(...)) -> None:
     data.order_number = (product.order_number + 1) if product is not None else 0
 
     logger.info("Saving product", data=data)
-    product = product_crud.create_by_shop_id(obj_in=data, shop_id=shop_id)
+    try:
+        product = product_crud.create_by_shop_id(obj_in=data, shop_id=shop_id)
+    except IntegrityError:
+        db.session.rollback()
+        raise_status(HTTPStatus.CONFLICT, f"A product with SKU '{data.sku}' already exists in this shop")
     return product
 
 
@@ -318,9 +323,9 @@ def update(*, product_id: UUID, shop_id: UUID, item_in: ProductUpdate) -> Any:
         raise HTTPException(status_code=404, detail="Product not found")
 
     shop = get_shop(shop_id)
-    raw = json.loads(shop.config) if isinstance(shop.config, str) else shop.config
-    config = ConfigurationV1.model_validate(raw) if raw else ConfigurationV1()
-    if config.toggles.force_unique_product_names:
+    raw = json.loads(shop.config) if isinstance(shop.config, str) else (shop.config or {})
+    toggles = Toggles.model_validate(raw.get("toggles", {}) if isinstance(raw, dict) else {})
+    if toggles.force_unique_product_names:
         _assert_unique_name(shop_id, item_in.translation.main_name, exclude_product_id=product_id)
 
     item_in.modified_at = datetime.now(timezone.utc)

--- a/server/api/endpoints/shops.py
+++ b/server/api/endpoints/shops.py
@@ -14,6 +14,7 @@ from server.api.deps import common_parameters
 from server.api.error_handling import raise_status
 from server.api.helpers import load
 from server.crud.crud_shop import shop_crud
+from server.db import db
 from server.db.models import ShopTable
 from server.schemas.shop import (
     MyShopsResponse,
@@ -209,6 +210,25 @@ def update_config(
     logger.info("Updating shop", data=shop)
     if not shop:
         raise HTTPException(status_code=404, detail="Shop not found")
+
+    if item_in.config.toggles.force_unique_product_names:
+        from sqlalchemy import func
+
+        from server.db.models import ProductTable, ProductTranslationTable
+
+        duplicate = (
+            db.session.query(ProductTranslationTable.main_name)
+            .join(ProductTable, ProductTranslationTable.product_id == ProductTable.id)
+            .filter(ProductTable.shop_id == id)
+            .group_by(ProductTranslationTable.main_name)
+            .having(func.count(ProductTranslationTable.main_name) > 1)
+            .first()
+        )
+        if duplicate:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Cannot enable force_unique_product_names: duplicate product name '{duplicate[0]}' exists in this shop.",
+            )
 
     shop = shop_crud.update(
         db_obj=shop,

--- a/server/crud/base.py
+++ b/server/crud/base.py
@@ -180,6 +180,9 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
 
         return db_obj
 
+    def _extra_create_fields(self) -> dict:
+        return {}
+
     def create_by_shop_id(self, *, shop_id: any, obj_in: CreateSchemaType) -> ModelType:
         obj_in_data = transform_json(obj_in.model_dump())
         # Todo: remove translate from base? We should handle this in a more generic way, for now a UGLY hack:
@@ -190,7 +193,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
             pass
 
         try:
-            db_obj = self.model(**{**obj_in_data, "shop_id": shop_id})
+            db_obj = self.model(**{**obj_in_data, "shop_id": shop_id, **self._extra_create_fields()})
             db.session.add(db_obj)
             db.session.flush()
 

--- a/server/crud/crud_product.py
+++ b/server/crud/crud_product.py
@@ -11,10 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Any, List, Literal, Optional, Tuple
+from uuid import UUID, uuid4
 
-from sqlalchemy import or_
+from sqlalchemy import String, cast, or_
 from sqlalchemy.orm import aliased
 
+from server.api.models import transform_json
 from server.crud.base import CRUDBase
 from server.db import db
 from server.db.models import (
@@ -23,8 +25,18 @@ from server.db.models import (
     AttributeTranslationTable,
     ProductAttributeValueTable,
     ProductTable,
+    ProductTranslationTable,
 )
 from server.schemas.product import ProductCreate, ProductUpdate
+
+
+def _generate_uuid_with_unique_short_id(model: type) -> UUID:
+    new_id = uuid4()
+    short = str(new_id)[:12]
+    exists = db.session.query(model).filter(cast(model.id, String).startswith(short)).count() > 0
+    if exists:
+        return _generate_uuid_with_unique_short_id(model)
+    return new_id
 
 
 class CRUDProduct(CRUDBase[ProductTable, ProductCreate, ProductUpdate]):
@@ -102,6 +114,36 @@ class CRUDProduct(CRUDBase[ProductTable, ProductCreate, ProductUpdate]):
             sort_parameters=sort_parameters,
             query_parameter=query,
         )
+
+    def create_by_shop_id(self, *, shop_id: any, obj_in: ProductCreate) -> ProductTable:
+        new_id = _generate_uuid_with_unique_short_id(self.model)
+        obj_in_data = transform_json(obj_in.model_dump())
+        translation_data = None
+        try:
+            translation_data = obj_in_data.pop("translation")
+        except Exception:
+            pass
+
+        try:
+            db_obj = self.model(**{**obj_in_data, "shop_id": shop_id, "id": new_id, "short_id": str(new_id)[:12]})
+            db.session.add(db_obj)
+            db.session.flush()
+
+            if translation_data:
+                for field in translation_data:
+                    if translation_data[field] == "":
+                        translation_data[field] = None
+                translation_data["product_id"] = db_obj.id
+                translation = ProductTranslationTable(**translation_data)
+                db.session.add(translation)
+                db.session.commit()
+                db.session.refresh(db_obj)
+                db.session.refresh(translation)
+        except Exception:
+            db.session.rollback()
+            raise
+
+        return db_obj
 
 
 product_crud = CRUDProduct(ProductTable)

--- a/server/crud/crud_product.py
+++ b/server/crud/crud_product.py
@@ -16,7 +16,6 @@ from uuid import UUID, uuid4
 from sqlalchemy import String, cast, or_
 from sqlalchemy.orm import aliased
 
-from server.api.models import transform_json
 from server.crud.base import CRUDBase
 from server.db import db
 from server.db.models import (
@@ -25,7 +24,6 @@ from server.db.models import (
     AttributeTranslationTable,
     ProductAttributeValueTable,
     ProductTable,
-    ProductTranslationTable,
 )
 from server.schemas.product import ProductCreate, ProductUpdate
 
@@ -115,35 +113,9 @@ class CRUDProduct(CRUDBase[ProductTable, ProductCreate, ProductUpdate]):
             query_parameter=query,
         )
 
-    def create_by_shop_id(self, *, shop_id: any, obj_in: ProductCreate) -> ProductTable:
+    def _extra_create_fields(self) -> dict:
         new_id = _generate_uuid_with_unique_short_id(self.model)
-        obj_in_data = transform_json(obj_in.model_dump())
-        translation_data = None
-        try:
-            translation_data = obj_in_data.pop("translation")
-        except Exception:
-            pass
-
-        try:
-            db_obj = self.model(**{**obj_in_data, "shop_id": shop_id, "id": new_id, "short_id": str(new_id)[:12]})
-            db.session.add(db_obj)
-            db.session.flush()
-
-            if translation_data:
-                for field in translation_data:
-                    if translation_data[field] == "":
-                        translation_data[field] = None
-                translation_data["product_id"] = db_obj.id
-                translation = ProductTranslationTable(**translation_data)
-                db.session.add(translation)
-                db.session.commit()
-                db.session.refresh(db_obj)
-                db.session.refresh(translation)
-        except Exception:
-            db.session.rollback()
-            raise
-
-        return db_obj
+        return {"id": new_id, "short_id": str(new_id)[:12]}
 
 
 product_crud = CRUDProduct(ProductTable)

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -343,6 +343,8 @@ class ProductTable(BaseModel):
     new_product = Column(Boolean(), default=False)
     order_number = Column(Integer, default=0)
     stock = Column(Integer, default=1)
+    sku = Column(String(64), nullable=True)
+    short_id = Column(String(12), nullable=True, index=True)
     image_1 = Column(String(255), index=True)
     image_2 = Column(String(255), index=True)
     image_3 = Column(String(255), index=True)

--- a/server/main.py
+++ b/server/main.py
@@ -74,7 +74,7 @@ async def lifespan(app_: FastAPI):
         yield
 
 
-APP_VERSION = "0.3.4"
+APP_VERSION = "0.3.5"
 
 # Assigned after the api_router is included if MCP_ENABLED. The lifespan
 # closure above references it.

--- a/server/schemas/product.py
+++ b/server/schemas/product.py
@@ -61,6 +61,7 @@ class ProductBase(BoilerplateBaseModel):
     discounted_to: Optional[datetime] = None
     order_number: Optional[int] = None
     stock: Optional[int] = 1
+    sku: Optional[str] = None
     image_1: Union[Optional[dict], Optional[str]]
     image_2: Union[Optional[dict], Optional[str]]
     image_3: Union[Optional[dict], Optional[str]]
@@ -82,6 +83,7 @@ class ProductUpdate(ProductBase):
 
 class ProductInDBBase(ProductBase):
     id: UUID
+    short_id: Optional[str] = None
     # created_at: datetime
     modified_at: Optional[datetime] = None
     approved_at: Optional[datetime] = None

--- a/server/schemas/shop.py
+++ b/server/schemas/shop.py
@@ -173,6 +173,7 @@ class Toggles(BoilerplateBaseModel):
     product_call_to_action_enabled: bool = False
     enable_stock_on_products: bool = False
     enable_attributes_for_categories: bool = False
+    force_unique_product_names: bool = False
 
 
 class ConfigurationShipping(BoilerplateBaseModel):

--- a/tests/unit_tests/api/test_products.py
+++ b/tests/unit_tests/api/test_products.py
@@ -311,6 +311,12 @@ def _product_body(shop_id, category_id, name="Test Product", sku=None):
             "main_description": "desc",
             "main_description_short": "short",
         },
+        "image_1": "",
+        "image_2": "",
+        "image_3": "",
+        "image_4": "",
+        "image_5": "",
+        "image_6": "",
     }
     if sku is not None:
         body["sku"] = sku
@@ -351,10 +357,10 @@ def test_product_duplicate_sku_same_shop_rejected(shop, category, test_client):
 
 
 def test_product_duplicate_sku_different_shop_allowed(shop, category, test_client):
-    from tests.unit_tests.factories.category import make_category
+    from tests.unit_tests.factories.categories import make_category
     from tests.unit_tests.factories.shop import make_shop
 
-    shop2 = make_shop(with_config=False)
+    shop2 = make_shop(with_config=False, random_shop_name=True)
     category2 = make_category(shop_id=shop2)
     test_client.post(f"/shops/{shop}/products/", content=json_dumps(_product_body(shop, category, sku="XSH-001")))
     response = test_client.post(
@@ -370,9 +376,14 @@ def test_force_unique_names_rejects_duplicate(shop_with_config, category, test_c
     shop = ShopTable.query.filter_by(id=shop_with_config).first()
     import json
 
-    config = json.loads(shop.config)
+    import copy
+
+    from sqlalchemy.orm.attributes import flag_modified
+
+    config = json.loads(shop.config) if isinstance(shop.config, str) else copy.deepcopy(shop.config)
     config["toggles"]["force_unique_product_names"] = True
-    shop.config = json.dumps(config)
+    shop.config = config
+    flag_modified(shop, "config")
     from server.db import db
 
     db.session.commit()

--- a/tests/unit_tests/api/test_products.py
+++ b/tests/unit_tests/api/test_products.py
@@ -374,9 +374,8 @@ def test_force_unique_names_rejects_duplicate(shop_with_config, category, test_c
     from server.db import ShopTable
 
     shop = ShopTable.query.filter_by(id=shop_with_config).first()
-    import json
-
     import copy
+    import json
 
     from sqlalchemy.orm.attributes import flag_modified
 

--- a/tests/unit_tests/api/test_products.py
+++ b/tests/unit_tests/api/test_products.py
@@ -294,3 +294,107 @@ def test_products_get_multi_with_attributes_filter_out_of_stock(shop, category, 
     ids = {p["product"]["id"] for p in response.json()}
     assert str(out_id) in ids
     assert str(in_id) not in ids
+
+
+def _product_body(shop_id, category_id, name="Test Product", sku=None):
+    body = {
+        "shop_id": str(shop_id),
+        "category_id": str(category_id),
+        "price": 1.0,
+        "tax_category": "vat_zero",
+        "max_one": False,
+        "shippable": True,
+        "featured": False,
+        "new_product": False,
+        "translation": {
+            "main_name": name,
+            "main_description": "desc",
+            "main_description_short": "short",
+        },
+    }
+    if sku is not None:
+        body["sku"] = sku
+    return body
+
+
+def test_product_create_sets_short_id(shop, category, test_client):
+    response = test_client.post(f"/shops/{shop}/products/", content=json_dumps(_product_body(shop, category)))
+    assert response.status_code == HTTPStatus.CREATED
+    product = ProductTable.query.filter_by(id=response.json()["id"]).first()
+    assert product.short_id is not None
+    assert len(product.short_id) == 12
+
+
+def test_product_create_with_sku(shop, category, test_client):
+    response = test_client.post(
+        f"/shops/{shop}/products/", content=json_dumps(_product_body(shop, category, sku="TST-001"))
+    )
+    assert response.status_code == HTTPStatus.CREATED
+    product = ProductTable.query.filter_by(id=response.json()["id"]).first()
+    assert product.sku == "TST-001"
+
+
+def test_product_update_sets_sku(shop_with_config, product, category, test_client):
+    body = _product_body(shop_with_config, category, sku="UPD-999")
+    response = test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body))
+    assert response.status_code == 201
+    updated = ProductTable.query.filter_by(id=product).first()
+    assert updated.sku == "UPD-999"
+
+
+def test_product_duplicate_sku_same_shop_rejected(shop, category, test_client):
+    test_client.post(f"/shops/{shop}/products/", content=json_dumps(_product_body(shop, category, sku="DUP-001")))
+    response = test_client.post(
+        f"/shops/{shop}/products/", content=json_dumps(_product_body(shop, category, name="Other", sku="DUP-001"))
+    )
+    assert response.status_code == HTTPStatus.CONFLICT
+
+
+def test_product_duplicate_sku_different_shop_allowed(shop, category, test_client):
+    from tests.unit_tests.factories.category import make_category
+    from tests.unit_tests.factories.shop import make_shop
+
+    shop2 = make_shop(with_config=False)
+    category2 = make_category(shop_id=shop2)
+    test_client.post(f"/shops/{shop}/products/", content=json_dumps(_product_body(shop, category, sku="XSH-001")))
+    response = test_client.post(
+        f"/shops/{shop2}/products/", content=json_dumps(_product_body(shop2, category2, sku="XSH-001"))
+    )
+    assert response.status_code == HTTPStatus.CREATED
+
+
+def test_force_unique_names_rejects_duplicate(shop_with_config, category, test_client):
+    # Enable the toggle via config update
+    from server.db import ShopTable
+
+    shop = ShopTable.query.filter_by(id=shop_with_config).first()
+    import json
+
+    config = json.loads(shop.config)
+    config["toggles"]["force_unique_product_names"] = True
+    shop.config = json.dumps(config)
+    from server.db import db
+
+    db.session.commit()
+
+    test_client.post(
+        f"/shops/{shop_with_config}/products/",
+        content=json_dumps(_product_body(shop_with_config, category, name="Unique Name")),
+    )
+    response = test_client.post(
+        f"/shops/{shop_with_config}/products/",
+        content=json_dumps(_product_body(shop_with_config, category, name="Unique Name")),
+    )
+    assert response.status_code == HTTPStatus.CONFLICT
+
+
+def test_force_unique_names_off_allows_duplicate(shop_with_config, category, test_client):
+    test_client.post(
+        f"/shops/{shop_with_config}/products/",
+        content=json_dumps(_product_body(shop_with_config, category, name="Shared Name")),
+    )
+    response = test_client.post(
+        f"/shops/{shop_with_config}/products/",
+        content=json_dumps(_product_body(shop_with_config, category, name="Shared Name")),
+    )
+    assert response.status_code == HTTPStatus.CREATED

--- a/tests/unit_tests/api/test_shops.py
+++ b/tests/unit_tests/api/test_shops.py
@@ -287,6 +287,7 @@ def test_shop_create_config(test_client, shop):
                 "product_call_to_action_enabled": False,
                 "enable_stock_on_products": True,
                 "enable_attributes_for_categories": False,
+                "force_unique_product_names": False,
             },
             "legal": {
                 "kvk_number": "string",
@@ -413,6 +414,7 @@ def test_shop_update_config(test_client, shop_with_config):
                 "product_call_to_action_enabled": False,
                 "enable_stock_on_products": True,
                 "enable_attributes_for_categories": False,
+                "force_unique_product_names": False,
             },
             "legal": {
                 "kvk_number": "string",
@@ -484,6 +486,7 @@ def test_shop_update_config_with_shipping(test_client, shop_with_config):
                 "product_call_to_action_enabled": False,
                 "enable_stock_on_products": True,
                 "enable_attributes_for_categories": False,
+                "force_unique_product_names": False,
             },
             "legal": None,
             "shipping": {

--- a/tests/unit_tests/factories/product.py
+++ b/tests/unit_tests/factories/product.py
@@ -1,4 +1,4 @@
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import structlog
 
@@ -17,13 +17,18 @@ def make_product(
     price=1.0,
     tax_category="vat_standard",
     stock: int = 1,
+    shippable: bool = True,
 ):
+    new_id = uuid4()
     product = ProductTable(
+        id=new_id,
+        short_id=str(new_id)[:12],
         shop_id=shop_id,
         category_id=category_id,
         price=price,
         stock=stock,
         tax_category=tax_category,
+        shippable=shippable,
     )
     db.session.add(product)
     db.session.commit()
@@ -56,7 +61,8 @@ def make_translated_product(
     alt2_description_short="Test Produkt Kurzbeschreibung",
     price=1.0,
 ):
-    product = ProductTable(shop_id=shop_id, category_id=category_id, price=price, stock=1)
+    new_id = uuid4()
+    product = ProductTable(id=new_id, short_id=str(new_id)[:12], shop_id=shop_id, category_id=category_id, price=price, stock=1)
     db.session.add(product)
     db.session.commit()
 

--- a/tests/unit_tests/factories/product.py
+++ b/tests/unit_tests/factories/product.py
@@ -62,7 +62,9 @@ def make_translated_product(
     price=1.0,
 ):
     new_id = uuid4()
-    product = ProductTable(id=new_id, short_id=str(new_id)[:12], shop_id=shop_id, category_id=category_id, price=price, stock=1)
+    product = ProductTable(
+        id=new_id, short_id=str(new_id)[:12], shop_id=shop_id, category_id=category_id, price=price, stock=1
+    )
     db.session.add(product)
     db.session.commit()
 

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -3318,6 +3318,17 @@
             "title": "Shop Id",
             "type": "string"
           },
+          "sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku"
+          },
           "stock": {
             "anyOf": [
               {
@@ -3566,6 +3577,28 @@
           "shippable": {
             "title": "Shippable",
             "type": "boolean"
+          },
+          "short_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Short Id"
+          },
+          "sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku"
           },
           "stock": {
             "anyOf": [
@@ -4022,6 +4055,17 @@
             "title": "Shop Id",
             "type": "string"
           },
+          "sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku"
+          },
           "stock": {
             "anyOf": [
               {
@@ -4335,6 +4379,28 @@
             "title": "Shop Id",
             "type": "string"
           },
+          "short_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Short Id"
+          },
+          "sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku"
+          },
           "stock": {
             "anyOf": [
               {
@@ -4625,6 +4691,28 @@
             "format": "uuid",
             "title": "Shop Id",
             "type": "string"
+          },
+          "short_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Short Id"
+          },
+          "sku": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sku"
           },
           "stock": {
             "anyOf": [
@@ -5540,6 +5628,11 @@
             "title": "Enable Stock On Products",
             "type": "boolean"
           },
+          "force_unique_product_names": {
+            "default": false,
+            "title": "Force Unique Product Names",
+            "type": "boolean"
+          },
           "language_alt1_enabled": {
             "default": false,
             "title": "Language Alt1 Enabled",
@@ -5628,7 +5721,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.3.4"
+    "version": "0.3.5"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## Summary

- Adds `short_id` (12-char UUID prefix, globally unique) to `ProductTable` — backfilled for all existing rows in the schema migration
- Adds optional `sku` (VARCHAR 64, unique per shop) — SKU takes priority over `short_id` as the URL identifier in storefronts
- Adds `force_unique_product_names` toggle to `Toggles` config — when enabled, `POST`/`PUT` products reject duplicate `main_name` with HTTP 409
- Enabling `force_unique_product_names` via `PUT /shops/config/{id}` now validates existing product names first — returns 409 if duplicates already exist in the shop
- Both fields are exposed in `ProductResponse`, `ProductWithDetailsAndPrices`, `ProductCreate`, and `ProductUpdate` schemas
- Prices endpoint updated to include `short_id` and `sku` in the response

## Migration

`migrations/versions/schema/2026-06-26_f1a2b3c4d5e6_add_sku_and_short_id_to_products.py`:
- Adds `sku` and `short_id` columns
- Backfills `short_id = LEFT(id::text, 12)` for all existing products
- Makes `short_id` NOT NULL after backfill
- Creates unique index on `short_id` (global) and partial unique index on `(shop_id, sku)` where `sku IS NOT NULL`

## Test plan

- [ ] Run `PYTHONPATH=. alembic upgrade heads` — migration applies cleanly
- [ ] `GET /shops/{shop_id}/products/{id}` returns `short_id` and `sku` fields
- [ ] Creating a product sets `short_id` automatically
- [ ] Creating a product with a duplicate `sku` within the same shop returns 409
- [ ] With `force_unique_product_names=true`, creating a product with a duplicate name returns 409
- [ ] With `force_unique_product_names=false` (default), duplicate names are allowed
- [ ] Enabling `force_unique_product_names` on a shop with existing duplicate names returns 409 with the offending name
- [ ] Enabling `force_unique_product_names` on a shop with no duplicates saves successfully

Closes acidjunk/shop-poc#262

🤖 Generated with [Claude Code](https://claude.com/claude-code)