### PR TITLE
Add revisions, soft deletes and trash/restore to the PIM

### DIFF
--- a/migrations/versions/schema/2026-07-01_a3f5c7d9e1b2_add_revisions_table.py
+++ b/migrations/versions/schema/2026-07-01_a3f5c7d9e1b2_add_revisions_table.py
@@ -1,0 +1,58 @@
+"""Add revisions table for PIM aggregate snapshots.
+
+Revision ID: a3f5c7d9e1b2
+Revises: f1a2b3c4d5e6
+Create Date: 2026-07-01 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a3f5c7d9e1b2"
+down_revision = "f1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "revisions",
+        sa.Column(
+            "id",
+            sqlalchemy_utils.types.uuid.UUIDType(),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+        sa.Column("shop_id", sqlalchemy_utils.types.uuid.UUIDType(), nullable=False),
+        sa.Column("entity_type", sa.String(30), nullable=False),
+        sa.Column("entity_id", sqlalchemy_utils.types.uuid.UUIDType(), nullable=False),
+        sa.Column("revision_no", sa.Integer(), nullable=False),
+        sa.Column("action", sa.String(20), nullable=False),
+        sa.Column("schema_version", sa.Integer(), server_default="1", nullable=False),
+        sa.Column("data", postgresql.JSONB(), nullable=False),
+        sa.Column("created_by", sa.String(128), nullable=True),
+        sa.Column("source", sa.String(10), server_default="rest", nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(["shop_id"], ["shops.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("entity_type", "entity_id", "revision_no", name="uq_revision_entity_no"),
+    )
+    op.create_index(op.f("ix_revisions_id"), "revisions", ["id"], unique=False)
+    op.create_index(op.f("ix_revisions_shop_id"), "revisions", ["shop_id"], unique=False)
+    op.create_index("ix_revisions_entity", "revisions", ["entity_type", "entity_id", "revision_no"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_revisions_entity", table_name="revisions")
+    op.drop_index(op.f("ix_revisions_shop_id"), table_name="revisions")
+    op.drop_index(op.f("ix_revisions_id"), table_name="revisions")
+    op.drop_table("revisions")

--- a/migrations/versions/schema/2026-07-01_b4e6d8f0a2c3_add_soft_delete_columns.py
+++ b/migrations/versions/schema/2026-07-01_b4e6d8f0a2c3_add_soft_delete_columns.py
@@ -1,0 +1,36 @@
+"""Add soft-delete columns to PIM tables.
+
+Revision ID: b4e6d8f0a2c3
+Revises: a3f5c7d9e1b2
+Create Date: 2026-07-01 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+import sqlalchemy_utils
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b4e6d8f0a2c3"
+down_revision = "a3f5c7d9e1b2"
+branch_labels = None
+depends_on = None
+
+SOFT_DELETE_TABLES = ["products", "categories", "tags", "attributes", "attribute_options"]
+
+
+def upgrade() -> None:
+    for table in SOFT_DELETE_TABLES:
+        op.add_column(table, sa.Column("deleted_at", sa.TIMESTAMP(timezone=True), nullable=True))
+        op.create_index(f"ix_{table}_deleted_at", table, ["deleted_at"], unique=False)
+
+    op.add_column("products", sa.Column("deleted_batch_id", sqlalchemy_utils.types.uuid.UUIDType(), nullable=True))
+    op.create_index("ix_products_deleted_batch_id", "products", ["deleted_batch_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_products_deleted_batch_id", table_name="products")
+    op.drop_column("products", "deleted_batch_id")
+    for table in reversed(SOFT_DELETE_TABLES):
+        op.drop_index(f"ix_{table}_deleted_at", table_name=table)
+        op.drop_column(table, "deleted_at")

--- a/server/api/api.py
+++ b/server/api/api.py
@@ -43,6 +43,7 @@ from server.api.endpoints.shop_endpoints import (
     product_attribute_values,
     products,
     products_to_tags,
+    revisions,
     shipping,
     stripe,
     tags,
@@ -135,6 +136,12 @@ api_router.include_router(
     prefix="/shops/{shop_id}/products-to-tags",
     tags=["shops", "products"],
     dependencies=[Depends(auth_required)],
+)
+api_router.include_router(
+    revisions.router,
+    prefix="/shops/{shop_id}",
+    tags=["shops", "revisions"],
+    dependencies=[Depends(auth_required_any)],
 )
 api_router.include_router(
     tags.router,

--- a/server/api/endpoints/shop_endpoints/attribute_options.py
+++ b/server/api/endpoints/shop_endpoints/attribute_options.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timezone
 from http import HTTPStatus
-from typing import List
+from typing import Any, List
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 from fastapi.param_functions import Body, Depends
 from sqlalchemy.exc import IntegrityError
 from starlette.responses import Response
@@ -16,11 +16,12 @@ from server.crud.crud_attribute_option import attribute_option_crud
 from server.db import db
 from server.db.models import AttributeOptionTable, AttributeTable
 from server.schemas.attribute_option import (
-    AttributeOptionBase,
     AttributeOptionCreate,
     AttributeOptionSchema,
     AttributeOptionUpdate,
 )
+from server.security import auth_required
+from server.services.revisions import actor, ensure_baseline_attribute_revision, record_attribute_revision
 
 logger = structlog.get_logger(__name__)
 
@@ -84,7 +85,13 @@ def get_option(shop_id: UUID, attribute_id: UUID, option_id: UUID) -> AttributeO
     description="Create a new option for a specific attribute. The value_key should be a language-agnostic identifier (e.g., 'XL').",
     deprecated=True,
 )
-def create_option(shop_id: UUID, attribute_id: UUID, data: dict = Body(...)) -> AttributeOptionSchema:
+def create_option(
+    shop_id: UUID,
+    attribute_id: UUID,
+    request: Request,
+    data: dict = Body(...),
+    principal: Any = Depends(auth_required),
+) -> AttributeOptionSchema:
     """
     Create a new option for an attribute within a shop.
 
@@ -100,14 +107,20 @@ def create_option(shop_id: UUID, attribute_id: UUID, data: dict = Body(...)) -> 
     if not value_key:
         raise_status(HTTPStatus.UNPROCESSABLE_ENTITY, "value_key is required")
 
-    payload = AttributeOptionBase(attribute_id=attribute_id, value_key=value_key)
-    logger.info("Saving attribute option", attribute_id=str(attribute_id), value_key=payload.value_key)
+    logger.info("Saving attribute option", attribute_id=str(attribute_id), value_key=value_key)
 
+    created_by, source = actor(principal, request)
+    ensure_baseline_attribute_revision(attribute)
+    option = AttributeOptionTable(attribute_id=attribute_id, value_key=value_key)
+    db.session.add(option)
     try:
-        option = attribute_option_crud.create(obj_in=payload)
-        return option
+        record_attribute_revision(attribute, action="update", created_by=created_by, source=source)
+        db.session.commit()
     except IntegrityError:
+        db.session.rollback()
         raise_status(HTTPStatus.CONFLICT, f"Option with value_key {value_key} already exists for this attribute")
+    db.session.refresh(option)
+    return option
 
 
 @deprecated_router.delete(
@@ -122,7 +135,9 @@ def delete_option(
     shop_id: UUID,
     attribute_id: UUID,
     option_id: UUID,
+    request: Request,
     force: bool = Query(False, description="Permanently purge instead of moving to trash. Irreversible."),
+    principal: Any = Depends(auth_required),
 ) -> None:
     """Delete an attribute option."""
     # Ensure attribute belongs to shop
@@ -134,18 +149,30 @@ def delete_option(
     if not option or option.attribute_id != attribute_id:
         raise_status(HTTPStatus.NOT_FOUND, f"Option with id {option_id} not found for this attribute")
 
-    if force:
-        try:
-            attribute_option_crud.delete(id=str(option_id))
-        except IntegrityError:
-            raise_status(
-                HTTPStatus.CONFLICT,
-                detail={"message": "Attribute option is in use and cannot be deleted"},
-            )
-        return None
+    return _delete_option(attribute, option, force, principal, request)
 
-    option.deleted_at = datetime.now(timezone.utc)
-    db.session.commit()
+
+def _delete_option(
+    attribute: AttributeTable, option: AttributeOptionTable, force: bool, principal: Any, request: Request
+) -> None:
+    """Shared delete flow: soft delete by default, hard purge with force; both record an attribute revision."""
+    created_by, source = actor(principal, request)
+    ensure_baseline_attribute_revision(attribute)
+
+    if force:
+        db.session.delete(option)
+    else:
+        option.deleted_at = datetime.now(timezone.utc)
+
+    try:
+        record_attribute_revision(attribute, action="update", created_by=created_by, source=source)
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        raise_status(
+            HTTPStatus.CONFLICT,
+            detail={"message": "Attribute option is in use and cannot be deleted"},
+        )
     return None
 
 
@@ -178,7 +205,9 @@ def list_options_for_shop(
     summary="Create attribute option",
     description="Create a new option for a specific attribute within a shop. The attribute_id must be provided in the request body.",
 )
-def create_option_v2(shop_id: UUID, data: AttributeOptionCreate = Body(...)) -> AttributeOptionSchema:
+def create_option_v2(
+    shop_id: UUID, request: Request, data: AttributeOptionCreate = Body(...), principal: Any = Depends(auth_required)
+) -> AttributeOptionSchema:
     """
     Create a new option for an attribute within a shop.
 
@@ -191,11 +220,18 @@ def create_option_v2(shop_id: UUID, data: AttributeOptionCreate = Body(...)) -> 
 
     logger.info("Saving attribute option", attribute_id=str(data.attribute_id), value_key=data.value_key)
 
+    created_by, source = actor(principal, request)
+    ensure_baseline_attribute_revision(attribute)
+    option = AttributeOptionTable(**data.model_dump())
+    db.session.add(option)
     try:
-        option = attribute_option_crud.create(obj_in=data)
-        return option
+        record_attribute_revision(attribute, action="update", created_by=created_by, source=source)
+        db.session.commit()
     except IntegrityError:
+        db.session.rollback()
         raise_status(HTTPStatus.CONFLICT, f"Option with value_key {data.value_key} already exists for this attribute")
+    db.session.refresh(option)
+    return option
 
 
 @router.get(
@@ -223,7 +259,13 @@ def get_option_v2(shop_id: UUID, option_id: UUID) -> AttributeOptionSchema:
     summary="Update attribute option",
     description="Update the details of an existing attribute option, ensuring it belongs to the shop.",
 )
-def update_option_v2(shop_id: UUID, option_id: UUID, data: AttributeOptionUpdate = Body(...)) -> AttributeOptionSchema:
+def update_option_v2(
+    shop_id: UUID,
+    option_id: UUID,
+    request: Request,
+    data: AttributeOptionUpdate = Body(...),
+    principal: Any = Depends(auth_required),
+) -> AttributeOptionSchema:
     """Update an attribute option."""
     option = (
         db.session.query(AttributeOptionTable)
@@ -234,9 +276,16 @@ def update_option_v2(shop_id: UUID, option_id: UUID, data: AttributeOptionUpdate
     if not option:
         raise_status(HTTPStatus.NOT_FOUND, f"Option with id {option_id} not found for this shop")
 
+    attribute = option.attribute
+    created_by, source = actor(principal, request)
+    ensure_baseline_attribute_revision(attribute)
     try:
-        return attribute_option_crud.update(db_obj=option, obj_in=data)
+        option = attribute_option_crud.update(db_obj=option, obj_in=data, commit=False)
+        record_attribute_revision(attribute, action="update", created_by=created_by, source=source)
+        db.session.commit()
+        return option
     except IntegrityError:
+        db.session.rollback()
         raise_status(HTTPStatus.CONFLICT, f"Option with value_key {data.value_key} already exists for this attribute")
 
 
@@ -250,7 +299,9 @@ def update_option_v2(shop_id: UUID, option_id: UUID, data: AttributeOptionUpdate
 def delete_option_v2(
     shop_id: UUID,
     option_id: UUID,
+    request: Request,
     force: bool = Query(False, description="Permanently purge instead of moving to trash. Irreversible."),
+    principal: Any = Depends(auth_required),
 ) -> None:
     """Delete an attribute option."""
     option = (
@@ -263,16 +314,4 @@ def delete_option_v2(
     if not option:
         raise_status(HTTPStatus.NOT_FOUND, f"Option with id {option_id} not found for this shop")
 
-    if force:
-        try:
-            attribute_option_crud.delete(id=str(option_id))
-        except IntegrityError:
-            raise_status(
-                HTTPStatus.CONFLICT,
-                detail={"message": "Attribute option is in use and cannot be deleted"},
-            )
-        return None
-
-    option.deleted_at = datetime.now(timezone.utc)
-    db.session.commit()
-    return None
+    return _delete_option(option.attribute, option, force, principal, request)

--- a/server/api/endpoints/shop_endpoints/attribute_options.py
+++ b/server/api/endpoints/shop_endpoints/attribute_options.py
@@ -1,9 +1,10 @@
+from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import List
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from fastapi.param_functions import Body, Depends
 from sqlalchemy.exc import IntegrityError
 from starlette.responses import Response
@@ -117,7 +118,12 @@ def create_option(shop_id: UUID, attribute_id: UUID, data: dict = Body(...)) -> 
     description="Remove an attribute option. This will fail if the option is currently used by any product values.",
     deprecated=True,
 )
-def delete_option(shop_id: UUID, attribute_id: UUID, option_id: UUID) -> None:
+def delete_option(
+    shop_id: UUID,
+    attribute_id: UUID,
+    option_id: UUID,
+    force: bool = Query(False, description="Permanently purge instead of moving to trash. Irreversible."),
+) -> None:
     """Delete an attribute option."""
     # Ensure attribute belongs to shop
     attribute = attribute_crud.get_id_by_shop_id(shop_id=shop_id, id=attribute_id)
@@ -128,13 +134,18 @@ def delete_option(shop_id: UUID, attribute_id: UUID, option_id: UUID) -> None:
     if not option or option.attribute_id != attribute_id:
         raise_status(HTTPStatus.NOT_FOUND, f"Option with id {option_id} not found for this attribute")
 
-    try:
-        attribute_option_crud.delete(id=str(option_id))
-    except IntegrityError:
-        raise_status(
-            HTTPStatus.CONFLICT,
-            detail={"message": "Attribute option is in use and cannot be deleted"},
-        )
+    if force:
+        try:
+            attribute_option_crud.delete(id=str(option_id))
+        except IntegrityError:
+            raise_status(
+                HTTPStatus.CONFLICT,
+                detail={"message": "Attribute option is in use and cannot be deleted"},
+            )
+        return None
+
+    option.deleted_at = datetime.now(timezone.utc)
+    db.session.commit()
     return None
 
 
@@ -236,22 +247,32 @@ def update_option_v2(shop_id: UUID, option_id: UUID, data: AttributeOptionUpdate
     summary="Delete attribute option",
     description="Remove an attribute option, ensuring it belongs to the shop.",
 )
-def delete_option_v2(shop_id: UUID, option_id: UUID) -> None:
+def delete_option_v2(
+    shop_id: UUID,
+    option_id: UUID,
+    force: bool = Query(False, description="Permanently purge instead of moving to trash. Irreversible."),
+) -> None:
     """Delete an attribute option."""
     option = (
         db.session.query(AttributeOptionTable)
         .join(AttributeTable)
         .filter(AttributeOptionTable.id == option_id, AttributeTable.shop_id == shop_id)
+        .execution_options(include_deleted=force)
         .first()
     )
     if not option:
         raise_status(HTTPStatus.NOT_FOUND, f"Option with id {option_id} not found for this shop")
 
-    try:
-        attribute_option_crud.delete(id=str(option_id))
-    except IntegrityError:
-        raise_status(
-            HTTPStatus.CONFLICT,
-            detail={"message": "Attribute option is in use and cannot be deleted"},
-        )
+    if force:
+        try:
+            attribute_option_crud.delete(id=str(option_id))
+        except IntegrityError:
+            raise_status(
+                HTTPStatus.CONFLICT,
+                detail={"message": "Attribute option is in use and cannot be deleted"},
+            )
+        return None
+
+    option.deleted_at = datetime.now(timezone.utc)
+    db.session.commit()
     return None

--- a/server/api/endpoints/shop_endpoints/attributes.py
+++ b/server/api/endpoints/shop_endpoints/attributes.py
@@ -4,7 +4,7 @@ from typing import Any, List
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.param_functions import Body, Depends
 from sqlalchemy.exc import IntegrityError
 from starlette.responses import Response
@@ -25,6 +25,7 @@ from server.schemas.attribute import (
     AttributeWithOptionsSchema,
 )
 from server.security import auth_required_any
+from server.services.revisions import actor, ensure_baseline_attribute_revision, record_attribute_revision
 
 logger = structlog.get_logger(__name__)
 
@@ -165,7 +166,9 @@ def get_by_name(name: str, shop_id: UUID) -> AttributeSchema:
     tags=[AgentTag.EXPOSED],
     operation_id="create_attribute",
 )
-def create(shop_id: UUID, data: AttributeCreate = Body(...)) -> AttributeSchema:
+def create(
+    shop_id: UUID, request: Request, data: AttributeCreate = Body(...), principal: Any = Depends(auth_required_any)
+) -> AttributeSchema:
     """
     Create a new attribute for the given shop.
 
@@ -176,9 +179,14 @@ def create(shop_id: UUID, data: AttributeCreate = Body(...)) -> AttributeSchema:
     if data.translation is None or data.translation.main_name is None:
         data.translation = AttributeTranslationBase(main_name=data.name)
 
+    created_by, source = actor(principal, request)
     try:
-        attr = attribute_crud.create_by_shop_id(shop_id=shop_id, obj_in=data)
+        attr = attribute_crud.create_by_shop_id(shop_id=shop_id, obj_in=data, commit=False)
+        record_attribute_revision(attr, action="create", created_by=created_by, source=source)
+        db.session.commit()
+        db.session.refresh(attr)
     except IntegrityError:
+        db.session.rollback()
         raise_status(HTTPStatus.CONFLICT, f"Attribute with name {data.name} already exists for this shop")
     return attr
 
@@ -191,15 +199,27 @@ def create(shop_id: UUID, data: AttributeCreate = Body(...)) -> AttributeSchema:
     tags=[AgentTag.EXPOSED],
     operation_id="update_attribute",
 )
-def update(attribute_id: UUID, shop_id: UUID, data: AttributeUpdate = Body(...)) -> AttributeSchema:
+def update(
+    attribute_id: UUID,
+    shop_id: UUID,
+    request: Request,
+    data: AttributeUpdate = Body(...),
+    principal: Any = Depends(auth_required_any),
+) -> AttributeSchema:
     """Update an attribute for a shop."""
-    attribute = attribute_crud.get_id_by_shop_id(shop_id, attribute_id)
+    attribute = attribute_crud.get_id_by_shop_id(shop_id, attribute_id, for_update=True)
     if not attribute:
         raise_status(HTTPStatus.NOT_FOUND, f"Attribute with id {attribute_id} not found")
 
+    created_by, source = actor(principal, request)
+    ensure_baseline_attribute_revision(attribute)
     try:
-        return attribute_crud.update(db_obj=attribute, obj_in=data)
+        attribute = attribute_crud.update(db_obj=attribute, obj_in=data, commit=False)
+        record_attribute_revision(attribute, action="update", created_by=created_by, source=source)
+        db.session.commit()
+        return attribute
     except IntegrityError:
+        db.session.rollback()
         raise_status(HTTPStatus.CONFLICT, f"Attribute with name {data.name} already exists for this shop")
 
 
@@ -220,6 +240,7 @@ def update(attribute_id: UUID, shop_id: UUID, data: AttributeUpdate = Body(...))
 def delete(
     attribute_id: UUID,
     shop_id: UUID,
+    request: Request,
     force: bool = Query(False, description="Permanently purge instead of moving to trash. Irreversible."),
     principal: Any = Depends(auth_required_any),
 ) -> None:
@@ -244,6 +265,8 @@ def delete(
                 detail={"message": "Attribute is in use and cannot be deleted"},
             )
 
+    created_by, source = actor(principal, request)
+    record_attribute_revision(attribute, action="delete", created_by=created_by, source=source)
     attribute.deleted_at = datetime.now(timezone.utc)
     db.session.commit()
     return None

--- a/server/api/endpoints/shop_endpoints/attributes.py
+++ b/server/api/endpoints/shop_endpoints/attributes.py
@@ -1,9 +1,10 @@
+from datetime import datetime, timezone
 from http import HTTPStatus
-from typing import List
+from typing import Any, List
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Query
 from fastapi.param_functions import Body, Depends
 from sqlalchemy.exc import IntegrityError
 from starlette.responses import Response
@@ -14,7 +15,7 @@ from server.api.error_handling import raise_status
 from server.crud.base import NotFound
 from server.crud.crud_attribute import attribute_crud
 from server.db import db
-from server.db.models import AttributeOptionTable
+from server.db.models import ApiKeyTable, AttributeOptionTable
 from server.schemas.attribute import (
     AttributeBase,
     AttributeCreate,
@@ -23,6 +24,7 @@ from server.schemas.attribute import (
     AttributeUpdate,
     AttributeWithOptionsSchema,
 )
+from server.security import auth_required_any
 
 logger = structlog.get_logger(__name__)
 
@@ -205,19 +207,43 @@ def update(attribute_id: UUID, shop_id: UUID, data: AttributeUpdate = Body(...))
     "/{attribute_id}",
     response_model=None,
     status_code=HTTPStatus.NO_CONTENT,
-    summary="Delete attribute",
-    description="Remove an attribute from a shop. This will fail if the attribute is currently in use by any products.",
+    summary="Delete attribute (moves to trash)",
+    description=(
+        "Moves an attribute to the trash: it disappears from listings but existing product values keep "
+        "their data, so restoring the attribute brings everything back. This action is reversible. "
+        "Only `force=true` permanently purges the attribute (fails with 409 while products still use it); "
+        "that is irreversible and requires user (Cognito) credentials — API keys get 403."
+    ),
     tags=[AgentTag.EXPOSED],
     operation_id="delete_attribute",
 )
-def delete(attribute_id: UUID, shop_id: UUID) -> None:
+def delete(
+    attribute_id: UUID,
+    shop_id: UUID,
+    force: bool = Query(False, description="Permanently purge instead of moving to trash. Irreversible."),
+    principal: Any = Depends(auth_required_any),
+) -> None:
     """Delete an attribute for a shop."""
-    try:
-        return attribute_crud.delete_by_shop_id(shop_id=shop_id, id=attribute_id)
-    except NotFound:
+    attribute = attribute_crud.get_id_by_shop_id(shop_id, attribute_id, for_update=True, include_deleted=force)
+    if not attribute:
         raise_status(HTTPStatus.NOT_FOUND, f"Attribute with id {attribute_id} not found")
-    except IntegrityError as e:
-        raise_status(
-            HTTPStatus.CONFLICT,
-            detail={"message": "Attribute is in use and cannot be deleted"},
-        )
+
+    if force:
+        if isinstance(principal, ApiKeyTable):
+            raise HTTPException(
+                status_code=403,
+                detail="Purging an attribute is irreversible and requires user credentials; API keys may only trash.",
+            )
+        try:
+            return attribute_crud.delete_by_shop_id(shop_id=shop_id, id=attribute_id, include_deleted=True)
+        except NotFound:
+            raise_status(HTTPStatus.NOT_FOUND, f"Attribute with id {attribute_id} not found")
+        except IntegrityError:
+            raise_status(
+                HTTPStatus.CONFLICT,
+                detail={"message": "Attribute is in use and cannot be deleted"},
+            )
+
+    attribute.deleted_at = datetime.now(timezone.utc)
+    db.session.commit()
+    return None

--- a/server/api/endpoints/shop_endpoints/categories.py
+++ b/server/api/endpoints/shop_endpoints/categories.py
@@ -1,11 +1,12 @@
 import json
 from collections import defaultdict
+from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import Any, List, Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import structlog
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.param_functions import Body, Depends
 from sqlalchemy import func
 from sqlalchemy.orm import aliased
@@ -47,6 +48,8 @@ from server.schemas.product import (
     ProductWithDefaultPrice,
 )
 from server.schemas.product_attribute import ProductAttributeItem
+from server.security import auth_required_any
+from server.services.revisions import actor, record_category_revision, record_product_revision
 
 logger = structlog.get_logger(__name__)
 
@@ -129,12 +132,19 @@ def get_by_name(name: str, shop_id: UUID) -> CategorySchema:
     summary="Create category",
     description="Add a new category to a shop. The `order_number` is automatically set to the next available value.",
 )
-def create(shop_id: UUID, data: CategoryCreate = Body(...)) -> None:
+def create(
+    shop_id: UUID, request: Request, data: CategoryCreate = Body(...), principal: Any = Depends(auth_required_any)
+) -> None:
     category = CategoryTable.query.filter_by(shop_id=shop_id).order_by(CategoryTable.order_number.desc()).first()
     data.order_number = (category.order_number + 1) if category is not None else 0
 
     logger.info("Saving category", data=data)
-    return category_crud.create_by_shop_id(obj_in=data, shop_id=shop_id)
+    created_by, source = actor(principal, request)
+    category = category_crud.create_by_shop_id(obj_in=data, shop_id=shop_id, commit=False)
+    record_category_revision(category, action="create", created_by=created_by, source=source)
+    db.session.commit()
+    db.session.refresh(category)
+    return category
 
 
 @router.put(
@@ -146,16 +156,27 @@ def create(shop_id: UUID, data: CategoryCreate = Body(...)) -> None:
     summary="Update category",
     description="Update an existing category's details and translations.",
 )
-def update(*, category_id: UUID, shop_id: UUID, item_in: CategoryUpdate) -> Any:
-    category = category_crud.get_id_by_shop_id(shop_id, category_id)
+def update(
+    *,
+    category_id: UUID,
+    shop_id: UUID,
+    item_in: CategoryUpdate,
+    request: Request,
+    principal: Any = Depends(auth_required_any),
+) -> Any:
+    category = category_crud.get_id_by_shop_id(shop_id, category_id, for_update=True)
     logger.info("Updating category", data=category)
     if not category:
         raise HTTPException(status_code=404, detail="Category not found")
 
+    created_by, source = actor(principal, request)
     category = category_crud.update(
         db_obj=category,
         obj_in=item_in,
+        commit=False,
     )
+    record_category_revision(category, action="update", created_by=created_by, source=source)
+    db.session.commit()
 
     # if category.shop_id is not None:
     #     invalidateShopCache(category.shop_id)
@@ -207,11 +228,78 @@ def swap(shop_id: UUID, category_id: UUID, move_up: bool):
     status_code=HTTPStatus.NO_CONTENT,
     tags=[AgentTag.EXPOSED],
     operation_id="delete_category",
-    summary="Delete category",
-    description="Remove a category from the shop. Fails if any products are still assigned to it.",
+    summary="Delete category (moves to trash)",
+    description=(
+        "Moves a category to the trash (restorable with `restore_category`). If products are still "
+        "assigned to it the request fails with 409 and the product count; retry with `force=true` to "
+        "also move all those products to the trash (restorable as one batch), or with `detach=true` to "
+        "keep the products but clear their category. `force` and `detach` are mutually exclusive."
+    ),
 )
-def delete(category_id: UUID, shop_id: UUID) -> None:
-    return category_crud.delete_by_shop_id(shop_id=shop_id, id=category_id)
+def delete(
+    category_id: UUID,
+    shop_id: UUID,
+    request: Request,
+    force: bool = Query(False, description="Also move all products in this category to the trash."),
+    detach: bool = Query(False, description="Keep the products; clear their category reference instead."),
+    principal: Any = Depends(auth_required_any),
+) -> None:
+    if force and detach:
+        raise HTTPException(status_code=422, detail="force and detach are mutually exclusive")
+
+    category = category_crud.get_id_by_shop_id(shop_id, category_id, for_update=True)
+    if not category:
+        raise HTTPException(status_code=404, detail="Category not found")
+
+    products = (
+        db.session.query(ProductTable)
+        .filter(ProductTable.shop_id == shop_id, ProductTable.category_id == category_id)
+        .with_for_update()
+        .all()
+    )
+
+    if products and not force and not detach:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": f"Category still has {len(products)} product(s); deleting it affects all of them.",
+                "product_count": len(products),
+                "hint": (
+                    "Retry with force=true to move the products to the trash too (restorable as one batch), "
+                    "or detach=true to keep the products without a category."
+                ),
+            },
+        )
+
+    created_by, source = actor(principal, request)
+    now = datetime.now(timezone.utc)
+    extra_data = None
+
+    if products and force:
+        batch_id = uuid4()
+        for product in products:
+            record_product_revision(product, action="delete", created_by=created_by, source=source)
+            product.deleted_at = now
+            product.deleted_batch_id = batch_id
+        extra_data = {"deleted_batch_id": str(batch_id), "deleted_product_count": len(products)}
+    elif products and detach:
+        category_name = category.translation.main_name if category.translation else None
+        detached_from = {"id": str(category_id), "name": category_name}
+        for product in products:
+            product.category_id = None
+            record_product_revision(
+                product,
+                action="update",
+                created_by=created_by,
+                source=source,
+                extra_data={"detached_from_category": detached_from},
+            )
+        extra_data = {"detached_product_count": len(products)}
+
+    record_category_revision(category, action="delete", created_by=created_by, source=source, extra_data=extra_data)
+    category.deleted_at = now
+    db.session.commit()
+    return None
 
 
 @public_router.get(

--- a/server/api/endpoints/shop_endpoints/categories.py
+++ b/server/api/endpoints/shop_endpoints/categories.py
@@ -49,7 +49,13 @@ from server.schemas.product import (
 )
 from server.schemas.product_attribute import ProductAttributeItem
 from server.security import auth_required_any
-from server.services.revisions import actor, record_category_revision, record_product_revision
+from server.services.revisions import (
+    actor,
+    ensure_baseline_category_revision,
+    ensure_baseline_product_revision,
+    record_category_revision,
+    record_product_revision,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -170,6 +176,7 @@ def update(
         raise HTTPException(status_code=404, detail="Category not found")
 
     created_by, source = actor(principal, request)
+    ensure_baseline_category_revision(category)
     category = category_crud.update(
         db_obj=category,
         obj_in=item_in,
@@ -286,6 +293,7 @@ def delete(
         category_name = category.translation.main_name if category.translation else None
         detached_from = {"id": str(category_id), "name": category_name}
         for product in products:
+            ensure_baseline_product_revision(product)
             product.category_id = None
             record_product_revision(
                 product,

--- a/server/api/endpoints/shop_endpoints/category_images.py
+++ b/server/api/endpoints/shop_endpoints/category_images.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from http import HTTPStatus
+from typing import Any
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.param_functions import Depends
 from starlette.responses import Response
 
@@ -11,7 +12,10 @@ from server.api.deps import common_parameters
 from server.api.error_handling import raise_status
 from server.api.helpers import name_file, upload_file
 from server.crud.crud_category import category_crud
+from server.db import db
 from server.schemas.category import CategoryImageDelete, CategoryUpdate
+from server.security import auth_required
+from server.services.revisions import actor, record_category_revision
 
 logger = structlog.get_logger(__name__)
 router = APIRouter()
@@ -41,7 +45,7 @@ def get_by_id(id: UUID):
 
 
 @router.put("/{id}", status_code=HTTPStatus.CREATED)
-def put(*, id: UUID, item_in: CategoryUpdate):
+def put(*, id: UUID, item_in: CategoryUpdate, request: Request, principal: Any = Depends(auth_required)):
     item = category_crud.get(id=id)
     # todo: raise 404 o abort
 
@@ -60,13 +64,17 @@ def put(*, id: UUID, item_in: CategoryUpdate):
         item = category_crud.update(
             db_obj=item,
             obj_in=item_in,
+            commit=False,
         )
+        created_by, source = actor(principal, request)
+        record_category_revision(item, action="update", created_by=created_by, source=source)
+        db.session.commit()
 
     return item
 
 
 @router.put("/delete/{id}", status_code=HTTPStatus.CREATED)
-def delete_image(*, id: UUID, col: CategoryImageDelete):
+def delete_image(*, id: UUID, col: CategoryImageDelete, request: Request, principal: Any = Depends(auth_required)):
     item = category_crud.get(id=id)
 
     if not item:
@@ -79,9 +87,15 @@ def delete_image(*, id: UUID, col: CategoryImageDelete):
 
     setattr(item_in, col.image, None)
 
+    # Only the DB reference is cleared; the underlying S3 object is intentionally kept
+    # so older revisions referencing this filename stay restorable.
     item = category_crud.update(
         db_obj=item,
         obj_in=item_in,
+        commit=False,
     )
+    created_by, source = actor(principal, request)
+    record_category_revision(item, action="update", created_by=created_by, source=source)
+    db.session.commit()
 
     return item

--- a/server/api/endpoints/shop_endpoints/category_images.py
+++ b/server/api/endpoints/shop_endpoints/category_images.py
@@ -15,7 +15,7 @@ from server.crud.crud_category import category_crud
 from server.db import db
 from server.schemas.category import CategoryImageDelete, CategoryUpdate
 from server.security import auth_required
-from server.services.revisions import actor, record_category_revision
+from server.services.revisions import actor, ensure_baseline_category_revision, record_category_revision
 
 logger = structlog.get_logger(__name__)
 router = APIRouter()
@@ -61,6 +61,7 @@ def put(*, id: UUID, item_in: CategoryUpdate, request: Request, principal: Any =
             item_in.__setattr__(image_col, name)
 
     if category_update:
+        ensure_baseline_category_revision(item)
         item = category_crud.update(
             db_obj=item,
             obj_in=item_in,
@@ -89,6 +90,7 @@ def delete_image(*, id: UUID, col: CategoryImageDelete, request: Request, princi
 
     # Only the DB reference is cleared; the underlying S3 object is intentionally kept
     # so older revisions referencing this filename stay restorable.
+    ensure_baseline_category_revision(item)
     item = category_crud.update(
         db_obj=item,
         obj_in=item_in,

--- a/server/api/endpoints/shop_endpoints/product_attribute_values.py
+++ b/server/api/endpoints/shop_endpoints/product_attribute_values.py
@@ -27,7 +27,7 @@ from server.schemas.product_attribute_value import (
     ProductAttributeValueSchema,
 )
 from server.security import auth_required
-from server.services.revisions import actor, record_product_revision
+from server.services.revisions import actor, ensure_baseline_product_revision, record_product_revision
 
 logger = structlog.get_logger(__name__)
 
@@ -135,6 +135,7 @@ def create_product_attribute_values(
         raise_status(HTTPStatus.CONFLICT, "Product attribute value already exists for this product/attribute/option")
 
     # Create + record a product revision in the same transaction
+    ensure_baseline_product_revision(product)
     db.session.add(ProductAttributeValueTable(**data.model_dump()))
     created_by, source = actor(principal, request)
     record_product_revision(product, action="update", created_by=created_by, source=source)
@@ -206,6 +207,7 @@ def create_product_attribute_values_for_product(
     new_pavs = _create_product_attribute_values(product_id, options, {pav.option_id for pav in existing_pavs})
 
     if new_pavs:
+        ensure_baseline_product_revision(product)
         db.session.add_all(new_pavs)
         created_by, source = actor(principal, request)
         record_product_revision(product, action="update", created_by=created_by, source=source)
@@ -332,6 +334,8 @@ def put_selected_product_attribute_values_by_product(
             )
 
     # Batch execute changes
+    if to_add_objs or to_delete_objs:
+        ensure_baseline_product_revision(product)
     if to_add_objs:
         db.session.add_all(to_add_objs)
     for obj in to_delete_objs:
@@ -362,6 +366,7 @@ def delete_product_attribute_value(
     if not pav.product or pav.product.shop_id != shop_id:
         raise_status(HTTPStatus.NOT_FOUND, f"ProductAttributeValue with id {id} not found for this shop")
     product = pav.product
+    ensure_baseline_product_revision(product)
     db.session.delete(pav)
     created_by, source = actor(principal, request)
     record_product_revision(product, action="update", created_by=created_by, source=source)

--- a/server/api/endpoints/shop_endpoints/product_attribute_values.py
+++ b/server/api/endpoints/shop_endpoints/product_attribute_values.py
@@ -8,7 +8,7 @@ from typing import Any, List, Set, Union
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.param_functions import Body, Depends
 from starlette.responses import Response
 
@@ -26,6 +26,8 @@ from server.schemas.product_attribute_value import (
     ProductAttributeValueBase,
     ProductAttributeValueSchema,
 )
+from server.security import auth_required
+from server.services.revisions import actor, record_product_revision
 
 logger = structlog.get_logger(__name__)
 
@@ -85,7 +87,12 @@ def get_product_attribute_value(shop_id: UUID, id: UUID) -> ProductAttributeValu
     summary="Create product attribute values (deprecated)",
     operation_id="product_attribute_values_create_deprecated",
 )
-def create_product_attribute_values(shop_id: UUID, data: ProductAttributeValueBase = Body(...)) -> None:
+def create_product_attribute_values(
+    shop_id: UUID,
+    request: Request,
+    data: ProductAttributeValueBase = Body(...),
+    principal: Any = Depends(auth_required),
+) -> None:
     """
     DEPRECATED: Create a new product attribute value for a product within a shop.
 
@@ -127,10 +134,11 @@ def create_product_attribute_values(shop_id: UUID, data: ProductAttributeValueBa
     if existing:
         raise_status(HTTPStatus.CONFLICT, "Product attribute value already exists for this product/attribute/option")
 
-    # Create
-    product_attribute_value_crud.create(
-        obj_in=data,
-    )
+    # Create + record a product revision in the same transaction
+    db.session.add(ProductAttributeValueTable(**data.model_dump()))
+    created_by, source = actor(principal, request)
+    record_product_revision(product, action="update", created_by=created_by, source=source)
+    db.session.commit()
 
 
 def get_attribute_options_by_ids(option_ids: list[UUID], shop_id: UUID) -> list[AttributeOptionTable]:
@@ -158,7 +166,9 @@ def get_attribute_options_by_ids(option_ids: list[UUID], shop_id: UUID) -> list[
 def create_product_attribute_values_for_product(
     shop_id: UUID,
     product_id: UUID,
+    request: Request,
     data: ProductAttributeOptionSelectionAdd = Body(...),
+    principal: Any = Depends(auth_required),
 ) -> None:
     """Create new product attribute value(s) for a specific product using product_id in the URL.
 
@@ -197,6 +207,8 @@ def create_product_attribute_values_for_product(
 
     if new_pavs:
         db.session.add_all(new_pavs)
+        created_by, source = actor(principal, request)
+        record_product_revision(product, action="update", created_by=created_by, source=source)
         db.session.commit()
 
     return None
@@ -238,7 +250,9 @@ def _create_product_attribute_values(
 def put_selected_product_attribute_values_by_product(
     shop_id: UUID,
     product_id: UUID,
+    request: Request,
     data: ProductAttributeOptionSelectionReplace = Body(...),
+    principal: Any = Depends(auth_required),
 ) -> None:
     """New version of selected options endpoint addressed by product_id in the path.
 
@@ -324,6 +338,8 @@ def put_selected_product_attribute_values_by_product(
         db.session.delete(obj)
 
     if to_add_objs or to_delete_objs:
+        created_by, source = actor(principal, request)
+        record_product_revision(product, action="update", created_by=created_by, source=source)
         db.session.commit()
 
     return None
@@ -336,12 +352,18 @@ def put_selected_product_attribute_values_by_product(
     summary="Delete product attribute value",
     operation_id="product_attribute_values_delete",
 )
-def delete_product_attribute_value(shop_id: UUID, id: UUID) -> None:
+def delete_product_attribute_value(
+    shop_id: UUID, id: UUID, request: Request, principal: Any = Depends(auth_required)
+) -> None:
     """Delete a product attribute value if it belongs to the given shop."""
     pav = product_attribute_value_crud.get(id)
     if not pav:
         raise_status(HTTPStatus.NOT_FOUND, f"ProductAttributeValue with id {id} not found")
     if not pav.product or pav.product.shop_id != shop_id:
         raise_status(HTTPStatus.NOT_FOUND, f"ProductAttributeValue with id {id} not found for this shop")
-    product_attribute_value_crud.delete(id=str(id))
+    product = pav.product
+    db.session.delete(pav)
+    created_by, source = actor(principal, request)
+    record_product_revision(product, action="update", created_by=created_by, source=source)
+    db.session.commit()
     return None

--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -6,7 +6,7 @@ from typing import Any, List, Literal, Optional
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from sqlalchemy.exc import IntegrityError
 from starlette.responses import Response
 
@@ -17,7 +17,7 @@ from server.api.error_handling import raise_status
 from server.crud import crud_shop
 from server.crud.crud_product import product_crud
 from server.db import db
-from server.db.models import ProductTable, ProductTranslationTable
+from server.db.models import ApiKeyTable, ProductTable, ProductTranslationTable
 from server.schemas.product import (
     AttributeFilters,
     ProductCreate,
@@ -30,6 +30,8 @@ from server.schemas.product import (
 )
 from server.schemas.product_attribute import ProductAttributeItem
 from server.schemas.shop import Toggles
+from server.security import auth_required_any
+from server.services.revisions import actor, record_product_revision
 
 logger = structlog.get_logger(__name__)
 
@@ -283,7 +285,12 @@ def get_by_id(product_id: UUID, shop_id: UUID) -> ProductWithDetailsAndPrices:
     summary="Create product",
     description="Add a new product to a shop category. The `order_number` is automatically set to the next available value within the category.",
 )
-def create(shop_id: UUID, data: ProductCreate = Body(...)) -> None:
+def create(
+    shop_id: UUID,
+    request: Request,
+    data: ProductCreate = Body(...),
+    principal: Any = Depends(auth_required_any),
+) -> None:
     shop = get_shop(shop_id)
     raw = json.loads(shop.config) if isinstance(shop.config, str) else (shop.config or {})
     toggles = Toggles.model_validate(raw.get("toggles", {}) if isinstance(raw, dict) else {})
@@ -299,8 +306,13 @@ def create(shop_id: UUID, data: ProductCreate = Body(...)) -> None:
     data.order_number = (product.order_number + 1) if product is not None else 0
 
     logger.info("Saving product", data=data)
+    created_by, source = actor(principal, request)
     try:
-        product = product_crud.create_by_shop_id(obj_in=data, shop_id=shop_id)
+        product = product_crud.create_by_shop_id(obj_in=data, shop_id=shop_id, commit=False)
+        db.session.flush()
+        record_product_revision(product, action="create", created_by=created_by, source=source)
+        db.session.commit()
+        db.session.refresh(product)
     except IntegrityError:
         db.session.rollback()
         raise_status(HTTPStatus.CONFLICT, f"A product with SKU '{data.sku}' already exists in this shop")
@@ -316,8 +328,15 @@ def create(shop_id: UUID, data: ProductCreate = Body(...)) -> None:
     summary="Update product",
     description="Update an existing product's details, including name, description, pricing, stock, and feature flags.",
 )
-def update(*, product_id: UUID, shop_id: UUID, item_in: ProductUpdate) -> Any:
-    product = product_crud.get_id_by_shop_id(shop_id, product_id)
+def update(
+    *,
+    product_id: UUID,
+    shop_id: UUID,
+    item_in: ProductUpdate,
+    request: Request,
+    principal: Any = Depends(auth_required_any),
+) -> Any:
+    product = product_crud.get_id_by_shop_id(shop_id, product_id, for_update=True)
     logger.info("Updating product", data=product)
     if not product:
         raise HTTPException(status_code=404, detail="Product not found")
@@ -330,10 +349,15 @@ def update(*, product_id: UUID, shop_id: UUID, item_in: ProductUpdate) -> Any:
 
     item_in.modified_at = datetime.now(timezone.utc)
 
+    created_by, source = actor(principal, request)
     product = product_crud.update(
         db_obj=product,
         obj_in=item_in,
+        commit=False,
     )
+    db.session.flush()
+    record_product_revision(product, action="update", created_by=created_by, source=source)
+    db.session.commit()
     return product
 
 
@@ -396,8 +420,37 @@ def swap(shop_id: UUID, product_id: UUID, move_up: bool):
     status_code=HTTPStatus.NO_CONTENT,
     tags=[AgentTag.EXPOSED],
     operation_id="delete_product",
-    summary="Delete product",
-    description="Permanently remove a product from the shop.",
+    summary="Delete product (moves to trash)",
+    description=(
+        "Moves the product to the trash. The product disappears from all listings but can be "
+        "restored with `restore_product` or via its revisions — this action is reversible. "
+        "Only `force=true` permanently purges the product; that is irreversible and requires "
+        "user (Cognito) credentials — API keys get 403."
+    ),
 )
-def delete(product_id: UUID, shop_id: UUID) -> None:
-    return product_crud.delete_by_shop_id(shop_id=shop_id, id=product_id)
+def delete(
+    product_id: UUID,
+    shop_id: UUID,
+    request: Request,
+    force: bool = Query(False, description="Permanently purge instead of moving to trash. Irreversible."),
+    principal: Any = Depends(auth_required_any),
+) -> None:
+    product = product_crud.get_id_by_shop_id(shop_id, product_id, for_update=True, include_deleted=force)
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+
+    if force:
+        if isinstance(principal, ApiKeyTable):
+            raise HTTPException(
+                status_code=403,
+                detail="Purging a product is irreversible and requires user credentials; API keys may only trash.",
+            )
+        # Hard purge: removes the row (+ translation, tag links, attribute values via
+        # cascades). Revision rows are intentionally kept.
+        return product_crud.delete_by_shop_id(shop_id=shop_id, id=product_id, include_deleted=True)
+
+    created_by, source = actor(principal, request)
+    record_product_revision(product, action="delete", created_by=created_by, source=source)
+    product.deleted_at = datetime.now(timezone.utc)
+    db.session.commit()
+    return None

--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -31,7 +31,7 @@ from server.schemas.product import (
 from server.schemas.product_attribute import ProductAttributeItem
 from server.schemas.shop import Toggles
 from server.security import auth_required_any
-from server.services.revisions import actor, record_product_revision
+from server.services.revisions import actor, ensure_baseline_product_revision, record_product_revision
 
 logger = structlog.get_logger(__name__)
 
@@ -350,6 +350,7 @@ def update(
     item_in.modified_at = datetime.now(timezone.utc)
 
     created_by, source = actor(principal, request)
+    ensure_baseline_product_revision(product)
     product = product_crud.update(
         db_obj=product,
         obj_in=item_in,

--- a/server/api/endpoints/shop_endpoints/products_to_tags.py
+++ b/server/api/endpoints/shop_endpoints/products_to_tags.py
@@ -3,7 +3,7 @@ from typing import Any, List
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.param_functions import Body, Depends
 from starlette.responses import Response
 
@@ -12,7 +12,11 @@ from server.api.error_handling import raise_status
 from server.crud.crud_product import product_crud
 from server.crud.crud_product_to_tag import product_to_tag_crud
 from server.crud.crud_tag import tag_crud
+from server.db import db
+from server.db.models import ProductToTagTable
 from server.schemas.product_to_tag import ProductToTagCreate, ProductToTagSchema, ProductToTagUpdate
+from server.security import auth_required
+from server.services.revisions import actor, record_product_revision
 
 logger = structlog.get_logger(__name__)
 
@@ -76,7 +80,7 @@ def get_by_id(id: UUID) -> ProductToTagSchema:
     summary="Add tag to product",
     description="Create an association between a product and a tag. Both must exist within the shop.",
 )
-def create(data: ProductToTagCreate = Body(...)) -> None:
+def create(request: Request, data: ProductToTagCreate = Body(...), principal: Any = Depends(auth_required)) -> None:
     tag = tag_crud.get(data.tag_id)
     product = product_crud.get(data.product_id)
 
@@ -84,7 +88,11 @@ def create(data: ProductToTagCreate = Body(...)) -> None:
         raise_status(HTTPStatus.NOT_FOUND, "Tag or product not found")
 
     logger.info("Saving product_to_tag", data=data)
-    return product_to_tag_crud.create(obj_in=data)
+    db.session.add(ProductToTagTable(**data.model_dump()))
+    created_by, source = actor(principal, request)
+    record_product_revision(product, action="update", created_by=created_by, source=source)
+    db.session.commit()
+    return None
 
 
 @router.put(
@@ -94,7 +102,9 @@ def create(data: ProductToTagCreate = Body(...)) -> None:
     summary="Update product-tag association",
     description="Update an existing product-tag association record.",
 )
-def update(*, product_to_tag_id: UUID, item_in: ProductToTagUpdate) -> Any:
+def update(
+    *, product_to_tag_id: UUID, item_in: ProductToTagUpdate, request: Request, principal: Any = Depends(auth_required)
+) -> Any:
     product_to_tag = product_to_tag_crud.get(id=product_to_tag_id)
     logger.info("Updating product_to_tag", data=product_to_tag)
     if not product_to_tag:
@@ -103,7 +113,13 @@ def update(*, product_to_tag_id: UUID, item_in: ProductToTagUpdate) -> Any:
     product_to_tag = product_to_tag_crud.update(
         db_obj=product_to_tag,
         obj_in=item_in,
+        commit=False,
     )
+    product = product_crud.get(item_in.product_id)
+    if product is not None:
+        created_by, source = actor(principal, request)
+        record_product_revision(product, action="update", created_by=created_by, source=source)
+    db.session.commit()
     return product_to_tag
 
 
@@ -114,5 +130,14 @@ def update(*, product_to_tag_id: UUID, item_in: ProductToTagUpdate) -> Any:
     summary="Remove tag from product",
     description="Delete the association between a product and a tag.",
 )
-def delete(product_to_tag_id: UUID) -> None:
-    return product_to_tag_crud.delete(id=product_to_tag_id)
+def delete(product_to_tag_id: UUID, request: Request, principal: Any = Depends(auth_required)) -> None:
+    relation = product_to_tag_crud.get(product_to_tag_id)
+    if not relation:
+        raise_status(HTTPStatus.NOT_FOUND, f"ProductToTag with id {product_to_tag_id} not found")
+    product = relation.product
+    db.session.delete(relation)
+    if product is not None:
+        created_by, source = actor(principal, request)
+        record_product_revision(product, action="update", created_by=created_by, source=source)
+    db.session.commit()
+    return None

--- a/server/api/endpoints/shop_endpoints/products_to_tags.py
+++ b/server/api/endpoints/shop_endpoints/products_to_tags.py
@@ -16,7 +16,7 @@ from server.db import db
 from server.db.models import ProductToTagTable
 from server.schemas.product_to_tag import ProductToTagCreate, ProductToTagSchema, ProductToTagUpdate
 from server.security import auth_required
-from server.services.revisions import actor, record_product_revision
+from server.services.revisions import actor, ensure_baseline_product_revision, record_product_revision
 
 logger = structlog.get_logger(__name__)
 
@@ -88,6 +88,7 @@ def create(request: Request, data: ProductToTagCreate = Body(...), principal: An
         raise_status(HTTPStatus.NOT_FOUND, "Tag or product not found")
 
     logger.info("Saving product_to_tag", data=data)
+    ensure_baseline_product_revision(product)
     db.session.add(ProductToTagTable(**data.model_dump()))
     created_by, source = actor(principal, request)
     record_product_revision(product, action="update", created_by=created_by, source=source)
@@ -110,12 +111,14 @@ def update(
     if not product_to_tag:
         raise HTTPException(status_code=404, detail="Shop not found")
 
+    product = product_crud.get(item_in.product_id)
+    if product is not None:
+        ensure_baseline_product_revision(product)
     product_to_tag = product_to_tag_crud.update(
         db_obj=product_to_tag,
         obj_in=item_in,
         commit=False,
     )
-    product = product_crud.get(item_in.product_id)
     if product is not None:
         created_by, source = actor(principal, request)
         record_product_revision(product, action="update", created_by=created_by, source=source)
@@ -135,6 +138,8 @@ def delete(product_to_tag_id: UUID, request: Request, principal: Any = Depends(a
     if not relation:
         raise_status(HTTPStatus.NOT_FOUND, f"ProductToTag with id {product_to_tag_id} not found")
     product = relation.product
+    if product is not None:
+        ensure_baseline_product_revision(product)
     db.session.delete(relation)
     if product is not None:
         created_by, source = actor(principal, request)

--- a/server/api/endpoints/shop_endpoints/revisions.py
+++ b/server/api/endpoints/shop_endpoints/revisions.py
@@ -38,6 +38,7 @@ from server.services.restore import (
     restore_attribute_from_trash,
     restore_attribute_revision,
     restore_category_from_trash,
+    restore_category_revision,
     restore_product_from_trash,
     restore_product_revision,
     restore_tag_from_trash,
@@ -301,6 +302,49 @@ def restore_category_endpoint(
         shop_id=shop_id,
         category_id=category_id,
         restore_products=restore_products,
+        created_by=created_by,
+        source=source,
+    )
+
+
+@router.post(
+    "/categories/{category_id}/revisions/{revision_no}/restore",
+    response_model=RestoreReport,
+    tags=[AgentTag.EXPOSED],
+    operation_id="restore_category_revision",
+    summary="Restore category to a revision",
+    description=(
+        "Rolls the category back to the state captured in the given revision: fields, translations and "
+        "image references. Products are not touched — use `restore_category` for a trashed category with "
+        "its product batch, or per-product revision restores to reattach detached products. If the "
+        "category was permanently purged, `force=true` (user credentials required) recreates it under its "
+        "original id. The restore is recorded as a new revision."
+    ),
+)
+def restore_category_revision_endpoint(
+    shop_id: UUID,
+    category_id: UUID,
+    revision_no: int,
+    request: Request,
+    force: bool = Query(
+        False,
+        description=(
+            "Recreate the category from the snapshot even if it was permanently purged " "(user credentials required)."
+        ),
+    ),
+    principal: Any = Depends(auth_required_any),
+) -> RestoreReport:
+    if force and isinstance(principal, ApiKeyTable):
+        raise HTTPException(
+            status_code=403,
+            detail="Recreating a purged category requires user credentials; API keys cannot use force=true.",
+        )
+    created_by, source = actor(principal, request)
+    return restore_category_revision(
+        shop_id=shop_id,
+        category_id=category_id,
+        revision_no=revision_no,
+        allow_recreate=force,
         created_by=created_by,
         source=source,
     )

--- a/server/api/endpoints/shop_endpoints/revisions.py
+++ b/server/api/endpoints/shop_endpoints/revisions.py
@@ -1,0 +1,253 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Revision history, restore and trash endpoints for the PIM."""
+
+from typing import Any, List, Optional
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.param_functions import Depends
+
+from server.agent_tags import AgentTag
+from server.db import db
+from server.db.models import ApiKeyTable, CategoryTable, ProductTable, ProductTranslationTable, RevisionTable
+from server.schemas.revision import RestoreReport, RevisionDetail, RevisionSummary, TrashItem
+from server.security import auth_required_any
+from server.services.restore import (
+    restore_category_from_trash,
+    restore_product_from_trash,
+    restore_product_revision,
+)
+from server.services.revisions import ENTITY_CATEGORY, ENTITY_PRODUCT, actor
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+def _snapshot_name(revision: RevisionTable) -> Optional[str]:
+    translation = (revision.data or {}).get("translation") or {}
+    return translation.get("main_name")
+
+
+def _summaries(shop_id: UUID, entity_type: str, entity_id: UUID) -> List[RevisionSummary]:
+    revisions = (
+        db.session.query(RevisionTable)
+        .filter(
+            RevisionTable.shop_id == shop_id,
+            RevisionTable.entity_type == entity_type,
+            RevisionTable.entity_id == entity_id,
+        )
+        .order_by(RevisionTable.revision_no.desc())
+        .all()
+    )
+    out = []
+    for revision in revisions:
+        summary = RevisionSummary.model_validate(revision)
+        summary.name = _snapshot_name(revision)
+        out.append(summary)
+    return out
+
+
+@router.get(
+    "/products/{product_id}/revisions",
+    response_model=List[RevisionSummary],
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    operation_id="list_product_revisions",
+    summary="List product revisions",
+    description=(
+        "Returns the revision history of a product, newest first. Every change to the product "
+        "(fields, translation, tags, attribute values, images) recorded one revision. Use "
+        "`get_product_revision` to inspect a revision and `restore_product_revision` to roll back to it."
+    ),
+)
+def list_product_revisions(shop_id: UUID, product_id: UUID) -> List[RevisionSummary]:
+    return _summaries(shop_id, ENTITY_PRODUCT, product_id)
+
+
+@router.get(
+    "/products/{product_id}/revisions/{revision_no}",
+    response_model=RevisionDetail,
+    tags=[AgentTag.EXPOSED],
+    operation_id="get_product_revision",
+    summary="Get product revision",
+    description="Returns one product revision including the full snapshot data (all fields, tags, attribute values and image references at that point in time).",
+)
+def get_product_revision(shop_id: UUID, product_id: UUID, revision_no: int) -> RevisionDetail:
+    revision = (
+        db.session.query(RevisionTable)
+        .filter(
+            RevisionTable.shop_id == shop_id,
+            RevisionTable.entity_type == ENTITY_PRODUCT,
+            RevisionTable.entity_id == product_id,
+            RevisionTable.revision_no == revision_no,
+        )
+        .first()
+    )
+    if revision is None:
+        raise HTTPException(status_code=404, detail=f"Revision {revision_no} not found for product {product_id}")
+    detail = RevisionDetail.model_validate(revision)
+    detail.name = _snapshot_name(revision)
+    return detail
+
+
+@router.post(
+    "/products/{product_id}/revisions/{revision_no}/restore",
+    response_model=RestoreReport,
+    tags=[AgentTag.EXPOSED],
+    operation_id="restore_product_revision",
+    summary="Restore product to a revision",
+    description=(
+        "Rolls the product back to the state captured in the given revision: fields, translation, "
+        "category, tags, attribute values and image references. Soft-deleted categories/tags/attributes "
+        "referenced by the snapshot are automatically restored from the trash; references that were "
+        "permanently purged are matched by name where possible, otherwise reported in `unresolved`. "
+        "The restore itself is recorded as a new revision, so it can be undone too. Read the returned "
+        "report to see what could not be brought back."
+    ),
+)
+def restore_product_revision_endpoint(
+    shop_id: UUID,
+    product_id: UUID,
+    revision_no: int,
+    request: Request,
+    force: bool = Query(
+        False,
+        description="Recreate the product from the snapshot even if it was permanently purged (user credentials required).",
+    ),
+    principal: Any = Depends(auth_required_any),
+) -> RestoreReport:
+    if force and isinstance(principal, ApiKeyTable):
+        raise HTTPException(
+            status_code=403,
+            detail="Recreating a purged product requires user credentials; API keys cannot use force=true.",
+        )
+    created_by, source = actor(principal, request)
+    return restore_product_revision(
+        shop_id=shop_id,
+        product_id=product_id,
+        revision_no=revision_no,
+        allow_recreate=force,
+        created_by=created_by,
+        source=source,
+    )
+
+
+@router.post(
+    "/products/{product_id}/restore",
+    response_model=RestoreReport,
+    tags=[AgentTag.EXPOSED],
+    operation_id="restore_product",
+    summary="Restore product from trash",
+    description=(
+        "Brings a trashed (deleted) product back, including its tags and attribute values. "
+        "If the product's category is also in the trash it is restored as well."
+    ),
+)
+def restore_product_endpoint(
+    shop_id: UUID,
+    product_id: UUID,
+    request: Request,
+    principal: Any = Depends(auth_required_any),
+) -> RestoreReport:
+    created_by, source = actor(principal, request)
+    return restore_product_from_trash(shop_id=shop_id, product_id=product_id, created_by=created_by, source=source)
+
+
+@router.get(
+    "/categories/{category_id}/revisions",
+    response_model=List[RevisionSummary],
+    summary="List category revisions",
+    description="Returns the revision history of a category, newest first.",
+)
+def list_category_revisions(shop_id: UUID, category_id: UUID) -> List[RevisionSummary]:
+    return _summaries(shop_id, ENTITY_CATEGORY, category_id)
+
+
+@router.post(
+    "/categories/{category_id}/restore",
+    response_model=RestoreReport,
+    tags=[AgentTag.EXPOSED],
+    operation_id="restore_category",
+    summary="Restore category from trash",
+    description=(
+        "Brings a trashed (deleted) category back. With `restore_products=true` (default) it also "
+        "restores every product that was moved to the trash together with the category by a "
+        "`delete_category` with `force=true`."
+    ),
+)
+def restore_category_endpoint(
+    shop_id: UUID,
+    category_id: UUID,
+    request: Request,
+    restore_products: bool = Query(True, description="Also restore the products trashed together with this category."),
+    principal: Any = Depends(auth_required_any),
+) -> RestoreReport:
+    created_by, source = actor(principal, request)
+    return restore_category_from_trash(
+        shop_id=shop_id,
+        category_id=category_id,
+        restore_products=restore_products,
+        created_by=created_by,
+        source=source,
+    )
+
+
+@router.get(
+    "/trash",
+    response_model=List[TrashItem],
+    summary="List trashed products and categories",
+    description="Returns all soft-deleted products and categories of the shop, so they can be inspected and restored.",
+)
+def list_trash(shop_id: UUID) -> List[TrashItem]:
+    items: List[TrashItem] = []
+
+    products = (
+        db.session.query(ProductTable)
+        .filter(ProductTable.shop_id == shop_id, ProductTable.deleted_at.isnot(None))
+        .execution_options(include_deleted=True)
+        .all()
+    )
+    for product in products:
+        translation = (
+            db.session.query(ProductTranslationTable).filter(ProductTranslationTable.product_id == product.id).first()
+        )
+        items.append(
+            TrashItem(
+                entity_type=ENTITY_PRODUCT,
+                id=product.id,
+                name=translation.main_name if translation else None,
+                deleted_at=product.deleted_at,
+                deleted_batch_id=product.deleted_batch_id,
+            )
+        )
+
+    categories = (
+        db.session.query(CategoryTable)
+        .filter(CategoryTable.shop_id == shop_id, CategoryTable.deleted_at.isnot(None))
+        .execution_options(include_deleted=True)
+        .all()
+    )
+    for category in categories:
+        items.append(
+            TrashItem(
+                entity_type=ENTITY_CATEGORY,
+                id=category.id,
+                name=category.translation.main_name if category.translation else None,
+                deleted_at=category.deleted_at,
+            )
+        )
+
+    items.sort(key=lambda item: (item.deleted_at is None, item.deleted_at), reverse=True)
+    return items

--- a/server/api/endpoints/shop_endpoints/revisions.py
+++ b/server/api/endpoints/shop_endpoints/revisions.py
@@ -18,6 +18,7 @@ from uuid import UUID
 import structlog
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.param_functions import Depends
+from starlette.responses import Response
 
 from server.agent_tags import AgentTag
 from server.db import db
@@ -29,16 +30,23 @@ from server.services.restore import (
     restore_product_from_trash,
     restore_product_revision,
 )
-from server.services.revisions import ENTITY_CATEGORY, ENTITY_PRODUCT, actor
+from server.services.revisions import ENTITY_ATTRIBUTE, ENTITY_CATEGORY, ENTITY_PRODUCT, ENTITY_TAG, actor
 
 logger = structlog.get_logger(__name__)
 
 router = APIRouter()
 
+_ENTITY_TYPES = (ENTITY_PRODUCT, ENTITY_CATEGORY, ENTITY_TAG, ENTITY_ATTRIBUTE)
+
 
 def _snapshot_name(revision: RevisionTable) -> Optional[str]:
-    translation = (revision.data or {}).get("translation") or {}
-    return translation.get("main_name")
+    data = revision.data or {}
+    translation = data.get("translation") or {}
+    if translation.get("main_name"):
+        return translation["main_name"]
+    # Tags and attributes also carry a machine-friendly name on the entity itself
+    entity = data.get(revision.entity_type) or {}
+    return entity.get("name")
 
 
 def _summaries(shop_id: UUID, entity_type: str, entity_id: UUID) -> List[RevisionSummary]:
@@ -58,6 +66,87 @@ def _summaries(shop_id: UUID, entity_type: str, entity_id: UUID) -> List[Revisio
         summary.name = _snapshot_name(revision)
         out.append(summary)
     return out
+
+
+@router.get(
+    "/revisions",
+    response_model=List[RevisionSummary],
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    operation_id="list_shop_revisions",
+    summary="List all revisions in a shop",
+    description=(
+        "Shop-wide change feed: every recorded revision of every product, category, tag and attribute, "
+        "newest first. Supports filtering by `entity_type` (product | category | tag | attribute), "
+        "`entity_id`, `action` (create | update | delete | restore | baseline), `source` (rest | mcp) and "
+        "`created_by`, plus `skip`/`limit` pagination (the total is returned in the Content-Range header). "
+        "Use `get_revision` to inspect a revision's full snapshot."
+    ),
+)
+def list_shop_revisions(
+    shop_id: UUID,
+    response: Response,
+    entity_type: Optional[str] = Query(None, description="Filter: product | category | tag | attribute."),
+    entity_id: Optional[UUID] = Query(None, description="Filter on one specific entity."),
+    action: Optional[str] = Query(None, description="Filter: create | update | delete | restore | baseline."),
+    source: Optional[str] = Query(None, description="Filter: rest | mcp."),
+    created_by: Optional[str] = Query(None, description='Filter on actor, e.g. "api_key:<uuid>" or "cognito:<sub>".'),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+) -> List[RevisionSummary]:
+    if entity_type is not None and entity_type not in _ENTITY_TYPES:
+        raise HTTPException(status_code=422, detail=f"entity_type must be one of {', '.join(_ENTITY_TYPES)}")
+
+    query = db.session.query(RevisionTable).filter(RevisionTable.shop_id == shop_id)
+    if entity_type is not None:
+        query = query.filter(RevisionTable.entity_type == entity_type)
+    if entity_id is not None:
+        query = query.filter(RevisionTable.entity_id == entity_id)
+    if action is not None:
+        query = query.filter(RevisionTable.action == action)
+    if source is not None:
+        query = query.filter(RevisionTable.source == source)
+    if created_by is not None:
+        query = query.filter(RevisionTable.created_by == created_by)
+
+    total = query.count()
+    revisions = (
+        query.order_by(RevisionTable.created_at.desc(), RevisionTable.revision_no.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+    response.headers["Content-Range"] = f"revisions {skip}-{skip + len(revisions) - 1}/{total}"
+
+    out = []
+    for revision in revisions:
+        summary = RevisionSummary.model_validate(revision)
+        summary.name = _snapshot_name(revision)
+        out.append(summary)
+    return out
+
+
+@router.get(
+    "/revisions/{revision_id}",
+    response_model=RevisionDetail,
+    tags=[AgentTag.EXPOSED],
+    operation_id="get_revision",
+    summary="Get one revision by id",
+    description=(
+        "Returns one revision (of any entity type) by its id, including the full snapshot data. "
+        "Use it to inspect entries from the `list_shop_revisions` feed."
+    ),
+)
+def get_revision(shop_id: UUID, revision_id: UUID) -> RevisionDetail:
+    revision = (
+        db.session.query(RevisionTable)
+        .filter(RevisionTable.shop_id == shop_id, RevisionTable.id == revision_id)
+        .first()
+    )
+    if revision is None:
+        raise HTTPException(status_code=404, detail=f"Revision {revision_id} not found")
+    detail = RevisionDetail.model_validate(revision)
+    detail.name = _snapshot_name(revision)
+    return detail
 
 
 @router.get(

--- a/server/api/endpoints/shop_endpoints/revisions.py
+++ b/server/api/endpoints/shop_endpoints/revisions.py
@@ -18,17 +18,30 @@ from uuid import UUID
 import structlog
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.param_functions import Depends
+from sqlalchemy.exc import IntegrityError
 from starlette.responses import Response
 
 from server.agent_tags import AgentTag
 from server.db import db
-from server.db.models import ApiKeyTable, CategoryTable, ProductTable, ProductTranslationTable, RevisionTable
+from server.db.models import (
+    ApiKeyTable,
+    AttributeTable,
+    CategoryTable,
+    ProductTable,
+    ProductTranslationTable,
+    RevisionTable,
+    TagTable,
+)
 from server.schemas.revision import RestoreReport, RevisionDetail, RevisionSummary, TrashItem
 from server.security import auth_required_any
 from server.services.restore import (
+    restore_attribute_from_trash,
+    restore_attribute_revision,
     restore_category_from_trash,
     restore_product_from_trash,
     restore_product_revision,
+    restore_tag_from_trash,
+    restore_tag_revision,
 )
 from server.services.revisions import ENTITY_ATTRIBUTE, ENTITY_CATEGORY, ENTITY_PRODUCT, ENTITY_TAG, actor
 
@@ -293,11 +306,150 @@ def restore_category_endpoint(
     )
 
 
+@router.post(
+    "/tags/{tag_id}/revisions/{revision_no}/restore",
+    response_model=RestoreReport,
+    tags=[AgentTag.EXPOSED],
+    operation_id="restore_tag_revision",
+    summary="Restore tag to a revision",
+    description=(
+        "Rolls the tag back to the state captured in the given revision (name and translations). "
+        "Use the `list_shop_revisions` feed with `entity_type=tag` to find revisions. If the tag was "
+        "permanently purged, `force=true` (user credentials required) recreates it under its original id "
+        "so existing product links in old snapshots resolve again. The restore is recorded as a new revision."
+    ),
+)
+def restore_tag_revision_endpoint(
+    shop_id: UUID,
+    tag_id: UUID,
+    revision_no: int,
+    request: Request,
+    force: bool = Query(
+        False,
+        description="Recreate the tag from the snapshot even if it was permanently purged (user credentials required).",
+    ),
+    principal: Any = Depends(auth_required_any),
+) -> RestoreReport:
+    if force and isinstance(principal, ApiKeyTable):
+        raise HTTPException(
+            status_code=403,
+            detail="Recreating a purged tag requires user credentials; API keys cannot use force=true.",
+        )
+    created_by, source = actor(principal, request)
+    return restore_tag_revision(
+        shop_id=shop_id,
+        tag_id=tag_id,
+        revision_no=revision_no,
+        allow_recreate=force,
+        created_by=created_by,
+        source=source,
+    )
+
+
+@router.post(
+    "/tags/{tag_id}/restore",
+    response_model=RestoreReport,
+    tags=[AgentTag.EXPOSED],
+    operation_id="restore_tag",
+    summary="Restore tag from trash",
+    description=(
+        "Brings a trashed (deleted) tag back. Its product links were kept in the trash, "
+        "so the tag reappears on all products that carried it."
+    ),
+)
+def restore_tag_endpoint(
+    shop_id: UUID,
+    tag_id: UUID,
+    request: Request,
+    principal: Any = Depends(auth_required_any),
+) -> RestoreReport:
+    created_by, source = actor(principal, request)
+    return restore_tag_from_trash(shop_id=shop_id, tag_id=tag_id, created_by=created_by, source=source)
+
+
+@router.post(
+    "/attributes/{attribute_id}/revisions/{revision_no}/restore",
+    response_model=RestoreReport,
+    tags=[AgentTag.EXPOSED],
+    operation_id="restore_attribute_revision",
+    summary="Restore attribute to a revision",
+    description=(
+        "Rolls the attribute back to the state captured in the given revision: name, unit, translations "
+        "and its option set. Trashed options in the snapshot are restored, purged ones are recreated under "
+        "their original id, and live options that are not in the snapshot are moved to the trash (their "
+        "product values survive). Use `list_shop_revisions` with `entity_type=attribute` to find revisions. "
+        "If the attribute was permanently purged, `force=true` (user credentials required) recreates it. "
+        "The restore is recorded as a new revision. Read the returned report for what was resurrected, "
+        "recreated or trashed."
+    ),
+)
+def restore_attribute_revision_endpoint(
+    shop_id: UUID,
+    attribute_id: UUID,
+    revision_no: int,
+    request: Request,
+    force: bool = Query(
+        False,
+        description=(
+            "Recreate the attribute from the snapshot even if it was permanently purged " "(user credentials required)."
+        ),
+    ),
+    principal: Any = Depends(auth_required_any),
+) -> RestoreReport:
+    if force and isinstance(principal, ApiKeyTable):
+        raise HTTPException(
+            status_code=403,
+            detail="Recreating a purged attribute requires user credentials; API keys cannot use force=true.",
+        )
+    created_by, source = actor(principal, request)
+    try:
+        return restore_attribute_revision(
+            shop_id=shop_id,
+            attribute_id=attribute_id,
+            revision_no=revision_no,
+            allow_recreate=force,
+            created_by=created_by,
+            source=source,
+        )
+    except IntegrityError:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Restoring this revision collides with an option value_key that is still occupied "
+                "(possibly by a trashed option); purge or rename the conflicting option first."
+            ),
+        )
+
+
+@router.post(
+    "/attributes/{attribute_id}/restore",
+    response_model=RestoreReport,
+    tags=[AgentTag.EXPOSED],
+    operation_id="restore_attribute",
+    summary="Restore attribute from trash",
+    description=(
+        "Brings a trashed (deleted) attribute back, including its options and all product values that used "
+        "it. Options that were trashed individually before stay in the trash — restore an attribute revision "
+        "to bring those back too."
+    ),
+)
+def restore_attribute_endpoint(
+    shop_id: UUID,
+    attribute_id: UUID,
+    request: Request,
+    principal: Any = Depends(auth_required_any),
+) -> RestoreReport:
+    created_by, source = actor(principal, request)
+    return restore_attribute_from_trash(
+        shop_id=shop_id, attribute_id=attribute_id, created_by=created_by, source=source
+    )
+
+
 @router.get(
     "/trash",
     response_model=List[TrashItem],
-    summary="List trashed products and categories",
-    description="Returns all soft-deleted products and categories of the shop, so they can be inspected and restored.",
+    summary="List trashed products, categories, tags and attributes",
+    description="Returns all soft-deleted products, categories, tags and attributes of the shop, so they can be inspected and restored.",
 )
 def list_trash(shop_id: UUID) -> List[TrashItem]:
     items: List[TrashItem] = []
@@ -335,6 +487,28 @@ def list_trash(shop_id: UUID) -> List[TrashItem]:
                 id=category.id,
                 name=category.translation.main_name if category.translation else None,
                 deleted_at=category.deleted_at,
+            )
+        )
+
+    tags = (
+        db.session.query(TagTable)
+        .filter(TagTable.shop_id == shop_id, TagTable.deleted_at.isnot(None))
+        .execution_options(include_deleted=True)
+        .all()
+    )
+    for tag in tags:
+        items.append(TrashItem(entity_type=ENTITY_TAG, id=tag.id, name=tag.name, deleted_at=tag.deleted_at))
+
+    attributes = (
+        db.session.query(AttributeTable)
+        .filter(AttributeTable.shop_id == shop_id, AttributeTable.deleted_at.isnot(None))
+        .execution_options(include_deleted=True)
+        .all()
+    )
+    for attribute in attributes:
+        items.append(
+            TrashItem(
+                entity_type=ENTITY_ATTRIBUTE, id=attribute.id, name=attribute.name, deleted_at=attribute.deleted_at
             )
         )
 

--- a/server/api/endpoints/shop_endpoints/tags.py
+++ b/server/api/endpoints/shop_endpoints/tags.py
@@ -1,9 +1,10 @@
+from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import Any, List
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from fastapi.param_functions import Body, Depends
 from starlette.responses import Response
 
@@ -11,7 +12,10 @@ from server.agent_tags import AgentTag
 from server.api.deps import common_parameters
 from server.api.error_handling import raise_status
 from server.crud.crud_tag import tag_crud
+from server.db import db
+from server.db.models import ApiKeyTable
 from server.schemas.tag import TagCreate, TagSchema, TagUpdate
+from server.security import auth_required_any
 
 logger = structlog.get_logger(__name__)
 
@@ -110,12 +114,36 @@ def update(*, tag_id: UUID, shop_id: UUID, item_in: TagUpdate) -> Any:
     status_code=HTTPStatus.NO_CONTENT,
     tags=[AgentTag.EXPOSED],
     operation_id="delete_tag",
-    summary="Delete tag",
-    description="Remove a tag from a shop. Fails with 400 if products still reference this tag.",
+    summary="Delete tag (moves to trash)",
+    description=(
+        "Moves a tag to the trash: it disappears from listings and from the products carrying it, but its "
+        "product links are kept so restoring the tag brings everything back. This action is reversible. "
+        "Only `force=true` permanently purges the tag (and its product links); that is irreversible and "
+        "requires user (Cognito) credentials — API keys get 403."
+    ),
 )
-def delete(tag_id: UUID, shop_id: UUID) -> None:
-    try:
-        tag_crud.delete_by_shop_id(shop_id=shop_id, id=tag_id)
-    except Exception as e:
-        raise HTTPException(HTTPStatus.BAD_REQUEST, detail=f"{e.__cause__}")
-    return
+def delete(
+    tag_id: UUID,
+    shop_id: UUID,
+    force: bool = Query(False, description="Permanently purge instead of moving to trash. Irreversible."),
+    principal: Any = Depends(auth_required_any),
+) -> None:
+    tag = tag_crud.get_id_by_shop_id(shop_id, tag_id, for_update=True, include_deleted=force)
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    if force:
+        if isinstance(principal, ApiKeyTable):
+            raise HTTPException(
+                status_code=403,
+                detail="Purging a tag is irreversible and requires user credentials; API keys may only trash.",
+            )
+        try:
+            tag_crud.delete_by_shop_id(shop_id=shop_id, id=tag_id, include_deleted=True)
+        except Exception as e:
+            raise HTTPException(HTTPStatus.BAD_REQUEST, detail=f"{e.__cause__}")
+        return None
+
+    tag.deleted_at = datetime.now(timezone.utc)
+    db.session.commit()
+    return None

--- a/server/api/endpoints/shop_endpoints/tags.py
+++ b/server/api/endpoints/shop_endpoints/tags.py
@@ -4,7 +4,7 @@ from typing import Any, List
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.param_functions import Body, Depends
 from starlette.responses import Response
 
@@ -16,6 +16,7 @@ from server.db import db
 from server.db.models import ApiKeyTable
 from server.schemas.tag import TagCreate, TagSchema, TagUpdate
 from server.security import auth_required_any
+from server.services.revisions import actor, ensure_baseline_tag_revision, record_tag_revision
 
 logger = structlog.get_logger(__name__)
 
@@ -80,9 +81,15 @@ def get_by_name(name: str, shop_id: UUID) -> TagSchema:
     summary="Create tag",
     description="Create a new tag for a shop. Tags are attached to products via the `products-to-tags` resource.",
 )
-def create(shop_id: UUID, data: TagCreate = Body(...)) -> None:
+def create(
+    shop_id: UUID, request: Request, data: TagCreate = Body(...), principal: Any = Depends(auth_required_any)
+) -> None:
     logger.info("Saving tag", data=data)
-    tag = tag_crud.create_by_shop_id(shop_id=shop_id, obj_in=data)
+    created_by, source = actor(principal, request)
+    tag = tag_crud.create_by_shop_id(shop_id=shop_id, obj_in=data, commit=False)
+    record_tag_revision(tag, action="create", created_by=created_by, source=source)
+    db.session.commit()
+    db.session.refresh(tag)
     return tag
 
 
@@ -95,16 +102,23 @@ def create(shop_id: UUID, data: TagCreate = Body(...)) -> None:
     summary="Update tag",
     description="Update an existing tag's name or translations.",
 )
-def update(*, tag_id: UUID, shop_id: UUID, item_in: TagUpdate) -> Any:
-    tag = tag_crud.get_id_by_shop_id(shop_id, tag_id)
+def update(
+    *, tag_id: UUID, shop_id: UUID, item_in: TagUpdate, request: Request, principal: Any = Depends(auth_required_any)
+) -> Any:
+    tag = tag_crud.get_id_by_shop_id(shop_id, tag_id, for_update=True)
     logger.info("Updating tag", data=tag)
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
 
+    created_by, source = actor(principal, request)
+    ensure_baseline_tag_revision(tag)
     tag = tag_crud.update(
         db_obj=tag,
         obj_in=item_in,
+        commit=False,
     )
+    record_tag_revision(tag, action="update", created_by=created_by, source=source)
+    db.session.commit()
     return tag
 
 
@@ -125,6 +139,7 @@ def update(*, tag_id: UUID, shop_id: UUID, item_in: TagUpdate) -> Any:
 def delete(
     tag_id: UUID,
     shop_id: UUID,
+    request: Request,
     force: bool = Query(False, description="Permanently purge instead of moving to trash. Irreversible."),
     principal: Any = Depends(auth_required_any),
 ) -> None:
@@ -144,6 +159,8 @@ def delete(
             raise HTTPException(HTTPStatus.BAD_REQUEST, detail=f"{e.__cause__}")
         return None
 
+    created_by, source = actor(principal, request)
+    record_tag_revision(tag, action="delete", created_by=created_by, source=source)
     tag.deleted_at = datetime.now(timezone.utc)
     db.session.commit()
     return None

--- a/server/crud/base.py
+++ b/server/crud/base.py
@@ -55,13 +55,31 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         self.model = model
 
     def get(self, id: UUID | str) -> Optional[ModelType]:
-        return db.session.get(self.model, id)
+        obj = db.session.get(self.model, id)
+        # Session.get() can bypass the do_orm_execute soft-delete filter (identity map),
+        # so re-check deleted_at explicitly for soft-deletable models.
+        if obj is not None and getattr(obj, "deleted_at", None) is not None:
+            return None
+        return obj
 
     def get_id(self, id: UUID | str) -> Optional[ModelType]:
-        return db.session.get(self.model, id)
+        return self.get(id)
 
-    def get_id_by_shop_id(self, shop_id: UUID, id: UUID) -> Optional[ModelType]:
-        return db.session.query(self.model).filter(self.model.shop_id == shop_id, self.model.id == id).first()
+    def get_id_by_shop_id(
+        self,
+        shop_id: UUID,
+        id: UUID,
+        for_update: bool = False,
+        include_deleted: bool = False,
+    ) -> Optional[ModelType]:
+        query = db.session.query(self.model).filter(self.model.shop_id == shop_id, self.model.id == id)
+        if include_deleted:
+            query = query.execution_options(include_deleted=True)
+        if for_update:
+            # Row lock: serializes concurrent writers on the same entity so that
+            # revision numbering (max + 1) is race-free.
+            query = query.with_for_update()
+        return query.first()
 
     def get_multi(
         self,
@@ -183,7 +201,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
     def _extra_create_fields(self) -> dict:
         return {}
 
-    def create_by_shop_id(self, *, shop_id: any, obj_in: CreateSchemaType) -> ModelType:
+    def create_by_shop_id(self, *, shop_id: any, obj_in: CreateSchemaType, commit: bool = True) -> ModelType:
         obj_in_data = transform_json(obj_in.model_dump())
         # Todo: remove translate from base? We should handle this in a more generic way, for now a UGLY hack:
         translation_data = None
@@ -206,9 +224,12 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
                 translation_data[translation_name.lower() + "_id"] = db_obj.id
                 translation = translation_model(**translation_data)
                 db.session.add(translation)
-                db.session.commit()
-                db.session.refresh(db_obj)
-                db.session.refresh(translation)
+                if commit:
+                    db.session.commit()
+                    db.session.refresh(db_obj)
+                    db.session.refresh(translation)
+                else:
+                    db.session.flush()
         except:
             db.session.rollback()
             raise
@@ -261,8 +282,11 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         db.session.commit()
         return None
 
-    def delete_by_shop_id(self, *, shop_id: UUID, id: UUID) -> None:
-        obj = db.session.query(self.model).filter(self.model.shop_id == shop_id, self.model.id == id).first()
+    def delete_by_shop_id(self, *, shop_id: UUID, id: UUID, commit: bool = True, include_deleted: bool = False) -> None:
+        query = db.session.query(self.model).filter(self.model.shop_id == shop_id, self.model.id == id)
+        if include_deleted:
+            query = query.execution_options(include_deleted=True)
+        obj = query.first()
         if obj is None:
             raise NotFound
 
@@ -278,5 +302,6 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
                     db.session.delete(translation_obj)
 
         db.session.delete(obj)
-        db.session.commit()
+        if commit:
+            db.session.commit()
         return None

--- a/server/crud/crud_attribute.py
+++ b/server/crud/crud_attribute.py
@@ -65,21 +65,23 @@ class CRUDAttribute(CRUDBase[AttributeTable, AttributeCreate, AttributeUpdate]):
             db.session.rollback()
             raise
 
-    def delete_by_shop_id(self, *, shop_id: UUID, id: UUID) -> None:
+    def delete_by_shop_id(self, *, shop_id: UUID, id: UUID, commit: bool = True, include_deleted: bool = False) -> None:
         """
         Delete an attribute for a shop.
         Does NOT delete related records automatically (no deep delete here anymore).
         Deletion will fail at DB level if relationships (PAVs) are still active (FK constraint).
         """
         # Fetch attribute first to validate shop ownership
-        obj = (
-            db.session.query(AttributeTable).filter(AttributeTable.shop_id == shop_id, AttributeTable.id == id).first()
-        )
+        query = db.session.query(AttributeTable).filter(AttributeTable.shop_id == shop_id, AttributeTable.id == id)
+        if include_deleted:
+            query = query.execution_options(include_deleted=True)
+        obj = query.first()
         if obj is None:
             raise NotFound
         try:
             db.session.delete(obj)
-            db.session.commit()
+            if commit:
+                db.session.commit()
         except:
             db.session.rollback()
             raise

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -30,16 +30,17 @@ from sqlalchemy import (
     Numeric,
     String,
     TypeDecorator,
+    event,
     func,
     text,
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.engine import Dialect
 from sqlalchemy.exc import DontWrapMixin
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import backref, relationship, with_loader_criteria
 from sqlalchemy_utils import UUIDType
 
-from server.db.database import BaseModel, Database
+from server.db.database import BaseModel, Database, WrappedSession
 from server.schemas.shop import ShopType
 from server.settings import app_settings
 
@@ -75,6 +76,20 @@ class UtcTimestamp(TypeDecorator):
 
     def process_result_value(self, value: datetime | None, dialect: Dialect) -> datetime | None:
         return value.astimezone(timezone.utc) if value else value
+
+
+class SoftDeleteMixin:
+    """Soft delete support: rows with a non-NULL ``deleted_at`` are trashed, not gone.
+
+    NOTE: every SELECT that runs through the ORM session automatically excludes
+    soft-deleted rows via the ``do_orm_execute`` listener at the bottom of this
+    module. Code that must see trashed rows (trash listing, restore, purge) opts
+    out per statement with ``.execution_options(include_deleted=True)``.
+    ``Session.get()`` (identity-map lookups) can bypass the listener, so
+    ``CRUDBase.get``/``get_id`` re-check ``deleted_at`` explicitly.
+    """
+
+    deleted_at = Column(UtcTimestamp, nullable=True, index=True)
 
 
 class ShopTable(BaseModel):
@@ -114,7 +129,7 @@ class ShopTable(BaseModel):
         return self.name
 
 
-class TagTable(BaseModel):
+class TagTable(SoftDeleteMixin, BaseModel):
     __tablename__ = "tags"
     id = Column(
         UUIDType,
@@ -168,7 +183,7 @@ class Account(BaseModel):
         return f"{self.shop.name}: {self.name}"
 
 
-class CategoryTable(BaseModel):
+class CategoryTable(SoftDeleteMixin, BaseModel):
     __tablename__ = "categories"
     id = Column(
         UUIDType,
@@ -235,7 +250,7 @@ class OrderTable(BaseModel):
         return "<Order for shop: %s with total: %s>" % (self.shop.name, self.total)
 
 
-class ProductTable(BaseModel):
+class ProductTable(SoftDeleteMixin, BaseModel):
     __tablename__ = "products"
     id = Column(
         UUIDType,
@@ -267,6 +282,9 @@ class ProductTable(BaseModel):
     image_4 = Column(String(255), index=True)
     image_5 = Column(String(255), index=True)
     image_6 = Column(String(255), index=True)
+    # Groups products trashed together by one category cascade-delete, so the
+    # whole batch can be restored in a single operation.
+    deleted_batch_id = Column(UUIDType, nullable=True, index=True)
     created_at = Column(UtcTimestamp, server_default=text("CURRENT_TIMESTAMP"))
     modified_at = Column(
         UtcTimestamp,
@@ -413,7 +431,7 @@ class FaqTable(BaseModel):
     )
 
 
-class AttributeTable(BaseModel):
+class AttributeTable(SoftDeleteMixin, BaseModel):
     __tablename__ = "attributes"
 
     id = Column(UUIDType, server_default=text("uuid_generate_v4()"), primary_key=True, index=True)
@@ -474,7 +492,7 @@ class AttributeTranslationTable(BaseModel):
     attribute = relationship("AttributeTable", back_populates="translation")
 
 
-class AttributeOptionTable(BaseModel):
+class AttributeOptionTable(SoftDeleteMixin, BaseModel):
     __tablename__ = "attribute_options"
 
     id = Column(UUIDType, server_default=text("uuid_generate_v4()"), primary_key=True, index=True)
@@ -519,6 +537,37 @@ class ProductAttributeValueTable(BaseModel):
     )
 
 
+class RevisionTable(BaseModel):
+    __tablename__ = "revisions"
+
+    id = Column(UUIDType, server_default=text("uuid_generate_v4()"), primary_key=True, index=True)
+    shop_id = Column(UUIDType, ForeignKey("shops.id", ondelete="CASCADE"), nullable=False, index=True)
+    # 'product' | 'category'. entity_id has no FK on purpose: revisions must survive
+    # hard purges of the entity and future model churn.
+    entity_type = Column(String(30), nullable=False)
+    entity_id = Column(UUIDType, nullable=False)
+    # Monotonic per (entity_type, entity_id), starting at 1
+    revision_no = Column(Integer, nullable=False)
+    # create | update | delete | restore
+    action = Column(String(20), nullable=False)
+    # Version of the snapshot structure in `data`. Bump only for structural reshapes
+    # (renamed/nested keys); plain column additions/removals are handled at restore
+    # time by intersecting snapshot keys with the current model columns.
+    schema_version = Column(Integer, nullable=False, server_default="1")
+    # Full aggregate snapshot; see server/services/revisions.py for the shape.
+    data = Column(postgresql.JSONB(), nullable=False)
+    # "cognito:<sub>" or "api_key:<uuid>"
+    created_by = Column(String(128), nullable=True)
+    # 'rest' | 'mcp'
+    source = Column(String(10), nullable=False, server_default="rest")
+    created_at = Column(UtcTimestamp, server_default=text("CURRENT_TIMESTAMP"))
+
+    __table_args__ = (
+        sqlalchemy.UniqueConstraint("entity_type", "entity_id", "revision_no", name="uq_revision_entity_no"),
+        sqlalchemy.Index("ix_revisions_entity", "entity_type", "entity_id", "revision_no"),
+    )
+
+
 class ApiKeyTable(BaseModel):
     __tablename__ = "api_keys"
 
@@ -540,3 +589,23 @@ class ApiKeyTable(BaseModel):
     revoked_at = Column(UtcTimestamp, nullable=True)
 
     shop = relationship("ShopTable", lazy=True)
+
+
+@event.listens_for(WrappedSession, "do_orm_execute")
+def _exclude_soft_deleted(execute_state) -> None:
+    """Exclude soft-deleted rows from every ORM SELECT by default.
+
+    Applies ``deleted_at IS NULL`` to all entities inheriting SoftDeleteMixin in the
+    statement, including their eager/lazy relationship loads (the criteria propagate
+    from the top-level statement). Opt out per statement with
+    ``.execution_options(include_deleted=True)``.
+    """
+    if (
+        execute_state.is_select
+        and not execute_state.is_column_load
+        and not execute_state.is_relationship_load
+        and not execute_state.execution_options.get("include_deleted", False)
+    ):
+        execute_state.statement = execute_state.statement.options(
+            with_loader_criteria(SoftDeleteMixin, lambda cls: cls.deleted_at.is_(None), include_aliases=True)
+        )

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -542,13 +542,13 @@ class RevisionTable(BaseModel):
 
     id = Column(UUIDType, server_default=text("uuid_generate_v4()"), primary_key=True, index=True)
     shop_id = Column(UUIDType, ForeignKey("shops.id", ondelete="CASCADE"), nullable=False, index=True)
-    # 'product' | 'category'. entity_id has no FK on purpose: revisions must survive
-    # hard purges of the entity and future model churn.
+    # 'product' | 'category' | 'tag' | 'attribute'. entity_id has no FK on purpose:
+    # revisions must survive hard purges of the entity and future model churn.
     entity_type = Column(String(30), nullable=False)
     entity_id = Column(UUIDType, nullable=False)
     # Monotonic per (entity_type, entity_id), starting at 1
     revision_no = Column(Integer, nullable=False)
-    # create | update | delete | restore
+    # create | update | delete | restore | baseline
     action = Column(String(20), nullable=False)
     # Version of the snapshot structure in `data`. Bump only for structural reshapes
     # (renamed/nested keys); plain column additions/removals are handled at restore

--- a/server/main.py
+++ b/server/main.py
@@ -74,7 +74,7 @@ async def lifespan(app_: FastAPI):
         yield
 
 
-APP_VERSION = "0.4.3"
+APP_VERSION = "0.4.4"
 
 # Assigned after the api_router is included if MCP_ENABLED. The lifespan
 # closure above references it.

--- a/server/main.py
+++ b/server/main.py
@@ -74,7 +74,7 @@ async def lifespan(app_: FastAPI):
         yield
 
 
-APP_VERSION = "0.4.1"
+APP_VERSION = "0.4.2"
 
 # Assigned after the api_router is included if MCP_ENABLED. The lifespan
 # closure above references it.

--- a/server/main.py
+++ b/server/main.py
@@ -74,7 +74,7 @@ async def lifespan(app_: FastAPI):
         yield
 
 
-APP_VERSION = "0.3.5"
+APP_VERSION = "0.4.0"
 
 # Assigned after the api_router is included if MCP_ENABLED. The lifespan
 # closure above references it.

--- a/server/main.py
+++ b/server/main.py
@@ -74,7 +74,7 @@ async def lifespan(app_: FastAPI):
         yield
 
 
-APP_VERSION = "0.4.0"
+APP_VERSION = "0.4.1"
 
 # Assigned after the api_router is included if MCP_ENABLED. The lifespan
 # closure above references it.

--- a/server/main.py
+++ b/server/main.py
@@ -74,7 +74,7 @@ async def lifespan(app_: FastAPI):
         yield
 
 
-APP_VERSION = "0.4.2"
+APP_VERSION = "0.4.3"
 
 # Assigned after the api_router is included if MCP_ENABLED. The lifespan
 # closure above references it.

--- a/server/schemas/product.py
+++ b/server/schemas/product.py
@@ -45,7 +45,8 @@ class ProductBase(BoilerplateBaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     shop_id: UUID
-    category_id: UUID
+    # None for products detached from a deleted category (delete_category with detach=true)
+    category_id: Optional[UUID] = None
     price: Optional[Money] = None
     recurring_price_monthly: Optional[Money] = None
     recurring_price_yearly: Optional[Money] = None

--- a/server/schemas/revision.py
+++ b/server/schemas/revision.py
@@ -1,0 +1,74 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime
+from typing import Any, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class RevisionSummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    entity_type: str
+    entity_id: UUID
+    revision_no: int
+    action: str
+    schema_version: int
+    created_by: Optional[str] = None
+    source: str
+    created_at: Optional[datetime] = None
+    # Human-readable label extracted from the snapshot (e.g. the product name at that point)
+    name: Optional[str] = None
+
+
+class RevisionDetail(RevisionSummary):
+    data: dict
+
+
+class UnresolvedReference(BaseModel):
+    kind: str  # 'category' | 'tag' | 'attribute' | 'attribute_option'
+    id: Optional[UUID] = None
+    name: Optional[str] = None
+
+
+class ResurrectedEntity(BaseModel):
+    kind: str  # 'category' | 'tag' | 'attribute' | 'attribute_option' | 'product'
+    id: UUID
+    name: Optional[str] = None
+
+
+class RestoreReport(BaseModel):
+    """What a restore actually did — agents should read this to see what didn't come back."""
+
+    restored: bool
+    entity_type: str
+    entity_id: UUID
+    restored_from_revision_no: Optional[int] = None
+    new_revision_no: Optional[int] = None
+    # Soft-deleted related entities that were brought back to make the restore complete
+    resurrected: List[ResurrectedEntity] = []
+    # Snapshot fields that no longer exist on the current model and were skipped
+    skipped_fields: List[str] = []
+    # Snapshot references (category/tags/attributes) that could not be matched by id or name
+    unresolved: List[UnresolvedReference] = []
+    warnings: List[str] = []
+
+
+class TrashItem(BaseModel):
+    entity_type: str
+    id: UUID
+    name: Optional[str] = None
+    deleted_at: Optional[datetime] = None
+    deleted_batch_id: Optional[UUID] = None

--- a/server/services/restore.py
+++ b/server/services/restore.py
@@ -44,6 +44,7 @@ from server.db import db
 from server.db.models import (
     AttributeOptionTable,
     AttributeTable,
+    AttributeTranslationTable,
     CategoryTable,
     CategoryTranslationTable,
     ProductTable,
@@ -51,14 +52,19 @@ from server.db.models import (
     ProductTranslationTable,
     RevisionTable,
     TagTable,
+    TagTranslationTable,
 )
 from server.schemas.revision import RestoreReport, ResurrectedEntity, UnresolvedReference
 from server.services.revisions import (
+    ENTITY_ATTRIBUTE,
     ENTITY_CATEGORY,
     ENTITY_PRODUCT,
+    ENTITY_TAG,
     SCHEMA_VERSION,
+    record_attribute_revision,
     record_category_revision,
     record_product_revision,
+    record_tag_revision,
 )
 
 logger = structlog.get_logger(__name__)
@@ -309,23 +315,26 @@ def restore_product_revision(
     revision = _get_revision(shop_id, ENTITY_PRODUCT, product_id, revision_no)
     data = _upconvert(dict(revision.data), revision.schema_version)
 
-    try:
-        product = (
-            db.session.query(ProductTable)
-            .filter(ProductTable.shop_id == shop_id, ProductTable.id == product_id)
-            .execution_options(include_deleted=True)
-            .with_for_update()
-            .first()
+    product = (
+        db.session.query(ProductTable)
+        .filter(ProductTable.shop_id == shop_id, ProductTable.id == product_id)
+        .execution_options(include_deleted=True)
+        .with_for_update()
+        .first()
+    )
+    # Control-flow errors are raised before the mutation phase so the rollback
+    # handler below only ever fires on genuine mid-mutation failures.
+    if product is None and not allow_recreate:
+        raise HTTPException(
+            status_code=410,
+            detail=(
+                "Product was permanently purged. Retry with force=true (user credentials required) "
+                "to recreate it from the snapshot."
+            ),
         )
+
+    try:
         if product is None:
-            if not allow_recreate:
-                raise HTTPException(
-                    status_code=410,
-                    detail=(
-                        "Product was permanently purged. Retry with force=true (user credentials required) "
-                        "to recreate it from the snapshot."
-                    ),
-                )
             product = ProductTable(id=product_id, shop_id=shop_id)
             db.session.add(product)
             report.warnings.append("Product row was purged; recreated from the snapshot.")
@@ -420,6 +429,274 @@ def restore_product_from_trash(
                 report.resurrected.append(ResurrectedEntity(kind="category", id=category.id))
 
         new_revision = record_product_revision(product, action="restore", created_by=created_by, source=source)
+        report.new_revision_no = new_revision.revision_no
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    report.restored = True
+    return report
+
+
+def restore_tag_revision(
+    *,
+    shop_id: uuid.UUID,
+    tag_id: uuid.UUID,
+    revision_no: int,
+    allow_recreate: bool = False,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+) -> RestoreReport:
+    """Re-apply a tag revision snapshot. Commits on success, rolls back on error."""
+    report = RestoreReport(restored=False, entity_type=ENTITY_TAG, entity_id=tag_id)
+    report.restored_from_revision_no = revision_no
+
+    revision = _get_revision(shop_id, ENTITY_TAG, tag_id, revision_no)
+    data = _upconvert(dict(revision.data), revision.schema_version)
+
+    tag = (
+        db.session.query(TagTable)
+        .filter(TagTable.shop_id == shop_id, TagTable.id == tag_id)
+        .execution_options(include_deleted=True)
+        .with_for_update()
+        .first()
+    )
+    if tag is None and not allow_recreate:
+        raise HTTPException(
+            status_code=410,
+            detail=(
+                "Tag was permanently purged. Retry with force=true (user credentials required) "
+                "to recreate it from the snapshot."
+            ),
+        )
+
+    try:
+        if tag is None:
+            tag = TagTable(id=tag_id, shop_id=shop_id)
+            db.session.add(tag)
+            report.warnings.append("Tag row was purged; recreated from the snapshot.")
+
+        if tag.deleted_at is not None:
+            report.resurrected.append(ResurrectedEntity(kind="tag", id=tag.id, name=tag.name))
+        tag.deleted_at = None
+
+        _apply_columns(tag, data.get("tag") or {}, "tag", report)
+
+        translation_data = data.get("translation")
+        if translation_data:
+            translation = db.session.query(TagTranslationTable).filter(TagTranslationTable.tag_id == tag.id).first()
+            if translation is None:
+                translation = TagTranslationTable(tag_id=tag.id, main_name=translation_data.get("main_name") or "")
+                db.session.add(translation)
+            _apply_columns(translation, translation_data, "translation", report)
+
+        new_revision = record_tag_revision(tag, action="restore", created_by=created_by, source=source)
+        report.new_revision_no = new_revision.revision_no
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    report.restored = True
+    return report
+
+
+def restore_tag_from_trash(
+    *,
+    shop_id: uuid.UUID,
+    tag_id: uuid.UUID,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+) -> RestoreReport:
+    """Undelete a trashed tag. Its product links were never removed, so this only clears ``deleted_at``."""
+    report = RestoreReport(restored=False, entity_type=ENTITY_TAG, entity_id=tag_id)
+
+    tag = (
+        db.session.query(TagTable)
+        .filter(TagTable.shop_id == shop_id, TagTable.id == tag_id)
+        .execution_options(include_deleted=True)
+        .with_for_update()
+        .first()
+    )
+    if tag is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Tag not found (it may have been permanently purged; use a revision restore with force=true).",
+        )
+    if tag.deleted_at is None:
+        report.warnings.append("Tag was not in the trash; nothing to do.")
+        report.restored = True
+        return report
+
+    try:
+        tag.deleted_at = None
+        report.resurrected.append(ResurrectedEntity(kind="tag", id=tag.id, name=tag.name))
+        new_revision = record_tag_revision(tag, action="restore", created_by=created_by, source=source)
+        report.new_revision_no = new_revision.revision_no
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    report.restored = True
+    return report
+
+
+def _restore_attribute_options(attribute: AttributeTable, snapshot_options: list, report: RestoreReport) -> None:
+    """Make the attribute's options match the snapshot (replace-all semantics).
+
+    Options are matched by id first (soft-deleted ones are resurrected), then by
+    ``value_key``. Purged options are recreated under their snapshot id, so option
+    references inside old product revisions resolve again. Live options that are
+    not in the snapshot are moved to the trash, never purged — their product
+    attribute values survive for a later restore.
+    """
+    existing = (
+        db.session.query(AttributeOptionTable)
+        .filter(AttributeOptionTable.attribute_id == attribute.id)
+        .execution_options(include_deleted=True)
+        .with_for_update()
+        .all()
+    )
+    by_id = {option.id: option for option in existing}
+    by_key = {option.value_key: option for option in existing}
+
+    desired_ids: set[uuid.UUID] = set()
+    for option_ref in snapshot_options or []:
+        ref_id = uuid.UUID(option_ref["id"]) if option_ref.get("id") else None
+        option = by_id.get(ref_id) if ref_id else None
+        if option is None:
+            option = by_key.get(option_ref.get("value_key"))
+        if option is None:
+            option = AttributeOptionTable(id=ref_id, attribute_id=attribute.id, value_key=option_ref.get("value_key"))
+            db.session.add(option)
+            db.session.flush()
+            report.warnings.append(f"Option '{option_ref.get('value_key')}' was purged; recreated from the snapshot.")
+        else:
+            if option.deleted_at is not None:
+                option.deleted_at = None
+                report.resurrected.append(
+                    ResurrectedEntity(kind="attribute_option", id=option.id, name=option.value_key)
+                )
+            option.value_key = option_ref.get("value_key")
+        desired_ids.add(option.id)
+
+    now = datetime.now(timezone.utc)
+    for option in existing:
+        if option.id not in desired_ids and option.deleted_at is None:
+            option.deleted_at = now
+            report.warnings.append(f"Option '{option.value_key}' is not in the snapshot; moved to the trash.")
+
+
+def restore_attribute_revision(
+    *,
+    shop_id: uuid.UUID,
+    attribute_id: uuid.UUID,
+    revision_no: int,
+    allow_recreate: bool = False,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+) -> RestoreReport:
+    """Re-apply an attribute revision snapshot (attribute, translation and options).
+
+    Commits on success, rolls back on error.
+    """
+    report = RestoreReport(restored=False, entity_type=ENTITY_ATTRIBUTE, entity_id=attribute_id)
+    report.restored_from_revision_no = revision_no
+
+    revision = _get_revision(shop_id, ENTITY_ATTRIBUTE, attribute_id, revision_no)
+    data = _upconvert(dict(revision.data), revision.schema_version)
+
+    attribute = (
+        db.session.query(AttributeTable)
+        .filter(AttributeTable.shop_id == shop_id, AttributeTable.id == attribute_id)
+        .execution_options(include_deleted=True)
+        .with_for_update()
+        .first()
+    )
+    if attribute is None and not allow_recreate:
+        raise HTTPException(
+            status_code=410,
+            detail=(
+                "Attribute was permanently purged. Retry with force=true (user credentials required) "
+                "to recreate it from the snapshot."
+            ),
+        )
+
+    try:
+        if attribute is None:
+            attribute = AttributeTable(id=attribute_id, shop_id=shop_id)
+            db.session.add(attribute)
+            report.warnings.append("Attribute row was purged; recreated from the snapshot.")
+
+        if attribute.deleted_at is not None:
+            report.resurrected.append(ResurrectedEntity(kind="attribute", id=attribute.id, name=attribute.name))
+        attribute.deleted_at = None
+
+        _apply_columns(attribute, data.get("attribute") or {}, "attribute", report)
+
+        translation_data = data.get("translation")
+        if translation_data:
+            translation = (
+                db.session.query(AttributeTranslationTable)
+                .filter(AttributeTranslationTable.attribute_id == attribute.id)
+                .first()
+            )
+            if translation is None:
+                translation = AttributeTranslationTable(
+                    attribute_id=attribute.id, main_name=translation_data.get("main_name") or ""
+                )
+                db.session.add(translation)
+            _apply_columns(translation, translation_data, "translation", report)
+
+        db.session.flush()
+        _restore_attribute_options(attribute, data.get("options") or [], report)
+
+        new_revision = record_attribute_revision(attribute, action="restore", created_by=created_by, source=source)
+        report.new_revision_no = new_revision.revision_no
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    report.restored = True
+    return report
+
+
+def restore_attribute_from_trash(
+    *,
+    shop_id: uuid.UUID,
+    attribute_id: uuid.UUID,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+) -> RestoreReport:
+    """Undelete a trashed attribute. Its options and product values were never
+    removed, so this only clears ``deleted_at``. Options that were trashed
+    individually stay in the trash (restore a revision to bring those back)."""
+    report = RestoreReport(restored=False, entity_type=ENTITY_ATTRIBUTE, entity_id=attribute_id)
+
+    attribute = (
+        db.session.query(AttributeTable)
+        .filter(AttributeTable.shop_id == shop_id, AttributeTable.id == attribute_id)
+        .execution_options(include_deleted=True)
+        .with_for_update()
+        .first()
+    )
+    if attribute is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Attribute not found (it may have been permanently purged; use a revision restore with force=true).",
+        )
+    if attribute.deleted_at is None:
+        report.warnings.append("Attribute was not in the trash; nothing to do.")
+        report.restored = True
+        return report
+
+    try:
+        attribute.deleted_at = None
+        report.resurrected.append(ResurrectedEntity(kind="attribute", id=attribute.id, name=attribute.name))
+        new_revision = record_attribute_revision(attribute, action="restore", created_by=created_by, source=source)
         report.new_revision_no = new_revision.revision_no
         db.session.commit()
     except Exception:

--- a/server/services/restore.py
+++ b/server/services/restore.py
@@ -1,0 +1,504 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Restore PIM entities from revision snapshots and from the trash.
+
+Restore is designed to never crash on missing references. For every reference
+in the snapshot (category, tags, attributes, options) the resolution order is:
+
+1. by id, including soft-deleted rows — soft-deleted rows are resurrected
+   (``deleted_at`` cleared) and reported in ``RestoreReport.resurrected``;
+2. by denormalized name stored in the snapshot (attribute ``name`` and option
+   ``value_key`` are unique per shop/attribute) — covers hard-purged rows that
+   were recreated under a new id;
+3. otherwise the reference is dropped and reported in
+   ``RestoreReport.unresolved``.
+
+Snapshot fields that no longer exist on the current model (model churn) are
+skipped and reported in ``RestoreReport.skipped_fields``. Old snapshots are
+up-converted through ``UPCONVERTERS`` before being applied: for every structural
+schema bump N -> N+1 register a ``UPCONVERTERS[N] = lambda data: ...`` that
+returns the version-N+1 shape. Plain column additions/removals never need an
+up-converter.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Callable, Optional
+
+import structlog
+from fastapi import HTTPException
+from sqlalchemy.inspection import inspect as sa_inspect
+
+from server.db import db
+from server.db.models import (
+    AttributeOptionTable,
+    AttributeTable,
+    CategoryTable,
+    CategoryTranslationTable,
+    ProductTable,
+    ProductToTagTable,
+    ProductTranslationTable,
+    RevisionTable,
+    TagTable,
+)
+from server.schemas.revision import RestoreReport, ResurrectedEntity, UnresolvedReference
+from server.services.revisions import (
+    ENTITY_CATEGORY,
+    ENTITY_PRODUCT,
+    SCHEMA_VERSION,
+    record_category_revision,
+    record_product_revision,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Structural snapshot up-converters: UPCONVERTERS[n] converts a version-n snapshot
+# dict into the version-(n+1) shape. v1 is current, so this is empty.
+UPCONVERTERS: dict[int, Callable[[dict], dict]] = {}
+
+# Identity/lifecycle fields never applied from a snapshot
+_NEVER_APPLY = {"id", "shop_id", "deleted_at", "deleted_batch_id", "created_at", "modified_at"}
+
+
+def _upconvert(data: dict, from_version: int) -> dict:
+    version = from_version
+    while version < SCHEMA_VERSION:
+        converter = UPCONVERTERS.get(version)
+        if converter is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Cannot restore: no up-converter registered for snapshot schema_version {version}",
+            )
+        data = converter(data)
+        version += 1
+    return data
+
+
+def _coerce(model: Any, key: str, value: Any) -> Any:
+    """Coerce a JSON snapshot value back to the column's python type."""
+    if value is None:
+        return None
+    column = sa_inspect(model).columns[key]
+    try:
+        python_type = column.type.python_type
+    except NotImplementedError:
+        return value
+    if python_type is datetime and isinstance(value, str):
+        return datetime.fromisoformat(value)
+    if python_type is Decimal and isinstance(value, (int, float, str)):
+        return Decimal(str(value))
+    if python_type is uuid.UUID and isinstance(value, str):
+        return uuid.UUID(value)
+    return value
+
+
+def _apply_columns(
+    obj: Any, snapshot: dict, prefix: str, report: RestoreReport, skip: Optional[set[str]] = None
+) -> None:
+    """Apply snapshot keys that still exist as columns; report the rest as skipped."""
+    current_columns = set(sa_inspect(type(obj)).columns.keys())
+    for key, value in snapshot.items():
+        if key in _NEVER_APPLY or (skip and key in skip):
+            continue
+        if key in current_columns:
+            setattr(obj, key, _coerce(type(obj), key, value))
+        else:
+            report.skipped_fields.append(f"{prefix}.{key}")
+
+
+def _get_revision(shop_id: uuid.UUID, entity_type: str, entity_id: uuid.UUID, revision_no: int) -> RevisionTable:
+    revision = (
+        db.session.query(RevisionTable)
+        .filter(
+            RevisionTable.shop_id == shop_id,
+            RevisionTable.entity_type == entity_type,
+            RevisionTable.entity_id == entity_id,
+            RevisionTable.revision_no == revision_no,
+        )
+        .first()
+    )
+    if revision is None:
+        raise HTTPException(status_code=404, detail=f"Revision {revision_no} not found for {entity_type} {entity_id}")
+    return revision
+
+
+def _resolve_category(
+    shop_id: uuid.UUID, cat_ref: Optional[dict], product: ProductTable, report: RestoreReport
+) -> None:
+    if not cat_ref or not (cat_ref.get("id") or cat_ref.get("name")):
+        product.category_id = None
+        return
+
+    category = None
+    if cat_ref.get("id"):
+        category = (
+            db.session.query(CategoryTable)
+            .filter(CategoryTable.shop_id == shop_id, CategoryTable.id == uuid.UUID(cat_ref["id"]))
+            .execution_options(include_deleted=True)
+            .first()
+        )
+    if category is None and cat_ref.get("name"):
+        category = (
+            db.session.query(CategoryTable)
+            .join(CategoryTranslationTable, CategoryTranslationTable.category_id == CategoryTable.id)
+            .filter(CategoryTable.shop_id == shop_id, CategoryTranslationTable.main_name == cat_ref["name"])
+            .execution_options(include_deleted=True)
+            .first()
+        )
+
+    if category is None:
+        product.category_id = None
+        report.unresolved.append(UnresolvedReference(kind="category", id=cat_ref.get("id"), name=cat_ref.get("name")))
+        return
+
+    if category.deleted_at is not None:
+        category.deleted_at = None
+        report.resurrected.append(ResurrectedEntity(kind="category", id=category.id, name=cat_ref.get("name")))
+    product.category_id = category.id
+
+
+def _resolve_tags(shop_id: uuid.UUID, snapshot_tags: list, product: ProductTable, report: RestoreReport) -> None:
+    resolved_tag_ids: list[uuid.UUID] = []
+    for tag_ref in snapshot_tags or []:
+        tag = None
+        if tag_ref.get("id"):
+            tag = (
+                db.session.query(TagTable)
+                .filter(TagTable.shop_id == shop_id, TagTable.id == uuid.UUID(tag_ref["id"]))
+                .execution_options(include_deleted=True)
+                .first()
+            )
+        if tag is None and tag_ref.get("name"):
+            tag = (
+                db.session.query(TagTable)
+                .filter(TagTable.shop_id == shop_id, TagTable.name == tag_ref["name"])
+                .execution_options(include_deleted=True)
+                .first()
+            )
+        if tag is None:
+            report.unresolved.append(UnresolvedReference(kind="tag", id=tag_ref.get("id"), name=tag_ref.get("name")))
+            continue
+        if tag.deleted_at is not None:
+            tag.deleted_at = None
+            report.resurrected.append(ResurrectedEntity(kind="tag", id=tag.id, name=tag.name))
+        resolved_tag_ids.append(tag.id)
+
+    # Replace-all semantics; products_to_tags has no unique constraint, so dedupe by
+    # querying the existing links first.
+    existing_links = db.session.query(ProductToTagTable).filter(ProductToTagTable.product_id == product.id).all()
+    existing_by_tag = {}
+    for link in existing_links:
+        if link.tag_id in existing_by_tag or link.tag_id not in resolved_tag_ids:
+            db.session.delete(link)
+        else:
+            existing_by_tag[link.tag_id] = link
+    for tag_id in resolved_tag_ids:
+        if tag_id not in existing_by_tag:
+            db.session.add(ProductToTagTable(shop_id=shop_id, product_id=product.id, tag_id=tag_id))
+
+
+def _resolve_attribute_values(
+    shop_id: uuid.UUID, snapshot_values: list, product: ProductTable, report: RestoreReport
+) -> None:
+    from server.db.models import ProductAttributeValueTable
+
+    desired: set[tuple[uuid.UUID, Optional[uuid.UUID]]] = set()
+    for value_ref in snapshot_values or []:
+        attribute = None
+        if value_ref.get("attribute_id"):
+            attribute = (
+                db.session.query(AttributeTable)
+                .filter(AttributeTable.shop_id == shop_id, AttributeTable.id == uuid.UUID(value_ref["attribute_id"]))
+                .execution_options(include_deleted=True)
+                .first()
+            )
+        if attribute is None and value_ref.get("attribute_name"):
+            attribute = (
+                db.session.query(AttributeTable)
+                .filter(AttributeTable.shop_id == shop_id, AttributeTable.name == value_ref["attribute_name"])
+                .execution_options(include_deleted=True)
+                .first()
+            )
+        if attribute is None:
+            report.unresolved.append(
+                UnresolvedReference(
+                    kind="attribute", id=value_ref.get("attribute_id"), name=value_ref.get("attribute_name")
+                )
+            )
+            continue
+        if attribute.deleted_at is not None:
+            attribute.deleted_at = None
+            report.resurrected.append(ResurrectedEntity(kind="attribute", id=attribute.id, name=attribute.name))
+
+        option = None
+        wants_option = bool(value_ref.get("option_id") or value_ref.get("option_value_key"))
+        if value_ref.get("option_id"):
+            option = (
+                db.session.query(AttributeOptionTable)
+                .filter(
+                    AttributeOptionTable.id == uuid.UUID(value_ref["option_id"]),
+                    AttributeOptionTable.attribute_id == attribute.id,
+                )
+                .execution_options(include_deleted=True)
+                .first()
+            )
+        if option is None and value_ref.get("option_value_key"):
+            option = (
+                db.session.query(AttributeOptionTable)
+                .filter(
+                    AttributeOptionTable.attribute_id == attribute.id,
+                    AttributeOptionTable.value_key == value_ref["option_value_key"],
+                )
+                .execution_options(include_deleted=True)
+                .first()
+            )
+        if wants_option and option is None:
+            report.unresolved.append(
+                UnresolvedReference(
+                    kind="attribute_option", id=value_ref.get("option_id"), name=value_ref.get("option_value_key")
+                )
+            )
+            continue
+        if option is not None and option.deleted_at is not None:
+            option.deleted_at = None
+            report.resurrected.append(ResurrectedEntity(kind="attribute_option", id=option.id, name=option.value_key))
+
+        desired.add((attribute.id, option.id if option else None))
+
+    # Replace-all: diff against existing PAVs so the unique constraint can never fire.
+    existing = (
+        db.session.query(ProductAttributeValueTable).filter(ProductAttributeValueTable.product_id == product.id).all()
+    )
+    existing_keys = set()
+    for pav in existing:
+        key = (pav.attribute_id, pav.option_id)
+        if key not in desired or key in existing_keys:
+            db.session.delete(pav)
+        else:
+            existing_keys.add(key)
+    for attribute_id, option_id in desired - existing_keys:
+        db.session.add(
+            ProductAttributeValueTable(product_id=product.id, attribute_id=attribute_id, option_id=option_id)
+        )
+
+
+def restore_product_revision(
+    *,
+    shop_id: uuid.UUID,
+    product_id: uuid.UUID,
+    revision_no: int,
+    allow_recreate: bool = False,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+) -> RestoreReport:
+    """Re-apply a product revision snapshot. Commits on success, rolls back on error."""
+    report = RestoreReport(restored=False, entity_type=ENTITY_PRODUCT, entity_id=product_id)
+    report.restored_from_revision_no = revision_no
+
+    revision = _get_revision(shop_id, ENTITY_PRODUCT, product_id, revision_no)
+    data = _upconvert(dict(revision.data), revision.schema_version)
+
+    try:
+        product = (
+            db.session.query(ProductTable)
+            .filter(ProductTable.shop_id == shop_id, ProductTable.id == product_id)
+            .execution_options(include_deleted=True)
+            .with_for_update()
+            .first()
+        )
+        if product is None:
+            if not allow_recreate:
+                raise HTTPException(
+                    status_code=410,
+                    detail=(
+                        "Product was permanently purged. Retry with force=true (user credentials required) "
+                        "to recreate it from the snapshot."
+                    ),
+                )
+            product = ProductTable(id=product_id, shop_id=shop_id)
+            db.session.add(product)
+            report.warnings.append("Product row was purged; recreated from the snapshot.")
+
+        if product.deleted_at is not None:
+            report.resurrected.append(ResurrectedEntity(kind="product", id=product.id))
+        product.deleted_at = None
+        product.deleted_batch_id = None
+
+        # category_id is deliberately skipped here: it may point at a purged category,
+        # so it is resolved (and possibly resurrected) by _resolve_category below.
+        _apply_columns(product, data.get("product") or {}, "product", report, skip={"category_id"})
+        product.modified_at = datetime.now(timezone.utc)
+
+        translation_data = data.get("translation")
+        if translation_data:
+            translation = (
+                db.session.query(ProductTranslationTable)
+                .filter(ProductTranslationTable.product_id == product.id)
+                .first()
+            )
+            if translation is None:
+                translation = ProductTranslationTable(
+                    product_id=product.id,
+                    main_name=translation_data.get("main_name") or "",
+                    main_description=translation_data.get("main_description") or "",
+                    main_description_short=translation_data.get("main_description_short") or "",
+                )
+                db.session.add(translation)
+            _apply_columns(translation, translation_data, "translation", report)
+
+        db.session.flush()
+        _resolve_category(shop_id, data.get("category"), product, report)
+        _resolve_tags(shop_id, data.get("tags") or [], product, report)
+        _resolve_attribute_values(shop_id, data.get("attribute_values") or [], product, report)
+
+        new_revision = record_product_revision(product, action="restore", created_by=created_by, source=source)
+        report.new_revision_no = new_revision.revision_no
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    report.restored = True
+    return report
+
+
+def restore_product_from_trash(
+    *,
+    shop_id: uuid.UUID,
+    product_id: uuid.UUID,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+) -> RestoreReport:
+    """Undelete a trashed product. The row still holds all its data (tags/attribute
+    values were never removed), so this only clears ``deleted_at``."""
+    report = RestoreReport(restored=False, entity_type=ENTITY_PRODUCT, entity_id=product_id)
+
+    product = (
+        db.session.query(ProductTable)
+        .filter(ProductTable.shop_id == shop_id, ProductTable.id == product_id)
+        .execution_options(include_deleted=True)
+        .with_for_update()
+        .first()
+    )
+    if product is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Product not found (it may have been permanently purged; use a revision restore with force=true).",
+        )
+    if product.deleted_at is None:
+        report.warnings.append("Product was not in the trash; nothing to do.")
+        report.restored = True
+        return report
+
+    try:
+        product.deleted_at = None
+        product.deleted_batch_id = None
+        report.resurrected.append(ResurrectedEntity(kind="product", id=product.id))
+
+        # If the product's category is itself trashed the product would stay invisible
+        # in category listings — resurrect it as well.
+        if product.category_id is not None:
+            category = (
+                db.session.query(CategoryTable)
+                .filter(CategoryTable.id == product.category_id)
+                .execution_options(include_deleted=True)
+                .first()
+            )
+            if category is not None and category.deleted_at is not None:
+                category.deleted_at = None
+                report.resurrected.append(ResurrectedEntity(kind="category", id=category.id))
+
+        new_revision = record_product_revision(product, action="restore", created_by=created_by, source=source)
+        report.new_revision_no = new_revision.revision_no
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    report.restored = True
+    return report
+
+
+def restore_category_from_trash(
+    *,
+    shop_id: uuid.UUID,
+    category_id: uuid.UUID,
+    restore_products: bool = True,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+) -> RestoreReport:
+    """Undelete a trashed category, optionally with the batch of products that was
+    trashed together with it (category delete with ``force=true``)."""
+    report = RestoreReport(restored=False, entity_type=ENTITY_CATEGORY, entity_id=category_id)
+
+    category = (
+        db.session.query(CategoryTable)
+        .filter(CategoryTable.shop_id == shop_id, CategoryTable.id == category_id)
+        .execution_options(include_deleted=True)
+        .with_for_update()
+        .first()
+    )
+    if category is None:
+        raise HTTPException(status_code=404, detail="Category not found (it may have been permanently purged).")
+    if category.deleted_at is None:
+        report.warnings.append("Category was not in the trash; nothing to do.")
+        report.restored = True
+        return report
+
+    try:
+        category.deleted_at = None
+        category_name = category.translation.main_name if category.translation else None
+        report.resurrected.append(ResurrectedEntity(kind="category", id=category.id, name=category_name))
+
+        if restore_products:
+            # The cascade delete stamped a batch id on every product it trashed and
+            # stored it in the category's delete revision.
+            last_delete = (
+                db.session.query(RevisionTable)
+                .filter(
+                    RevisionTable.entity_type == ENTITY_CATEGORY,
+                    RevisionTable.entity_id == category_id,
+                    RevisionTable.action == "delete",
+                )
+                .order_by(RevisionTable.revision_no.desc())
+                .first()
+            )
+            batch_id = (last_delete.data or {}).get("deleted_batch_id") if last_delete else None
+            if batch_id:
+                products = (
+                    db.session.query(ProductTable)
+                    .filter(ProductTable.shop_id == shop_id, ProductTable.deleted_batch_id == uuid.UUID(batch_id))
+                    .execution_options(include_deleted=True)
+                    .with_for_update()
+                    .all()
+                )
+                for product in products:
+                    product.deleted_at = None
+                    product.deleted_batch_id = None
+                    report.resurrected.append(ResurrectedEntity(kind="product", id=product.id))
+                    record_product_revision(product, action="restore", created_by=created_by, source=source)
+            elif last_delete is not None:
+                report.warnings.append(
+                    "No product batch found on the category's delete revision; only the category was restored."
+                )
+
+        new_revision = record_category_revision(category, action="restore", created_by=created_by, source=source)
+        report.new_revision_no = new_revision.revision_no
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    report.restored = True
+    return report

--- a/server/services/restore.py
+++ b/server/services/restore.py
@@ -707,6 +707,83 @@ def restore_attribute_from_trash(
     return report
 
 
+def restore_category_revision(
+    *,
+    shop_id: uuid.UUID,
+    category_id: uuid.UUID,
+    revision_no: int,
+    allow_recreate: bool = False,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+) -> RestoreReport:
+    """Re-apply a category revision snapshot (fields, translation, image references).
+
+    Products are deliberately left alone: reattaching or restoring them is the job of
+    the trash restore (batch) or of per-product revision restores. Commits on success,
+    rolls back on error.
+    """
+    report = RestoreReport(restored=False, entity_type=ENTITY_CATEGORY, entity_id=category_id)
+    report.restored_from_revision_no = revision_no
+
+    revision = _get_revision(shop_id, ENTITY_CATEGORY, category_id, revision_no)
+    data = _upconvert(dict(revision.data), revision.schema_version)
+
+    category = (
+        db.session.query(CategoryTable)
+        .filter(CategoryTable.shop_id == shop_id, CategoryTable.id == category_id)
+        .execution_options(include_deleted=True)
+        .with_for_update()
+        .first()
+    )
+    if category is None and not allow_recreate:
+        raise HTTPException(
+            status_code=410,
+            detail=(
+                "Category was permanently purged. Retry with force=true (user credentials required) "
+                "to recreate it from the snapshot."
+            ),
+        )
+
+    try:
+        if category is None:
+            category = CategoryTable(id=category_id, shop_id=shop_id)
+            db.session.add(category)
+            report.warnings.append("Category row was purged; recreated from the snapshot.")
+
+        if category.deleted_at is not None:
+            category_name = category.translation.main_name if category.translation else None
+            report.resurrected.append(ResurrectedEntity(kind="category", id=category.id, name=category_name))
+        category.deleted_at = None
+
+        _apply_columns(category, data.get("category") or {}, "category", report)
+
+        translation_data = data.get("translation")
+        if translation_data:
+            translation = (
+                db.session.query(CategoryTranslationTable)
+                .filter(CategoryTranslationTable.category_id == category.id)
+                .first()
+            )
+            if translation is None:
+                translation = CategoryTranslationTable(
+                    category_id=category.id,
+                    main_name=translation_data.get("main_name") or "",
+                    main_description=translation_data.get("main_description") or "",
+                )
+                db.session.add(translation)
+            _apply_columns(translation, translation_data, "translation", report)
+
+        new_revision = record_category_revision(category, action="restore", created_by=created_by, source=source)
+        report.new_revision_no = new_revision.revision_no
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    report.restored = True
+    return report
+
+
 def restore_category_from_trash(
     *,
     shop_id: uuid.UUID,

--- a/server/services/restore.py
+++ b/server/services/restore.py
@@ -65,6 +65,10 @@ from server.services.revisions import (
     record_category_revision,
     record_product_revision,
     record_tag_revision,
+    snapshot_attribute,
+    snapshot_category,
+    snapshot_product,
+    snapshot_tag,
 )
 
 logger = structlog.get_logger(__name__)
@@ -137,6 +141,20 @@ def _get_revision(shop_id: uuid.UUID, entity_type: str, entity_id: uuid.UUID, re
     if revision is None:
         raise HTTPException(status_code=404, detail=f"Revision {revision_no} not found for {entity_type} {entity_id}")
     return revision
+
+
+_NOOP_WARNING = "Restore was a no-op: the revision matches the current state; no new revision was recorded."
+
+
+def _is_noop(before: Optional[dict], entity: Any, snapshot_fn: Callable[[Any], dict], report: RestoreReport) -> bool:
+    """True when the restore changed nothing: nothing was resurrected or recreated and
+    the entity's snapshot is identical to the pre-restore one. Callers then skip
+    recording a restore revision so the history doesn't fill up with no-ops."""
+    if before is None or report.resurrected or report.warnings:
+        return False
+    db.session.flush()
+    db.session.expire(entity)
+    return snapshot_fn(entity) == before
 
 
 def _resolve_category(
@@ -333,6 +351,8 @@ def restore_product_revision(
             ),
         )
 
+    before = snapshot_product(product) if product is not None else None
+
     try:
         if product is None:
             product = ProductTable(id=product_id, shop_id=shop_id)
@@ -347,7 +367,6 @@ def restore_product_revision(
         # category_id is deliberately skipped here: it may point at a purged category,
         # so it is resolved (and possibly resurrected) by _resolve_category below.
         _apply_columns(product, data.get("product") or {}, "product", report, skip={"category_id"})
-        product.modified_at = datetime.now(timezone.utc)
 
         translation_data = data.get("translation")
         if translation_data:
@@ -371,8 +390,12 @@ def restore_product_revision(
         _resolve_tags(shop_id, data.get("tags") or [], product, report)
         _resolve_attribute_values(shop_id, data.get("attribute_values") or [], product, report)
 
-        new_revision = record_product_revision(product, action="restore", created_by=created_by, source=source)
-        report.new_revision_no = new_revision.revision_no
+        if _is_noop(before, product, snapshot_product, report):
+            report.warnings.append(_NOOP_WARNING)
+        else:
+            product.modified_at = datetime.now(timezone.utc)
+            new_revision = record_product_revision(product, action="restore", created_by=created_by, source=source)
+            report.new_revision_no = new_revision.revision_no
         db.session.commit()
     except Exception:
         db.session.rollback()
@@ -471,6 +494,8 @@ def restore_tag_revision(
             ),
         )
 
+    before = snapshot_tag(tag) if tag is not None else None
+
     try:
         if tag is None:
             tag = TagTable(id=tag_id, shop_id=shop_id)
@@ -491,8 +516,11 @@ def restore_tag_revision(
                 db.session.add(translation)
             _apply_columns(translation, translation_data, "translation", report)
 
-        new_revision = record_tag_revision(tag, action="restore", created_by=created_by, source=source)
-        report.new_revision_no = new_revision.revision_no
+        if _is_noop(before, tag, snapshot_tag, report):
+            report.warnings.append(_NOOP_WARNING)
+        else:
+            new_revision = record_tag_revision(tag, action="restore", created_by=created_by, source=source)
+            report.new_revision_no = new_revision.revision_no
         db.session.commit()
     except Exception:
         db.session.rollback()
@@ -624,6 +652,8 @@ def restore_attribute_revision(
             ),
         )
 
+    before = snapshot_attribute(attribute) if attribute is not None else None
+
     try:
         if attribute is None:
             attribute = AttributeTable(id=attribute_id, shop_id=shop_id)
@@ -653,8 +683,11 @@ def restore_attribute_revision(
         db.session.flush()
         _restore_attribute_options(attribute, data.get("options") or [], report)
 
-        new_revision = record_attribute_revision(attribute, action="restore", created_by=created_by, source=source)
-        report.new_revision_no = new_revision.revision_no
+        if _is_noop(before, attribute, snapshot_attribute, report):
+            report.warnings.append(_NOOP_WARNING)
+        else:
+            new_revision = record_attribute_revision(attribute, action="restore", created_by=created_by, source=source)
+            report.new_revision_no = new_revision.revision_no
         db.session.commit()
     except Exception:
         db.session.rollback()
@@ -744,6 +777,8 @@ def restore_category_revision(
             ),
         )
 
+    before = snapshot_category(category) if category is not None else None
+
     try:
         if category is None:
             category = CategoryTable(id=category_id, shop_id=shop_id)
@@ -773,8 +808,11 @@ def restore_category_revision(
                 db.session.add(translation)
             _apply_columns(translation, translation_data, "translation", report)
 
-        new_revision = record_category_revision(category, action="restore", created_by=created_by, source=source)
-        report.new_revision_no = new_revision.revision_no
+        if _is_noop(before, category, snapshot_category, report):
+            report.warnings.append(_NOOP_WARNING)
+        else:
+            new_revision = record_category_revision(category, action="restore", created_by=created_by, source=source)
+            report.new_revision_no = new_revision.revision_no
         db.session.commit()
     except Exception:
         db.session.rollback()

--- a/server/services/revisions.py
+++ b/server/services/revisions.py
@@ -189,6 +189,51 @@ def _record_revision(
     return revision
 
 
+def _has_revision(entity_type: str, entity_id: UUID) -> bool:
+    query = db.session.query(RevisionTable.id).filter(
+        RevisionTable.entity_type == entity_type, RevisionTable.entity_id == entity_id
+    )
+    return db.session.query(query.exists()).scalar()
+
+
+def _ensure_baseline(entity_type: str, entity: Any, snapshot: Any) -> Optional[RevisionTable]:
+    # Autoflush stays off for the whole capture so mutations already pending in the
+    # session (new tag links, attribute values) cannot leak into the baseline.
+    with db.session.no_autoflush:
+        if _has_revision(entity_type, entity.id):
+            return None
+        return _record_revision(
+            shop_id=entity.shop_id,
+            entity_type=entity_type,
+            entity_id=entity.id,
+            action="baseline",
+            data=snapshot(entity),
+            created_by=None,
+            source="rest",
+        )
+
+
+def ensure_baseline_product_revision(product: ProductTable) -> Optional[RevisionTable]:
+    """Capture the pre-mutation state of a product that predates the revisions feature.
+
+    Entities created before revision tracking shipped have no revision rows, so their
+    first edit would otherwise be un-undoable: the first recorded revision would hold
+    the *post*-edit state. This records the current state as revision 1
+    (``action="baseline"``) and is a no-op once any revision exists.
+
+    Call it BEFORE applying the mutation: in-memory column changes are visible to the
+    snapshot regardless of flushing. ``created_by`` stays empty because the captured
+    state was authored before tracking existed, not by the actor triggering the capture.
+    Deletes don't need a baseline — a delete revision already snapshots the pre-delete state.
+    """
+    return _ensure_baseline(ENTITY_PRODUCT, product, snapshot_product)
+
+
+def ensure_baseline_category_revision(category: CategoryTable) -> Optional[RevisionTable]:
+    """Category counterpart of ``ensure_baseline_product_revision`` — same contract."""
+    return _ensure_baseline(ENTITY_CATEGORY, category, snapshot_category)
+
+
 def record_product_revision(
     product: ProductTable,
     *,

--- a/server/services/revisions.py
+++ b/server/services/revisions.py
@@ -1,0 +1,241 @@
+# Copyright 2026 René Dohmen <acidjunk@gmail.com>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Aggregate revision snapshots for PIM entities (products, categories).
+
+Every mutation of a product aggregate — the product row, its translation, its
+tag links, its attribute values or its image slots — records one row in the
+``revisions`` table holding a full JSON snapshot of the aggregate. Restoring a
+revision (see ``server/services/restore.py``) deserializes that snapshot and
+re-applies it.
+
+Robustness against model churn is structural, not per-field: the serializer
+iterates the model's mapped columns at runtime, so newly added columns are
+snapshotted automatically with zero code change here. Restore applies only the
+intersection of snapshot keys and current columns and reports the difference.
+``SCHEMA_VERSION`` only needs a bump (plus an entry in
+``server/services/restore.py::UPCONVERTERS``) for *structural* reshapes of the
+snapshot dict — renamed or re-nested keys — never for plain column changes.
+
+Transactions: ``record_*_revision`` only ``session.add()``s the revision row and
+prunes old ones — it never commits. The calling endpoint owns the transaction
+and must hold a ``FOR UPDATE`` row lock on the entity (via
+``get_id_by_shop_id(..., for_update=True)``) so that revision numbering is
+race-free under concurrent writers.
+"""
+
+from typing import Any, Optional, Tuple
+from uuid import UUID
+
+import structlog
+from fastapi import Request
+from fastapi.encoders import jsonable_encoder
+from sqlalchemy import func
+from sqlalchemy.inspection import inspect as sa_inspect
+
+from server.db import db
+from server.db.models import CategoryTable, ProductTable, RevisionTable
+from server.settings import app_settings
+
+logger = structlog.get_logger(__name__)
+
+SCHEMA_VERSION = 1
+
+ENTITY_PRODUCT = "product"
+ENTITY_CATEGORY = "category"
+
+# Lifecycle/identity fields that are not part of an entity's content
+_EXCLUDED_KEYS = {"id", "shop_id", "deleted_at", "deleted_batch_id"}
+_EXCLUDED_TRANSLATION_KEYS = {"id", "product_id", "category_id"}
+
+# Minimum revisions to keep regardless of settings — the PIM undo story assumes it.
+_MIN_RETENTION = 10
+
+
+def retention() -> int:
+    return max(app_settings.REVISION_RETENTION, _MIN_RETENTION)
+
+
+def actor(principal: Any = None, request: Optional[Request] = None) -> Tuple[Optional[str], str]:
+    """Derive (created_by, source) from the auth principal and the incoming request.
+
+    ``principal`` is whatever ``auth_required_any`` returned: an ``ApiKeyTable`` row
+    for API-key clients or a ``CustomCognitoToken`` for Cognito users. MCP calls are
+    detected via the ``mcp-session-id`` header that fastmcp forwards into the
+    in-process request.
+    """
+    from server.db.models import ApiKeyTable
+
+    created_by = None
+    if isinstance(principal, ApiKeyTable):
+        created_by = f"api_key:{principal.id}"
+    elif principal is not None and getattr(principal, "cognito_id", None):
+        created_by = f"cognito:{principal.cognito_id}"
+
+    source = "mcp" if request is not None and request.headers.get("mcp-session-id") else "rest"
+    return created_by, source
+
+
+def _columns_snapshot(obj: Any, excluded: set[str]) -> dict:
+    """Snapshot every mapped column of ``obj`` (minus ``excluded``) as JSON-able values."""
+    keys = [k for k in sa_inspect(type(obj)).columns.keys() if k not in excluded]
+    return {key: jsonable_encoder(getattr(obj, key)) for key in keys}
+
+
+def snapshot_product(product: ProductTable) -> dict:
+    """Serialize the full product aggregate. Call after ``session.flush()`` so pending changes are visible."""
+    translation = product.translation
+    category = product.category
+
+    category_name = None
+    if category is not None and category.translation is not None:
+        category_name = category.translation.main_name
+
+    return {
+        "product": _columns_snapshot(product, _EXCLUDED_KEYS),
+        "translation": _columns_snapshot(translation, _EXCLUDED_TRANSLATION_KEYS) if translation else None,
+        "category": (
+            {"id": jsonable_encoder(category.id), "name": category_name}
+            if category is not None
+            else ({"id": jsonable_encoder(product.category_id), "name": None} if product.category_id else None)
+        ),
+        "tags": [{"id": jsonable_encoder(tag.id), "name": tag.name} for tag in (product.tags or [])],
+        "attribute_values": [
+            {
+                "attribute_id": jsonable_encoder(pav.attribute_id),
+                "attribute_name": pav.attribute.name if pav.attribute else None,
+                "option_id": jsonable_encoder(pav.option_id),
+                "option_value_key": pav.option.value_key if pav.option else None,
+            }
+            for pav in (product.attribute_values or [])
+        ],
+    }
+
+
+def snapshot_category(category: CategoryTable) -> dict:
+    translation = category.translation
+    return {
+        "category": _columns_snapshot(category, _EXCLUDED_KEYS),
+        "translation": _columns_snapshot(translation, _EXCLUDED_TRANSLATION_KEYS) if translation else None,
+    }
+
+
+def _next_revision_no(entity_type: str, entity_id: UUID) -> int:
+    current = (
+        db.session.query(func.max(RevisionTable.revision_no))
+        .filter(RevisionTable.entity_type == entity_type, RevisionTable.entity_id == entity_id)
+        .scalar()
+    )
+    return (current or 0) + 1
+
+
+def _prune(entity_type: str, entity_id: UUID, latest_no: int) -> None:
+    cutoff = latest_no - retention()
+    if cutoff <= 0:
+        return
+    (
+        db.session.query(RevisionTable)
+        .filter(
+            RevisionTable.entity_type == entity_type,
+            RevisionTable.entity_id == entity_id,
+            RevisionTable.revision_no <= cutoff,
+        )
+        .delete(synchronize_session=False)
+    )
+
+
+def _record_revision(
+    *,
+    shop_id: UUID,
+    entity_type: str,
+    entity_id: UUID,
+    action: str,
+    data: dict,
+    created_by: Optional[str],
+    source: str,
+) -> RevisionTable:
+    revision_no = _next_revision_no(entity_type, entity_id)
+    revision = RevisionTable(
+        shop_id=shop_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        revision_no=revision_no,
+        action=action,
+        schema_version=SCHEMA_VERSION,
+        data=data,
+        created_by=created_by,
+        source=source,
+    )
+    db.session.add(revision)
+    _prune(entity_type, entity_id, revision_no)
+    logger.info(
+        "Recorded revision",
+        entity_type=entity_type,
+        entity_id=str(entity_id),
+        revision_no=revision_no,
+        action=action,
+        created_by=created_by,
+        source=source,
+    )
+    return revision
+
+
+def record_product_revision(
+    product: ProductTable,
+    *,
+    action: str,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+    extra_data: Optional[dict] = None,
+) -> RevisionTable:
+    """Record a snapshot of the product aggregate. Does NOT commit — the caller owns the transaction."""
+    # Make sure pending mutations are visible and relationship caches (tags,
+    # attribute_values) are not stale from before the mutation.
+    db.session.flush()
+    db.session.expire(product)
+    data = snapshot_product(product)
+    if extra_data:
+        data.update(extra_data)
+    return _record_revision(
+        shop_id=product.shop_id,
+        entity_type=ENTITY_PRODUCT,
+        entity_id=product.id,
+        action=action,
+        data=data,
+        created_by=created_by,
+        source=source,
+    )
+
+
+def record_category_revision(
+    category: CategoryTable,
+    *,
+    action: str,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+    extra_data: Optional[dict] = None,
+) -> RevisionTable:
+    """Record a snapshot of the category. Does NOT commit — the caller owns the transaction."""
+    db.session.flush()
+    db.session.expire(category)
+    data = snapshot_category(category)
+    if extra_data:
+        data.update(extra_data)
+    return _record_revision(
+        shop_id=category.shop_id,
+        entity_type=ENTITY_CATEGORY,
+        entity_id=category.id,
+        action=action,
+        data=data,
+        created_by=created_by,
+        source=source,
+    )

--- a/server/services/revisions.py
+++ b/server/services/revisions.py
@@ -43,7 +43,7 @@ from sqlalchemy import func
 from sqlalchemy.inspection import inspect as sa_inspect
 
 from server.db import db
-from server.db.models import CategoryTable, ProductTable, RevisionTable
+from server.db.models import AttributeOptionTable, AttributeTable, CategoryTable, ProductTable, RevisionTable, TagTable
 from server.settings import app_settings
 
 logger = structlog.get_logger(__name__)
@@ -52,10 +52,12 @@ SCHEMA_VERSION = 1
 
 ENTITY_PRODUCT = "product"
 ENTITY_CATEGORY = "category"
+ENTITY_TAG = "tag"
+ENTITY_ATTRIBUTE = "attribute"
 
 # Lifecycle/identity fields that are not part of an entity's content
 _EXCLUDED_KEYS = {"id", "shop_id", "deleted_at", "deleted_batch_id"}
-_EXCLUDED_TRANSLATION_KEYS = {"id", "product_id", "category_id"}
+_EXCLUDED_TRANSLATION_KEYS = {"id", "product_id", "category_id", "tag_id", "attribute_id"}
 
 # Minimum revisions to keep regardless of settings — the PIM undo story assumes it.
 _MIN_RETENTION = 10
@@ -126,6 +128,34 @@ def snapshot_category(category: CategoryTable) -> dict:
     return {
         "category": _columns_snapshot(category, _EXCLUDED_KEYS),
         "translation": _columns_snapshot(translation, _EXCLUDED_TRANSLATION_KEYS) if translation else None,
+    }
+
+
+def snapshot_tag(tag: TagTable) -> dict:
+    translation = tag.translation
+    return {
+        "tag": _columns_snapshot(tag, _EXCLUDED_KEYS),
+        "translation": _columns_snapshot(translation, _EXCLUDED_TRANSLATION_KEYS) if translation else None,
+    }
+
+
+def snapshot_attribute(attribute: AttributeTable) -> dict:
+    """Serialize the attribute aggregate: the attribute, its translation and its (live) options.
+
+    Option changes record an attribute revision, so one entity type covers the whole aggregate.
+    """
+    translation = attribute.translation
+    # Top-level query instead of the relationship so the soft-delete filter deterministically applies
+    options = (
+        db.session.query(AttributeOptionTable)
+        .filter(AttributeOptionTable.attribute_id == attribute.id)
+        .order_by(AttributeOptionTable.value_key)
+        .all()
+    )
+    return {
+        "attribute": _columns_snapshot(attribute, _EXCLUDED_KEYS),
+        "translation": _columns_snapshot(translation, _EXCLUDED_TRANSLATION_KEYS) if translation else None,
+        "options": [{"id": jsonable_encoder(option.id), "value_key": option.value_key} for option in options],
     }
 
 
@@ -234,6 +264,16 @@ def ensure_baseline_category_revision(category: CategoryTable) -> Optional[Revis
     return _ensure_baseline(ENTITY_CATEGORY, category, snapshot_category)
 
 
+def ensure_baseline_tag_revision(tag: TagTable) -> Optional[RevisionTable]:
+    """Tag counterpart of ``ensure_baseline_product_revision`` — same contract."""
+    return _ensure_baseline(ENTITY_TAG, tag, snapshot_tag)
+
+
+def ensure_baseline_attribute_revision(attribute: AttributeTable) -> Optional[RevisionTable]:
+    """Attribute counterpart of ``ensure_baseline_product_revision`` — same contract."""
+    return _ensure_baseline(ENTITY_ATTRIBUTE, attribute, snapshot_attribute)
+
+
 def record_product_revision(
     product: ProductTable,
     *,
@@ -281,6 +321,52 @@ def record_category_revision(
         entity_id=category.id,
         action=action,
         data=data,
+        created_by=created_by,
+        source=source,
+    )
+
+
+def record_tag_revision(
+    tag: TagTable,
+    *,
+    action: str,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+) -> RevisionTable:
+    """Record a snapshot of the tag. Does NOT commit — the caller owns the transaction."""
+    db.session.flush()
+    db.session.expire(tag)
+    return _record_revision(
+        shop_id=tag.shop_id,
+        entity_type=ENTITY_TAG,
+        entity_id=tag.id,
+        action=action,
+        data=snapshot_tag(tag),
+        created_by=created_by,
+        source=source,
+    )
+
+
+def record_attribute_revision(
+    attribute: AttributeTable,
+    *,
+    action: str,
+    created_by: Optional[str] = None,
+    source: str = "rest",
+) -> RevisionTable:
+    """Record a snapshot of the attribute aggregate (incl. options). Does NOT commit.
+
+    Option mutations record an attribute revision with ``action="update"``; the option
+    itself has no revision history of its own.
+    """
+    db.session.flush()
+    db.session.expire(attribute)
+    return _record_revision(
+        shop_id=attribute.shop_id,
+        entity_type=ENTITY_ATTRIBUTE,
+        entity_id=attribute.id,
+        action=action,
+        data=snapshot_attribute(attribute),
         created_by=created_by,
         source=source,
     )

--- a/server/settings.py
+++ b/server/settings.py
@@ -40,6 +40,9 @@ class AppSettings(BaseSettings):
     TESTING: bool = True
     EMAILS_ENABLED: bool = False
     MCP_ENABLED: bool = False
+    # How many revisions to keep per entity (product/category). Pruned on write.
+    # The PIM undo story assumes at least 10; values below that are ignored.
+    REVISION_RETENTION: int = 25
     # SESSION_SECRET: str = "".join(secrets.choice(string.ascii_letters) for i in range(16))  # noqa: S311
     SESSION_SECRET: str = "CHANGEME"
 

--- a/tests/unit_tests/api/test_attributes_delete.py
+++ b/tests/unit_tests/api/test_attributes_delete.py
@@ -3,7 +3,28 @@ from server.db.models import AttributeOptionTable, AttributeTable, AttributeTran
 from tests.unit_tests.factories.attribute import make_attribute, make_option, make_pav
 
 
-def test_delete_attribute_blocked_by_products(test_client, shop_with_products_and_attributes):
+def test_delete_attribute_soft_deletes_by_default(test_client, shop_with_products_and_attributes):
+    ids = shop_with_products_and_attributes
+    shop_id = ids["shop_id"]
+    attr_id = ids["attr1_id"]
+    opt_a_id = ids["opt1a_id"]
+    product_id = ids["product_id"]
+
+    # Seed some PAVs — soft delete is allowed even while the attribute is in use
+    make_pav(product_id, attr_id, opt_a_id)
+
+    resp = test_client.delete(f"/shops/{shop_id}/attributes/{attr_id}")
+    assert resp.status_code == 204
+
+    # Hidden from normal queries...
+    assert db.session.query(AttributeTable).filter_by(id=attr_id).first() is None
+    # ...but the row, its options and the PAV data are all still there
+    row = db.session.query(AttributeTable).filter_by(id=attr_id).execution_options(include_deleted=True).first()
+    assert row is not None and row.deleted_at is not None
+    assert db.session.query(ProductAttributeValueTable).filter_by(attribute_id=attr_id).count() == 1
+
+
+def test_purge_attribute_blocked_by_products(test_client, shop_with_products_and_attributes):
     ids = shop_with_products_and_attributes
     shop_id = ids["shop_id"]
     attr_id = ids["attr1_id"]
@@ -13,14 +34,14 @@ def test_delete_attribute_blocked_by_products(test_client, shop_with_products_an
     # Seed some PAVs
     make_pav(product_id, attr_id, opt_a_id)
 
-    # Perform delete - should fail with 409
-    resp = test_client.delete(f"/shops/{shop_id}/attributes/{attr_id}")
+    # Hard purge should fail with 409 while in use
+    resp = test_client.delete(f"/shops/{shop_id}/attributes/{attr_id}?force=true")
     assert resp.status_code == 409
     data = resp.json()
     assert data["detail"]["message"] == "Attribute is in use and cannot be deleted"
 
 
-def test_delete_attribute_success_no_products(test_client, shop_with_products_and_attributes):
+def test_purge_attribute_success_no_products(test_client, shop_with_products_and_attributes):
     ids = shop_with_products_and_attributes
     shop_id = ids["shop_id"]
     attr_id = ids["attr1_id"]
@@ -28,14 +49,22 @@ def test_delete_attribute_success_no_products(test_client, shop_with_products_an
     # Pre-verification
     assert db.session.query(AttributeTable).filter_by(id=attr_id).first() is not None
 
-    # Perform delete
-    resp = test_client.delete(f"/shops/{shop_id}/attributes/{attr_id}")
+    # Perform hard purge
+    resp = test_client.delete(f"/shops/{shop_id}/attributes/{attr_id}?force=true")
     assert resp.status_code == 204
 
-    # Post-verification: Attribute should be gone
-    assert db.session.query(AttributeTable).filter_by(id=attr_id).first() is None
+    # Post-verification: Attribute should be gone (even when including trashed rows)
+    assert (
+        db.session.query(AttributeTable).filter_by(id=attr_id).execution_options(include_deleted=True).first() is None
+    )
     # Options and translations should also be gone due to SQLAlchemy cascade
-    assert db.session.query(AttributeOptionTable).filter_by(attribute_id=attr_id).count() == 0
+    assert (
+        db.session.query(AttributeOptionTable)
+        .filter_by(attribute_id=attr_id)
+        .execution_options(include_deleted=True)
+        .count()
+        == 0
+    )
     assert db.session.query(AttributeTranslationTable).filter_by(attribute_id=attr_id).count() == 0
 
 

--- a/tests/unit_tests/api/test_category_delete_flow.py
+++ b/tests/unit_tests/api/test_category_delete_flow.py
@@ -99,6 +99,15 @@ def test_detach_keeps_products_without_category(shop_with_config, test_client):
     assert row.deleted_at is None
     assert row.category_id is None
 
+    # Product endpoints must keep serializing detached products (category_id is None)
+    resp = test_client.get(f"/shops/{shop_with_config}/products/")
+    assert resp.status_code == 200, resp.text
+    listed = {item["id"]: item for item in resp.json()}
+    assert listed[str(product_id)]["category_id"] is None
+    resp = test_client.get(f"/shops/{shop_with_config}/products/{product_id}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["category_id"] is None
+
     # The detach was recorded on the product with a pointer to the old category
     last = (
         db.session.query(RevisionTable)

--- a/tests/unit_tests/api/test_category_delete_flow.py
+++ b/tests/unit_tests/api/test_category_delete_flow.py
@@ -1,0 +1,123 @@
+"""Tests for the category delete flow: 409 warning, force cascade, detach, and batch restore."""
+
+from server.db import db
+from server.db.models import CategoryTable, ProductTable, RevisionTable
+from tests.unit_tests.factories.categories import make_category
+from tests.unit_tests.factories.product import make_product
+
+
+def get_product(product_id, include_deleted=True):
+    # Endpoint writes happen in a different (request) session on the same connection;
+    # expire cached instances so we read the current DB state, not the identity map.
+    db.session.expire_all()
+    return (
+        db.session.query(ProductTable).filter_by(id=product_id).execution_options(include_deleted=include_deleted).one()
+    )
+
+
+def test_delete_category_with_products_warns_409(shop_with_config, test_client):
+    category = make_category(shop_id=shop_with_config)
+    make_product(shop_id=shop_with_config, category_id=category)
+    make_product(shop_id=shop_with_config, category_id=category, main_name="Second product")
+
+    resp = test_client.delete(f"/shops/{shop_with_config}/categories/{category}")
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["product_count"] == 2
+    assert "force=true" in detail["hint"]
+    assert "detach=true" in detail["hint"]
+
+    # Nothing was deleted
+    assert db.session.query(CategoryTable).filter_by(id=category).first() is not None
+
+
+def test_force_and_detach_are_mutually_exclusive(shop_with_config, test_client):
+    category = make_category(shop_id=shop_with_config)
+    resp = test_client.delete(f"/shops/{shop_with_config}/categories/{category}?force=true&detach=true")
+    assert resp.status_code == 422
+
+
+def test_empty_category_delete_is_soft(shop_with_config, test_client):
+    category = make_category(shop_id=shop_with_config)
+    resp = test_client.delete(f"/shops/{shop_with_config}/categories/{category}")
+    assert resp.status_code == 204
+
+    assert db.session.query(CategoryTable).filter_by(id=category).first() is None
+    row = db.session.query(CategoryTable).filter_by(id=category).execution_options(include_deleted=True).one()
+    assert row.deleted_at is not None
+
+
+def test_force_cascade_and_batch_restore(shop_with_config, test_client):
+    category = make_category(shop_id=shop_with_config)
+    product_1 = make_product(shop_id=shop_with_config, category_id=category)
+    product_2 = make_product(shop_id=shop_with_config, category_id=category, main_name="Second product")
+    trashed_before = make_product(shop_id=shop_with_config, category_id=category, main_name="Trashed earlier")
+    assert test_client.delete(f"/shops/{shop_with_config}/products/{trashed_before}").status_code == 204
+
+    resp = test_client.delete(f"/shops/{shop_with_config}/categories/{category}?force=true")
+    assert resp.status_code == 204
+
+    # Both live products were trashed under one batch id; each got a delete revision
+    row_1, row_2 = get_product(product_1), get_product(product_2)
+    assert row_1.deleted_at is not None and row_2.deleted_at is not None
+    assert row_1.deleted_batch_id == row_2.deleted_batch_id is not None
+    for product_id in (product_1, product_2):
+        last = (
+            db.session.query(RevisionTable)
+            .filter(RevisionTable.entity_type == "product", RevisionTable.entity_id == product_id)
+            .order_by(RevisionTable.revision_no.desc())
+            .first()
+        )
+        assert last.action == "delete"
+    # The previously trashed product is NOT part of the batch
+    assert get_product(trashed_before).deleted_batch_id is None
+
+    # Restore the category with its batch
+    resp = test_client.post(f"/shops/{shop_with_config}/categories/{category}/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    restored_kinds = [r["kind"] for r in report["resurrected"]]
+    assert restored_kinds.count("product") == 2
+
+    assert db.session.query(CategoryTable).filter_by(id=category).first() is not None
+    assert get_product(product_1).deleted_at is None
+    assert get_product(product_2).deleted_at is None
+    # The product trashed before the cascade stays in the trash
+    assert get_product(trashed_before).deleted_at is not None
+
+
+def test_detach_keeps_products_without_category(shop_with_config, test_client):
+    category = make_category(shop_id=shop_with_config, main_name="Doomed category")
+    product_id = make_product(shop_id=shop_with_config, category_id=category)
+
+    resp = test_client.delete(f"/shops/{shop_with_config}/categories/{category}?detach=true")
+    assert resp.status_code == 204
+
+    # Category trashed, product alive without a category
+    assert db.session.query(CategoryTable).filter_by(id=category).first() is None
+    row = get_product(product_id, include_deleted=False)
+    assert row.deleted_at is None
+    assert row.category_id is None
+
+    # The detach was recorded on the product with a pointer to the old category
+    last = (
+        db.session.query(RevisionTable)
+        .filter(RevisionTable.entity_type == "product", RevisionTable.entity_id == product_id)
+        .order_by(RevisionTable.revision_no.desc())
+        .first()
+    )
+    assert last.action == "update"
+    assert last.data["detached_from_category"]["id"] == str(category)
+    assert last.data["detached_from_category"]["name"] == "Doomed category"
+    assert last.data["category"] is None
+
+
+def test_restore_category_without_products_flag(shop_with_config, test_client):
+    category = make_category(shop_id=shop_with_config)
+    product_id = make_product(shop_id=shop_with_config, category_id=category)
+    assert test_client.delete(f"/shops/{shop_with_config}/categories/{category}?force=true").status_code == 204
+
+    resp = test_client.post(f"/shops/{shop_with_config}/categories/{category}/restore?restore_products=false")
+    assert resp.status_code == 200
+    assert db.session.query(CategoryTable).filter_by(id=category).first() is not None
+    assert get_product(product_id).deleted_at is not None

--- a/tests/unit_tests/api/test_category_delete_flow.py
+++ b/tests/unit_tests/api/test_category_delete_flow.py
@@ -1,9 +1,22 @@
-"""Tests for the category delete flow: 409 warning, force cascade, detach, and batch restore."""
+"""Tests for the category delete flow: 409 warning, force cascade, detach, batch restore
+and category revision restore."""
 
 from server.db import db
 from server.db.models import CategoryTable, ProductTable, RevisionTable
+from server.utils.json import json_dumps
 from tests.unit_tests.factories.categories import make_category
 from tests.unit_tests.factories.product import make_product
+
+
+def category_body(shop_id, main_name, color="#FFFFFF"):
+    return {
+        "shop_id": str(shop_id),
+        "color": color,
+        "translation": {"main_name": main_name, "main_description": f"{main_name} description"},
+        "main_image": "",
+        "alt1_image": "",
+        "alt2_image": "",
+    }
 
 
 def get_product(product_id, include_deleted=True):
@@ -119,6 +132,61 @@ def test_detach_keeps_products_without_category(shop_with_config, test_client):
     assert last.data["detached_from_category"]["id"] == str(category)
     assert last.data["detached_from_category"]["name"] == "Doomed category"
     assert last.data["category"] is None
+
+
+def test_restore_category_revision_undoes_rename(shop_with_config, test_client):
+    resp = test_client.post(
+        f"/shops/{shop_with_config}/categories/", content=json_dumps(category_body(shop_with_config, "Good name"))
+    )
+    assert resp.status_code == 201, resp.text
+    category_id = resp.json()["id"]
+
+    body = category_body(shop_with_config, "LLM made a mess", color="#000000")
+    resp = test_client.put(f"/shops/{shop_with_config}/categories/{category_id}", content=json_dumps(body))
+    assert resp.status_code == 201, resp.text
+
+    resp = test_client.post(f"/shops/{shop_with_config}/categories/{category_id}/revisions/1/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["restored"] is True
+    assert report["entity_type"] == "category"
+
+    db.session.expire_all()
+    row = db.session.query(CategoryTable).filter_by(id=category_id).one()
+    assert row.translation.main_name == "Good name"
+    assert row.color == "#FFFFFF"
+    last = (
+        db.session.query(RevisionTable)
+        .filter(RevisionTable.entity_type == "category", RevisionTable.entity_id == category_id)
+        .order_by(RevisionTable.revision_no.desc())
+        .first()
+    )
+    assert last.action == "restore"
+
+
+def test_restore_purged_category_revision_requires_force(shop_with_config, test_client):
+    resp = test_client.post(
+        f"/shops/{shop_with_config}/categories/", content=json_dumps(category_body(shop_with_config, "Purged"))
+    )
+    category_id = resp.json()["id"]
+
+    # Hard-purge the row directly (the API only ever trashes categories)
+    row = db.session.query(CategoryTable).filter_by(id=category_id).one()
+    if row.translation:
+        db.session.delete(row.translation)
+    db.session.delete(row)
+    db.session.commit()
+
+    assert (
+        test_client.post(f"/shops/{shop_with_config}/categories/{category_id}/revisions/1/restore").status_code == 410
+    )
+
+    resp = test_client.post(f"/shops/{shop_with_config}/categories/{category_id}/revisions/1/restore?force=true")
+    assert resp.status_code == 200, resp.json()
+    assert any("recreated" in w for w in resp.json()["warnings"])
+    db.session.expire_all()
+    row = db.session.query(CategoryTable).filter_by(id=category_id).one()
+    assert row.translation.main_name == "Purged"
 
 
 def test_restore_category_without_products_flag(shop_with_config, test_client):

--- a/tests/unit_tests/api/test_image_restore_repro.py
+++ b/tests/unit_tests/api/test_image_restore_repro.py
@@ -1,0 +1,57 @@
+"""Regression: deleting images via update (the shop UI sends image_X: ''),
+then restoring the with-images revision must bring the images back — both on
+the product row and in the new restore revision's snapshot."""
+
+from uuid import UUID
+
+from server.db import db
+from server.db.models import ProductTable, RevisionTable
+from server.utils.json import json_dumps
+from tests.unit_tests.api.test_product_revisions import product_body, product_category_id
+
+
+def _revisions(product_id):
+    return (
+        db.session.query(RevisionTable)
+        .filter(RevisionTable.entity_type == "product", RevisionTable.entity_id == product_id)
+        .order_by(RevisionTable.revision_no)
+        .all()
+    )
+
+
+def test_restore_brings_deleted_images_back(shop_with_config, product, test_client):
+    category = product_category_id(product)
+
+    body_with_images = product_body(shop_with_config, category, main_name="Shirt", price=10.0)
+    body_with_images["image_1"] = "shop-prefix/foo.png"
+    body_with_images["image_2"] = "shop-prefix/bar.png"
+    resp = test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body_with_images))
+    assert resp.status_code == 201, resp.json()
+
+    # Removed image slots arrive as empty strings from the shop UI
+    body_removed = product_body(shop_with_config, category, main_name="Shirt", price=10.0)
+    resp = test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body_removed))
+    assert resp.status_code == 201, resp.json()
+
+    rows = _revisions(product)
+    assert [r.action for r in rows] == ["baseline", "update", "update"]
+    with_images_no = rows[1].revision_no
+    assert rows[1].data["product"]["image_1"] == "shop-prefix/foo.png"
+    assert not rows[2].data["product"]["image_1"]
+
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/{with_images_no}/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["restored"] is True
+    assert report["skipped_fields"] == []
+
+    db.session.expire_all()
+    row = db.session.query(ProductTable).filter_by(id=UUID(str(product))).one()
+    assert row.image_1 == "shop-prefix/foo.png"
+    assert row.image_2 == "shop-prefix/bar.png"
+
+    rows = _revisions(product)
+    assert rows[-1].action == "restore"
+    restore_snapshot = rows[-1].data["product"]
+    assert restore_snapshot["image_1"] == "shop-prefix/foo.png"
+    assert restore_snapshot["image_2"] == "shop-prefix/bar.png"

--- a/tests/unit_tests/api/test_product_revisions.py
+++ b/tests/unit_tests/api/test_product_revisions.py
@@ -84,14 +84,16 @@ def test_updates_append_revisions_and_are_listable(shop_with_config, product, te
     resp = test_client.get(f"/shops/{shop_with_config}/products/{product}/revisions")
     assert resp.status_code == 200
     revisions = resp.json()
-    assert len(revisions) == 2
+    # The factory product predates revision tracking, so the first edit also captures a baseline
+    assert len(revisions) == 3
     # Newest first
-    assert revisions[0]["revision_no"] == 2
+    assert revisions[0]["revision_no"] == 3
     assert revisions[0]["action"] == "update"
     assert revisions[0]["name"] == "Name v1"
     assert revisions[1]["name"] == "Name v0"
+    assert revisions[2]["action"] == "baseline"
 
-    detail = test_client.get(f"/shops/{shop_with_config}/products/{product}/revisions/1").json()
+    detail = test_client.get(f"/shops/{shop_with_config}/products/{product}/revisions/2").json()
     assert detail["data"]["product"]["price"] == 2.0
     assert detail["data"]["translation"]["main_name"] == "Name v0"
     assert detail["data"]["category"] is not None
@@ -114,7 +116,10 @@ def test_tag_and_attribute_mutations_record_revisions(shop_with_config, product,
     assert resp.status_code == 204, resp.text
 
     rows = revision_rows(product)
-    assert [r.action for r in rows] == ["update", "update"]
+    assert [r.action for r in rows] == ["baseline", "update", "update"]
+    # The baseline holds the state before the first mutation: no tags, no attribute values
+    assert rows[0].data["tags"] == []
+    assert rows[0].data["attribute_values"] == []
     latest = rows[-1].data
     assert latest["tags"] == [{"id": str(tag_id), "name": "revtag"}]
     assert latest["attribute_values"] == [
@@ -138,12 +143,13 @@ def test_restore_previous_revision(shop_with_config, product, test_client):
         test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body_v2)).status_code == 201
     )
 
-    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/1/restore")
+    # Revision 1 is the baseline of the pre-existing product; revision 2 is "Original name"
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/2/restore")
     assert resp.status_code == 200, resp.json()
     report = resp.json()
     assert report["restored"] is True
-    assert report["restored_from_revision_no"] == 1
-    assert report["new_revision_no"] == 3
+    assert report["restored_from_revision_no"] == 2
+    assert report["new_revision_no"] == 4
     assert report["unresolved"] == []
     assert report["skipped_fields"] == []
 

--- a/tests/unit_tests/api/test_product_revisions.py
+++ b/tests/unit_tests/api/test_product_revisions.py
@@ -1,0 +1,330 @@
+"""Tests for product revision snapshots and restores."""
+
+from http import HTTPStatus
+from uuid import UUID, uuid4
+
+import pytest
+
+from server.db import db
+from server.db.models import (
+    AttributeOptionTable,
+    AttributeTable,
+    CategoryTable,
+    ProductAttributeValueTable,
+    ProductTable,
+    ProductToTagTable,
+    RevisionTable,
+    TagTable,
+)
+from server.utils.json import json_dumps
+from tests.unit_tests.factories.attribute import make_attribute, make_option
+from tests.unit_tests.factories.categories import make_category
+from tests.unit_tests.factories.product import make_product
+from tests.unit_tests.factories.tag import make_tag
+
+
+def product_body(shop_id, category_id, main_name="Revision Test Product", price=1.0):
+    return {
+        "shop_id": str(shop_id),
+        "category_id": str(category_id),
+        "price": price,
+        "tax_category": "vat_zero",
+        "max_one": False,
+        "shippable": True,
+        "featured": False,
+        "new_product": False,
+        "translation": {
+            "main_name": main_name,
+            "main_description": "Description",
+            "main_description_short": "Short description",
+        },
+        "image_1": "",
+        "image_2": "",
+        "image_3": "",
+        "image_4": "",
+        "image_5": "",
+        "image_6": "",
+    }
+
+
+def product_category_id(product_id):
+    return db.session.query(ProductTable).filter_by(id=product_id).one().category_id
+
+
+def revision_rows(product_id):
+    return (
+        db.session.query(RevisionTable)
+        .filter(RevisionTable.entity_type == "product", RevisionTable.entity_id == product_id)
+        .order_by(RevisionTable.revision_no)
+        .all()
+    )
+
+
+def test_create_records_revision(shop, category, test_client):
+    response = test_client.post(f"/shops/{shop}/products/", content=json_dumps(product_body(shop, category)))
+    assert response.status_code == HTTPStatus.CREATED, response.json()
+    product_id = UUID(response.json()["id"])
+
+    rows = revision_rows(product_id)
+    assert len(rows) == 1
+    assert rows[0].revision_no == 1
+    assert rows[0].action == "create"
+    assert rows[0].created_by == "cognito:5678"
+    assert rows[0].source == "rest"
+    assert rows[0].data["translation"]["main_name"] == "Revision Test Product"
+
+
+def test_updates_append_revisions_and_are_listable(shop_with_config, product, test_client):
+    category = product_category_id(product)
+    for i, price in enumerate([2.0, 3.0]):
+        body = product_body(shop_with_config, category, main_name=f"Name v{i}", price=price)
+        resp = test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body))
+        assert resp.status_code == 201, resp.json()
+
+    resp = test_client.get(f"/shops/{shop_with_config}/products/{product}/revisions")
+    assert resp.status_code == 200
+    revisions = resp.json()
+    assert len(revisions) == 2
+    # Newest first
+    assert revisions[0]["revision_no"] == 2
+    assert revisions[0]["action"] == "update"
+    assert revisions[0]["name"] == "Name v1"
+    assert revisions[1]["name"] == "Name v0"
+
+    detail = test_client.get(f"/shops/{shop_with_config}/products/{product}/revisions/1").json()
+    assert detail["data"]["product"]["price"] == 2.0
+    assert detail["data"]["translation"]["main_name"] == "Name v0"
+    assert detail["data"]["category"] is not None
+
+
+def test_tag_and_attribute_mutations_record_revisions(shop_with_config, product, test_client):
+    tag_id = make_tag(shop_id=shop_with_config, main_name="revtag")
+    resp = test_client.post(
+        f"/shops/{shop_with_config}/products-to-tags/",
+        json={"product_id": str(product), "tag_id": str(tag_id), "shop_id": str(shop_with_config)},
+    )
+    assert resp.status_code == 204, resp.text
+
+    attr_id = make_attribute(shop_with_config, name="size")
+    opt_id = make_option(attr_id, "XL")
+    resp = test_client.put(
+        f"/shops/{shop_with_config}/product-attribute-values/{product}",
+        json={"option_ids": [str(opt_id)]},
+    )
+    assert resp.status_code == 204, resp.text
+
+    rows = revision_rows(product)
+    assert [r.action for r in rows] == ["update", "update"]
+    latest = rows[-1].data
+    assert latest["tags"] == [{"id": str(tag_id), "name": "revtag"}]
+    assert latest["attribute_values"] == [
+        {
+            "attribute_id": str(attr_id),
+            "attribute_name": "size",
+            "option_id": str(opt_id),
+            "option_value_key": "XL",
+        }
+    ]
+
+
+def test_restore_previous_revision(shop_with_config, product, test_client):
+    category = product_category_id(product)
+    body_v1 = product_body(shop_with_config, category, main_name="Original name", price=10.0)
+    body_v2 = product_body(shop_with_config, category, main_name="LLM made a mess", price=999.0)
+    assert (
+        test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body_v1)).status_code == 201
+    )
+    assert (
+        test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body_v2)).status_code == 201
+    )
+
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/1/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["restored"] is True
+    assert report["restored_from_revision_no"] == 1
+    assert report["new_revision_no"] == 3
+    assert report["unresolved"] == []
+    assert report["skipped_fields"] == []
+
+    product_resp = test_client.get(f"/shops/{shop_with_config}/products/{product}").json()
+    assert product_resp["translation"]["main_name"] == "Original name"
+    assert float(product_resp["price"]) == 10.0
+
+    rows = revision_rows(product)
+    assert rows[-1].action == "restore"
+
+
+def test_restore_resurrects_soft_deleted_references(shop_with_config, product, test_client):
+    category = product_category_id(product)
+    # Build the aggregate: tag + attribute value; the PAV PUT records the snapshot
+    tag_id = make_tag(shop_id=shop_with_config, main_name="resurrect-me")
+    test_client.post(
+        f"/shops/{shop_with_config}/products-to-tags/",
+        json={"product_id": str(product), "tag_id": str(tag_id), "shop_id": str(shop_with_config)},
+    )
+    attr_id = make_attribute(shop_with_config, name="material")
+    opt_id = make_option(attr_id, "WOOL")
+    test_client.put(
+        f"/shops/{shop_with_config}/product-attribute-values/{product}",
+        json={"option_ids": [str(opt_id)]},
+    )
+    snapshot_revision_no = revision_rows(product)[-1].revision_no
+
+    # Trash the tag and the attribute, then trash the category with the product (cascade)
+    assert test_client.delete(f"/shops/{shop_with_config}/tags/{tag_id}").status_code == 204
+    assert test_client.delete(f"/shops/{shop_with_config}/attributes/{attr_id}").status_code == 204
+    assert test_client.delete(f"/shops/{shop_with_config}/categories/{category}?force=true").status_code == 204
+
+    # Restore the snapshot revision — everything should come back
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/{snapshot_revision_no}/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["restored"] is True
+    assert report["unresolved"] == []
+    resurrected_kinds = {r["kind"] for r in report["resurrected"]}
+    assert {"product", "category", "tag", "attribute"} <= resurrected_kinds
+
+    assert db.session.query(ProductTable).filter_by(id=product).one().deleted_at is None
+    assert db.session.query(CategoryTable).filter_by(id=category).one().deleted_at is None
+    assert db.session.query(TagTable).filter_by(id=tag_id).one().deleted_at is None
+    assert db.session.query(AttributeTable).filter_by(id=attr_id).one().deleted_at is None
+    pavs = db.session.query(ProductAttributeValueTable).filter_by(product_id=product).all()
+    assert [(p.attribute_id, p.option_id) for p in pavs] == [(attr_id, opt_id)]
+
+
+def test_restore_matches_purged_tag_by_name(shop_with_config, product, test_client):
+    tag_id = make_tag(shop_id=shop_with_config, main_name="stable-name")
+    test_client.post(
+        f"/shops/{shop_with_config}/products-to-tags/",
+        json={"product_id": str(product), "tag_id": str(tag_id), "shop_id": str(shop_with_config)},
+    )
+    snapshot_revision_no = revision_rows(product)[-1].revision_no
+
+    # Hard-purge the tag (links + row), then recreate it under a NEW id with the same name
+    db.session.query(ProductToTagTable).filter_by(tag_id=tag_id).delete()
+    tag_row = db.session.query(TagTable).filter_by(id=tag_id).one()
+    if tag_row.translation:
+        db.session.delete(tag_row.translation)
+    db.session.delete(tag_row)
+    db.session.commit()
+    new_tag_id = make_tag(shop_id=shop_with_config, main_name="stable-name")
+
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/{snapshot_revision_no}/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["unresolved"] == []
+
+    links = db.session.query(ProductToTagTable).filter_by(product_id=product).all()
+    assert [link.tag_id for link in links] == [new_tag_id]
+
+
+def test_restore_reports_unresolved_when_attribute_purged(shop_with_config, product, test_client):
+    attr_id = make_attribute(shop_with_config, name="doomed")
+    opt_id = make_option(attr_id, "GONE")
+    test_client.put(
+        f"/shops/{shop_with_config}/product-attribute-values/{product}",
+        json={"option_ids": [str(opt_id)]},
+    )
+    snapshot_revision_no = revision_rows(product)[-1].revision_no
+
+    # Hard-purge PAVs, option, translation and attribute
+    db.session.query(ProductAttributeValueTable).filter_by(attribute_id=attr_id).delete()
+    db.session.query(AttributeOptionTable).filter_by(attribute_id=attr_id).delete()
+    attribute = db.session.query(AttributeTable).filter_by(id=attr_id).one()
+    if attribute.translation:
+        db.session.delete(attribute.translation)
+    db.session.delete(attribute)
+    db.session.commit()
+
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/{snapshot_revision_no}/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["restored"] is True
+    assert any(u["kind"] == "attribute" and u["name"] == "doomed" for u in report["unresolved"])
+    assert db.session.query(ProductAttributeValueTable).filter_by(product_id=product).count() == 0
+
+
+def test_double_restore_is_idempotent(shop_with_config, product, test_client):
+    tag_id = make_tag(shop_id=shop_with_config, main_name="twice")
+    test_client.post(
+        f"/shops/{shop_with_config}/products-to-tags/",
+        json={"product_id": str(product), "tag_id": str(tag_id), "shop_id": str(shop_with_config)},
+    )
+    attr_id = make_attribute(shop_with_config, name="width")
+    opt_id = make_option(attr_id, "S")
+    test_client.put(
+        f"/shops/{shop_with_config}/product-attribute-values/{product}",
+        json={"option_ids": [str(opt_id)]},
+    )
+    snapshot_revision_no = revision_rows(product)[-1].revision_no
+
+    for _ in range(2):
+        resp = test_client.post(
+            f"/shops/{shop_with_config}/products/{product}/revisions/{snapshot_revision_no}/restore"
+        )
+        assert resp.status_code == 200, resp.json()
+
+    # No duplicated links or attribute values
+    assert db.session.query(ProductToTagTable).filter_by(product_id=product).count() == 1
+    assert db.session.query(ProductAttributeValueTable).filter_by(product_id=product).count() == 1
+
+
+def test_model_churn_round_trip(shop_with_config, product, test_client):
+    category = product_category_id(product)
+    """Snapshot → restore must reproduce every mapped column (guards future model churn)."""
+    from sqlalchemy.inspection import inspect as sa_inspect
+
+    body = product_body(shop_with_config, category, main_name="Churn guard", price=42.5)
+    assert test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body)).status_code == 201
+
+    row = db.session.query(ProductTable).filter_by(id=product).one()
+    ignored = {"deleted_at", "deleted_batch_id", "created_at", "modified_at"}
+    before = {key: getattr(row, key) for key in sa_inspect(ProductTable).columns.keys() if key not in ignored}
+
+    latest_no = revision_rows(product)[-1].revision_no
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/{latest_no}/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["skipped_fields"] == [], "snapshot contains fields restore can no longer apply"
+    assert report["unresolved"] == []
+
+    row = db.session.query(ProductTable).filter_by(id=product).one()
+    after = {key: getattr(row, key) for key in before}
+    assert before == after
+
+
+def test_unknown_snapshot_keys_are_skipped_not_fatal(shop_with_config, product, test_client):
+    category = product_category_id(product)
+    body = product_body(shop_with_config, category)
+    assert test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body)).status_code == 201
+
+    # Simulate a snapshot written by a future model version with an extra column
+    revision = revision_rows(product)[-1]
+    data = dict(revision.data)
+    data["product"] = {**data["product"], "column_from_the_future": "value"}
+    revision.data = data
+    db.session.commit()
+
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/{revision.revision_no}/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["restored"] is True
+    assert "product.column_from_the_future" in report["skipped_fields"]
+
+
+def test_restore_missing_revision_404(shop_with_config, product, test_client):
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/99/restore")
+    assert resp.status_code == 404
+
+
+def test_restore_unknown_schema_version_422(shop_with_config, product, test_client):
+    category = product_category_id(product)
+    body = product_body(shop_with_config, category)
+    assert test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body)).status_code == 201
+    revision = revision_rows(product)[-1]
+    revision.schema_version = 0  # no up-converter registered for 0
+    db.session.commit()
+
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/{revision.revision_no}/restore")
+    assert resp.status_code == 422

--- a/tests/unit_tests/api/test_products.py
+++ b/tests/unit_tests/api/test_products.py
@@ -86,7 +86,7 @@ def test_products_delete(shop_with_config, product, test_client):
 
 
 def test_products_delete_cascade_cleanup(shop_with_config, product, category, test_client):
-    """Test that deleting a product also deletes its attribute values and tag associations, but NOT the tags/options."""
+    """Test that purging (force=true) a product also deletes its attribute values, but NOT the tags/options."""
     from server.db import db
     from server.db.models import AttributeOptionTable, AttributeTable, ProductAttributeValueTable
     from tests.unit_tests.factories.attribute import make_attribute, make_option, make_pav
@@ -103,12 +103,13 @@ def test_products_delete_cascade_cleanup(shop_with_config, product, category, te
     # Verify setup
     assert db.session.get(ProductAttributeValueTable, pav_id) is not None
 
-    # 2. Perform Delete
-    response = test_client.delete(f"/shops/{shop_with_config}/products/{product}")
+    # 2. Perform hard purge (a plain delete only moves to trash and keeps the PAVs)
+    response = test_client.delete(f"/shops/{shop_with_config}/products/{product}?force=true")
     assert response.status_code == 204
 
     # 3. Verify Cascade Deletion
     # These should be gone
+    assert db.session.get(ProductTable, product) is None
     assert db.session.get(ProductAttributeValueTable, pav_id) is None
 
     # These should still exist

--- a/tests/unit_tests/api/test_restore_noop.py
+++ b/tests/unit_tests/api/test_restore_noop.py
@@ -1,0 +1,82 @@
+"""A restore whose snapshot matches the current state must not record a new
+revision — it returns a warning instead, so the history doesn't fill up with no-ops."""
+
+from uuid import UUID
+
+from server.utils.json import json_dumps
+from tests.unit_tests.api.test_category_delete_flow import category_body
+from tests.unit_tests.api.test_product_revisions import product_body, product_category_id, revision_rows
+from tests.unit_tests.api.test_shop_revision_feed import entity_revisions, tag_body
+
+
+def assert_noop(resp, entity_type, entity_id, revision_count_before):
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["restored"] is True
+    assert report["new_revision_no"] is None
+    assert any("no-op" in warning for warning in report["warnings"])
+    assert len(entity_revisions(entity_type, entity_id)) == revision_count_before
+
+
+def test_product_noop_restore_records_no_revision(shop_with_config, product, test_client):
+    category = product_category_id(product)
+    body = product_body(shop_with_config, category, main_name="Current state", price=7.5)
+    assert test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body)).status_code == 201
+
+    rows = revision_rows(product)  # baseline + update
+    latest_no = rows[-1].revision_no
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/{latest_no}/restore")
+    assert_noop(resp, "product", product, len(rows))
+
+    # A revision that differs still records a restore revision
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/1/restore")
+    assert resp.status_code == 200
+    assert resp.json()["new_revision_no"] is not None
+
+
+def test_tag_noop_restore_records_no_revision(shop, test_client):
+    resp = test_client.post(f"/shops/{shop}/tags/", content=json_dumps(tag_body(shop, "stable")))
+    tag_id = UUID(resp.json()["id"])
+
+    resp = test_client.post(f"/shops/{shop}/tags/{tag_id}/revisions/1/restore")
+    assert_noop(resp, "tag", tag_id, 1)
+
+
+def test_attribute_noop_restore_records_no_revision(shop, test_client):
+    resp = test_client.post(f"/shops/{shop}/attributes/", json={"name": "steady"})
+    attr_id = UUID(resp.json()["id"])
+    assert (
+        test_client.post(
+            f"/shops/{shop}/attribute-options/", json={"attribute_id": str(attr_id), "value_key": "ON"}
+        ).status_code
+        == 201
+    )
+
+    latest_no = entity_revisions("attribute", attr_id)[-1].revision_no
+    resp = test_client.post(f"/shops/{shop}/attributes/{attr_id}/revisions/{latest_no}/restore")
+    assert_noop(resp, "attribute", attr_id, 2)
+
+
+def test_category_noop_restore_records_no_revision(shop_with_config, test_client):
+    resp = test_client.post(
+        f"/shops/{shop_with_config}/categories/", content=json_dumps(category_body(shop_with_config, "Steady"))
+    )
+    category_id = UUID(resp.json()["id"])
+
+    resp = test_client.post(f"/shops/{shop_with_config}/categories/{category_id}/revisions/1/restore")
+    assert_noop(resp, "category", category_id, 1)
+
+
+def test_trashed_entity_restore_is_never_a_noop(shop_with_config, test_client):
+    """Resurrection counts as a change even when the content matches the snapshot."""
+    resp = test_client.post(
+        f"/shops/{shop_with_config}/tags/", content=json_dumps(tag_body(shop_with_config, "trash-me"))
+    )
+    tag_id = UUID(resp.json()["id"])
+    assert test_client.delete(f"/shops/{shop_with_config}/tags/{tag_id}").status_code == 204
+
+    resp = test_client.post(f"/shops/{shop_with_config}/tags/{tag_id}/revisions/1/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert [r["kind"] for r in report["resurrected"]] == ["tag"]
+    assert report["new_revision_no"] is not None

--- a/tests/unit_tests/api/test_revision_baseline.py
+++ b/tests/unit_tests/api/test_revision_baseline.py
@@ -1,0 +1,131 @@
+"""Tests for baseline revisions.
+
+Entities created before revision tracking shipped have no revision rows. Without a
+baseline, their first edit would record the *post*-edit state as revision 1 and the
+old data would be lost. The first mutation therefore captures the pre-mutation state
+as a ``baseline`` revision, making that first edit undoable.
+"""
+
+from server.db import db
+from server.db.models import ProductTable, RevisionTable
+from server.utils.json import json_dumps
+from tests.unit_tests.api.test_product_revisions import product_body, product_category_id, revision_rows
+from tests.unit_tests.factories.categories import make_category
+from tests.unit_tests.factories.product import make_product
+from tests.unit_tests.factories.tag import make_tag
+
+
+def test_first_edit_captures_baseline_and_is_undoable(shop_with_config, product, test_client):
+    category = product_category_id(product)
+    body = test_client.put(
+        f"/shops/{shop_with_config}/products/{product}",
+        content=json_dumps(product_body(shop_with_config, category, main_name="LLM made a mess", price=999.0)),
+    )
+    assert body.status_code == 201, body.json()
+
+    rows = revision_rows(product)
+    assert [r.action for r in rows] == ["baseline", "update"]
+    baseline = rows[0]
+    # The baseline holds the pre-edit data, unattributed: it was authored before tracking existed
+    assert baseline.data["translation"]["main_name"] == "Product for Testing"
+    assert float(baseline.data["product"]["price"]) == 1.0
+    assert baseline.created_by is None
+
+    # Undo the very first edit by restoring the baseline
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/revisions/1/restore")
+    assert resp.status_code == 200, resp.json()
+    product_resp = test_client.get(f"/shops/{shop_with_config}/products/{product}").json()
+    assert product_resp["translation"]["main_name"] == "Product for Testing"
+    assert float(product_resp["price"]) == 1.0
+
+
+def test_baseline_is_recorded_only_once(shop_with_config, product, test_client):
+    category = product_category_id(product)
+    for i in range(3):
+        resp = test_client.put(
+            f"/shops/{shop_with_config}/products/{product}",
+            content=json_dumps(product_body(shop_with_config, category, main_name=f"Edit {i}")),
+        )
+        assert resp.status_code == 201, resp.json()
+
+    rows = revision_rows(product)
+    assert [r.action for r in rows] == ["baseline", "update", "update", "update"]
+
+
+def test_products_created_via_api_get_no_baseline(shop, category, test_client):
+    resp = test_client.post(
+        f"/shops/{shop}/products/", content=json_dumps(product_body(shop, category, main_name="Fresh product"))
+    )
+    assert resp.status_code == 201, resp.json()
+    product_id = resp.json()["id"]
+
+    resp = test_client.put(
+        f"/shops/{shop}/products/{product_id}",
+        content=json_dumps(product_body(shop, category, main_name="Fresh product v2")),
+    )
+    assert resp.status_code == 201, resp.json()
+
+    rows = revision_rows(product_id)
+    assert [r.action for r in rows] == ["create", "update"]
+
+
+def test_tag_link_baseline_excludes_pending_link(shop_with_config, product, test_client):
+    """The baseline reflects the state before the mutation that triggered it."""
+    tag_id = make_tag(shop_id=shop_with_config, main_name="first-tag")
+    resp = test_client.post(
+        f"/shops/{shop_with_config}/products-to-tags/",
+        json={"product_id": str(product), "tag_id": str(tag_id), "shop_id": str(shop_with_config)},
+    )
+    assert resp.status_code == 204, resp.text
+
+    rows = revision_rows(product)
+    assert [r.action for r in rows] == ["baseline", "update"]
+    assert rows[0].data["tags"] == []
+    assert rows[1].data["tags"] == [{"id": str(tag_id), "name": "first-tag"}]
+
+
+def test_trash_needs_no_baseline(shop_with_config, product, test_client):
+    """A delete revision already snapshots the pre-delete state; no baseline is added."""
+    assert test_client.delete(f"/shops/{shop_with_config}/products/{product}").status_code == 204
+
+    rows = revision_rows(product)
+    assert [r.action for r in rows] == ["delete"]
+    assert rows[0].data["translation"]["main_name"] == "Product for Testing"
+
+
+def test_category_first_edit_captures_baseline(shop_with_config, test_client):
+    category = make_category(shop_id=shop_with_config, main_name="Legacy category")
+    body = {
+        "shop_id": str(shop_with_config),
+        "color": "#FFFFFF",
+        "translation": {"main_name": "Renamed category", "main_description": "Updated"},
+        "main_image": "",
+        "alt1_image": "",
+        "alt2_image": "",
+    }
+    resp = test_client.put(f"/shops/{shop_with_config}/categories/{category}", content=json_dumps(body))
+    assert resp.status_code == 201, resp.json()
+
+    rows = (
+        db.session.query(RevisionTable)
+        .filter(RevisionTable.entity_type == "category", RevisionTable.entity_id == category)
+        .order_by(RevisionTable.revision_no)
+        .all()
+    )
+    assert [r.action for r in rows] == ["baseline", "update"]
+    assert rows[0].data["translation"]["main_name"] == "Legacy category"
+    assert rows[1].data["translation"]["main_name"] == "Renamed category"
+
+
+def test_detach_captures_product_baseline_with_old_category(shop_with_config, test_client):
+    category = make_category(shop_id=shop_with_config, main_name="Detach source")
+    product_id = make_product(shop_id=shop_with_config, category_id=category)
+
+    resp = test_client.delete(f"/shops/{shop_with_config}/categories/{category}?detach=true")
+    assert resp.status_code == 204
+
+    rows = revision_rows(product_id)
+    assert [r.action for r in rows] == ["baseline", "update"]
+    # Baseline preserves the product's pre-detach category; the update shows it cleared
+    assert rows[0].data["category"]["id"] == str(category)
+    assert rows[1].data["category"] is None

--- a/tests/unit_tests/api/test_revision_retention.py
+++ b/tests/unit_tests/api/test_revision_retention.py
@@ -1,0 +1,38 @@
+"""Tests for revision retention pruning and its configuration."""
+
+from server.db import db
+from server.db.models import RevisionTable
+from server.settings import app_settings
+from server.utils.json import json_dumps
+from tests.unit_tests.api.test_product_revisions import product_body, product_category_id, revision_rows
+
+
+def _update_n_times(test_client, shop_id, product_id, category_id, n):
+    for i in range(n):
+        body = product_body(shop_id, category_id, main_name=f"Retention v{i}", price=float(i + 1))
+        resp = test_client.put(f"/shops/{shop_id}/products/{product_id}", content=json_dumps(body))
+        assert resp.status_code == 201, resp.json()
+
+
+def test_retention_prunes_old_revisions(shop_with_config, product, test_client, monkeypatch):
+    monkeypatch.setattr(app_settings, "REVISION_RETENTION", 12)
+    category = product_category_id(product)
+
+    _update_n_times(test_client, shop_with_config, product, category, 15)
+
+    rows = revision_rows(product)
+    assert len(rows) == 12
+    # The highest, contiguous revision numbers survive
+    assert [r.revision_no for r in rows] == list(range(4, 16))
+    assert rows[-1].data["translation"]["main_name"] == "Retention v14"
+
+
+def test_retention_never_drops_below_minimum(shop_with_config, product, test_client, monkeypatch):
+    monkeypatch.setattr(app_settings, "REVISION_RETENTION", 3)  # below the floor of 10
+    category = product_category_id(product)
+
+    _update_n_times(test_client, shop_with_config, product, category, 12)
+
+    rows = revision_rows(product)
+    assert len(rows) == 10
+    assert [r.revision_no for r in rows] == list(range(3, 13))

--- a/tests/unit_tests/api/test_revision_retention.py
+++ b/tests/unit_tests/api/test_revision_retention.py
@@ -20,10 +20,11 @@ def test_retention_prunes_old_revisions(shop_with_config, product, test_client, 
 
     _update_n_times(test_client, shop_with_config, product, category, 15)
 
+    # 16 revisions were written (baseline + 15 updates); the newest 12 survive
     rows = revision_rows(product)
     assert len(rows) == 12
     # The highest, contiguous revision numbers survive
-    assert [r.revision_no for r in rows] == list(range(4, 16))
+    assert [r.revision_no for r in rows] == list(range(5, 17))
     assert rows[-1].data["translation"]["main_name"] == "Retention v14"
 
 
@@ -33,6 +34,7 @@ def test_retention_never_drops_below_minimum(shop_with_config, product, test_cli
 
     _update_n_times(test_client, shop_with_config, product, category, 12)
 
+    # 13 revisions were written (baseline + 12 updates); the floor keeps the newest 10
     rows = revision_rows(product)
     assert len(rows) == 10
-    assert [r.revision_no for r in rows] == list(range(3, 13))
+    assert [r.revision_no for r in rows] == list(range(4, 14))

--- a/tests/unit_tests/api/test_shop_revision_feed.py
+++ b/tests/unit_tests/api/test_shop_revision_feed.py
@@ -1,0 +1,200 @@
+"""Tests for the shop-wide revision feed and tag/attribute entity revisions."""
+
+from server.db import db
+from server.db.models import RevisionTable
+from server.utils.json import json_dumps
+from tests.unit_tests.api.test_product_revisions import product_body, product_category_id
+from tests.unit_tests.factories.attribute import make_attribute, make_option
+from tests.unit_tests.factories.tag import make_tag
+
+
+def entity_revisions(entity_type, entity_id):
+    return (
+        db.session.query(RevisionTable)
+        .filter(RevisionTable.entity_type == entity_type, RevisionTable.entity_id == entity_id)
+        .order_by(RevisionTable.revision_no)
+        .all()
+    )
+
+
+def tag_body(shop_id, name):
+    return {"shop_id": str(shop_id), "name": name, "translation": {"main_name": name}}
+
+
+# --- Tag entity revisions ---
+
+
+def test_tag_lifecycle_records_revisions(shop, test_client):
+    resp = test_client.post(f"/shops/{shop}/tags/", content=json_dumps(tag_body(shop, "summer")))
+    assert resp.status_code == 201, resp.text
+    tag_id = resp.json()["id"]
+
+    resp = test_client.put(f"/shops/{shop}/tags/{tag_id}", content=json_dumps(tag_body(shop, "winter")))
+    assert resp.status_code == 201, resp.text
+
+    assert test_client.delete(f"/shops/{shop}/tags/{tag_id}").status_code == 204
+
+    rows = entity_revisions("tag", tag_id)
+    assert [r.action for r in rows] == ["create", "update", "delete"]
+    assert rows[0].data["tag"]["name"] == "summer"
+    assert rows[1].data["tag"]["name"] == "winter"
+    assert rows[1].data["translation"]["main_name"] == "winter"
+    # The delete revision snapshots the pre-delete state, so a rename can be recovered from it
+    assert rows[2].data["tag"]["name"] == "winter"
+    assert rows[0].created_by == "cognito:5678"
+
+
+def test_legacy_tag_rename_gets_baseline(shop_with_config, test_client):
+    tag_id = make_tag(shop_id=shop_with_config, main_name="old-name")
+
+    body = {"shop_id": str(shop_with_config), "name": "new-name", "translation": {"main_name": "new-name"}}
+    resp = test_client.put(f"/shops/{shop_with_config}/tags/{tag_id}", content=json_dumps(body))
+    assert resp.status_code == 201, resp.text
+
+    rows = entity_revisions("tag", tag_id)
+    assert [r.action for r in rows] == ["baseline", "update"]
+    assert rows[0].data["translation"]["main_name"] == "old-name"
+    assert rows[0].created_by is None
+
+
+# --- Attribute (incl. options) entity revisions ---
+
+
+def test_attribute_and_option_mutations_record_revisions(shop, test_client):
+    resp = test_client.post(f"/shops/{shop}/attributes/", json={"name": "color", "unit": None})
+    assert resp.status_code == 201, resp.text
+    attr_id = resp.json()["id"]
+
+    resp = test_client.post(f"/shops/{shop}/attribute-options/", json={"attribute_id": attr_id, "value_key": "RED"})
+    assert resp.status_code == 201, resp.text
+    option_id = resp.json()["id"]
+
+    resp = test_client.put(f"/shops/{shop}/attribute-options/{option_id}", json={"value_key": "CRIMSON"})
+    assert resp.status_code == 200, resp.text
+
+    assert test_client.delete(f"/shops/{shop}/attribute-options/{option_id}").status_code == 204
+
+    rows = entity_revisions("attribute", attr_id)
+    assert [r.action for r in rows] == ["create", "update", "update", "update"]
+    assert rows[0].data["attribute"]["name"] == "color"
+    assert rows[0].data["options"] == []
+    assert rows[1].data["options"] == [{"id": option_id, "value_key": "RED"}]
+    assert rows[2].data["options"] == [{"id": option_id, "value_key": "CRIMSON"}]
+    # Soft-deleted options disappear from the snapshot
+    assert rows[3].data["options"] == []
+
+
+def test_legacy_attribute_gets_baseline_with_existing_options(shop_with_config, test_client):
+    attr_id = make_attribute(shop_with_config, name="size")
+    make_option(attr_id, "XL")
+
+    resp = test_client.post(
+        f"/shops/{shop_with_config}/attribute-options/", json={"attribute_id": str(attr_id), "value_key": "XXL"}
+    )
+    assert resp.status_code == 201, resp.text
+
+    rows = entity_revisions("attribute", attr_id)
+    assert [r.action for r in rows] == ["baseline", "update"]
+    assert [o["value_key"] for o in rows[0].data["options"]] == ["XL"]
+    assert [o["value_key"] for o in rows[1].data["options"]] == ["XL", "XXL"]
+
+
+def test_attribute_delete_records_revision(shop_with_config, test_client):
+    attr_id = make_attribute(shop_with_config, name="doomed-attr")
+    assert test_client.delete(f"/shops/{shop_with_config}/attributes/{attr_id}").status_code == 204
+
+    rows = entity_revisions("attribute", attr_id)
+    assert rows[-1].action == "delete"
+    assert rows[-1].data["attribute"]["name"] == "doomed-attr"
+
+
+# --- Shop-wide feed ---
+
+
+def test_feed_lists_all_entity_types(shop_with_config, product, test_client):
+    # Product edit (legacy product → baseline + update)
+    category = product_category_id(product)
+    body = product_body(shop_with_config, category, main_name="Feed product")
+    assert test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body)).status_code == 201
+    # Tag create
+    assert (
+        test_client.post(
+            f"/shops/{shop_with_config}/tags/", content=json_dumps(tag_body(shop_with_config, "feed-tag"))
+        ).status_code
+        == 201
+    )
+    # Attribute create
+    assert test_client.post(f"/shops/{shop_with_config}/attributes/", json={"name": "feed-attr"}).status_code == 201
+
+    resp = test_client.get(f"/shops/{shop_with_config}/revisions")
+    assert resp.status_code == 200, resp.text
+    feed = resp.json()
+    assert {item["entity_type"] for item in feed} == {"product", "tag", "attribute"}
+    assert len(feed) == 4  # product baseline + product update + tag create + attribute create
+    assert resp.headers["Content-Range"] == "revisions 0-3/4"
+    # Every entry carries a human-readable name
+    names = {item["name"] for item in feed}
+    assert {"Feed product", "feed-tag", "feed-attr"} <= names
+    # Newest first per entity: the product update outranks its baseline
+    product_entries = [item for item in feed if item["entity_type"] == "product"]
+    assert [e["revision_no"] for e in product_entries] == [2, 1]
+
+
+def test_feed_filters(shop_with_config, test_client):
+    resp = test_client.post(
+        f"/shops/{shop_with_config}/tags/", content=json_dumps(tag_body(shop_with_config, "filter-tag"))
+    )
+    tag_id = resp.json()["id"]
+    body = tag_body(shop_with_config, "filter-tag-renamed")
+    assert test_client.put(f"/shops/{shop_with_config}/tags/{tag_id}", content=json_dumps(body)).status_code == 201
+
+    resp = test_client.get(f"/shops/{shop_with_config}/revisions?entity_type=tag")
+    assert [item["action"] for item in resp.json()] == ["update", "create"]
+
+    resp = test_client.get(f"/shops/{shop_with_config}/revisions?entity_type=tag&action=create")
+    assert [item["name"] for item in resp.json()] == ["filter-tag"]
+
+    resp = test_client.get(f"/shops/{shop_with_config}/revisions?entity_id={tag_id}")
+    assert len(resp.json()) == 2
+
+    resp = test_client.get(f"/shops/{shop_with_config}/revisions?source=mcp")
+    assert resp.json() == []
+
+    resp = test_client.get(f"/shops/{shop_with_config}/revisions?created_by=cognito:5678")
+    assert len(resp.json()) == 2
+
+    assert test_client.get(f"/shops/{shop_with_config}/revisions?entity_type=bogus").status_code == 422
+
+
+def test_feed_pagination(shop_with_config, test_client):
+    for i in range(3):
+        resp = test_client.post(
+            f"/shops/{shop_with_config}/tags/", content=json_dumps(tag_body(shop_with_config, f"page-tag-{i}"))
+        )
+        assert resp.status_code == 201
+
+    resp = test_client.get(f"/shops/{shop_with_config}/revisions?limit=2")
+    assert len(resp.json()) == 2
+    assert resp.headers["Content-Range"] == "revisions 0-1/3"
+
+    resp = test_client.get(f"/shops/{shop_with_config}/revisions?skip=2&limit=2")
+    assert len(resp.json()) == 1
+    assert resp.headers["Content-Range"] == "revisions 2-2/3"
+
+
+def test_feed_is_shop_scoped_and_detail_matches(shop, shop_with_config, test_client):
+    resp = test_client.post(f"/shops/{shop}/tags/", content=json_dumps(tag_body(shop, "mine")))
+    assert resp.status_code == 201
+
+    feed = test_client.get(f"/shops/{shop}/revisions").json()
+    assert [item["name"] for item in feed] == ["mine"]
+    # The other shop's feed does not contain it
+    other_feed = test_client.get(f"/shops/{shop_with_config}/revisions").json()
+    assert other_feed == []
+
+    # Detail by revision id, shop-scoped
+    revision_id = feed[0]["id"]
+    detail = test_client.get(f"/shops/{shop}/revisions/{revision_id}")
+    assert detail.status_code == 200
+    assert detail.json()["data"]["tag"]["name"] == "mine"
+    assert test_client.get(f"/shops/{shop_with_config}/revisions/{revision_id}").status_code == 404

--- a/tests/unit_tests/api/test_soft_delete.py
+++ b/tests/unit_tests/api/test_soft_delete.py
@@ -1,0 +1,130 @@
+"""Tests for soft delete (trash), the query filter, restore and purge auth rules."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server.db import db
+from server.db.models import ProductAttributeValueTable, ProductTable, ProductToTagTable, TagTable
+from server.security import auth_required_any
+from tests.unit_tests.factories.api_key import make_api_key
+from tests.unit_tests.factories.attribute import make_attribute, make_option, make_pav
+from tests.unit_tests.factories.tag import make_tag
+
+
+@pytest.fixture
+def as_api_key(fastapi_app):
+    """Temporarily authenticate ``auth_required_any`` routes as an API-key principal."""
+    saved = fastapi_app.dependency_overrides[auth_required_any]
+
+    def _activate(shop_id):
+        row, _ = make_api_key(shop_id)
+        fastapi_app.dependency_overrides[auth_required_any] = lambda: row
+        return row
+
+    yield _activate
+    fastapi_app.dependency_overrides[auth_required_any] = saved
+
+
+def test_deleted_product_hidden_everywhere(shop_with_config, product, test_client):
+    resp = test_client.delete(f"/shops/{shop_with_config}/products/{product}")
+    assert resp.status_code == 204
+
+    # Row still exists, flagged deleted
+    row = db.session.query(ProductTable).filter_by(id=product).execution_options(include_deleted=True).one()
+    assert row.deleted_at is not None
+
+    # Hidden from list and detail endpoints
+    listing = test_client.get(f"/shops/{shop_with_config}/products/").json()
+    assert str(product) not in [p["id"] for p in listing]
+    assert test_client.get(f"/shops/{shop_with_config}/products/{product}").status_code == 404
+
+    # Deleting it again is a 404 (it's no longer visible)
+    assert test_client.delete(f"/shops/{shop_with_config}/products/{product}").status_code == 404
+
+
+def test_trash_and_restore_product_with_relations(shop_with_config, product, test_client):
+    tag_id = make_tag(shop_id=shop_with_config, main_name="keepme")
+    db.session.add(ProductToTagTable(shop_id=shop_with_config, product_id=product, tag_id=tag_id))
+    db.session.commit()
+    attr_id = make_attribute(shop_with_config, name="size")
+    opt_id = make_option(attr_id, "M")
+    make_pav(product, attr_id, opt_id)
+
+    assert test_client.delete(f"/shops/{shop_with_config}/products/{product}").status_code == 204
+
+    trash = test_client.get(f"/shops/{shop_with_config}/trash").json()
+    trashed_ids = [t["id"] for t in trash if t["entity_type"] == "product"]
+    assert str(product) in trashed_ids
+
+    resp = test_client.post(f"/shops/{shop_with_config}/products/{product}/restore")
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()["restored"] is True
+
+    # Product is visible again with tags and attribute values intact
+    assert test_client.get(f"/shops/{shop_with_config}/products/{product}").status_code == 200
+    assert db.session.query(ProductToTagTable).filter_by(product_id=product, tag_id=tag_id).count() == 1
+    assert db.session.query(ProductAttributeValueTable).filter_by(product_id=product).count() == 1
+    assert test_client.get(f"/shops/{shop_with_config}/trash").json() == []
+
+
+def test_purge_requires_cognito(shop_with_config, product, test_client, fastapi_app, as_api_key):
+    as_api_key(shop_with_config)
+    api_client = TestClient(fastapi_app)
+
+    # API key may trash…
+    resp = api_client.delete(f"/shops/{shop_with_config}/products/{product}?force=true")
+    assert resp.status_code == 403
+
+    # …but not purge
+    resp = api_client.delete(f"/shops/{shop_with_config}/products/{product}")
+    assert resp.status_code == 204
+
+
+def test_purge_with_cognito_removes_row(shop_with_config, product, test_client):
+    assert test_client.delete(f"/shops/{shop_with_config}/products/{product}").status_code == 204
+    # Purge from the trash with user credentials
+    assert test_client.delete(f"/shops/{shop_with_config}/products/{product}?force=true").status_code == 204
+    row = db.session.query(ProductTable).filter_by(id=product).execution_options(include_deleted=True).first()
+    assert row is None
+
+
+def test_api_key_actor_recorded_in_revision(shop_with_config, product, test_client, fastapi_app, as_api_key):
+    from server.db.models import RevisionTable
+
+    key_row = as_api_key(shop_with_config)
+    api_client = TestClient(fastapi_app)
+    assert api_client.delete(f"/shops/{shop_with_config}/products/{product}").status_code == 204
+
+    revision = (
+        db.session.query(RevisionTable)
+        .filter(RevisionTable.entity_type == "product", RevisionTable.entity_id == product)
+        .order_by(RevisionTable.revision_no.desc())
+        .first()
+    )
+    assert revision.action == "delete"
+    assert revision.created_by == f"api_key:{key_row.id}"
+
+
+def test_soft_deleted_tag_filtered_from_relationship_loads(shop_with_config, product, test_client):
+    tag_id = make_tag(shop_id=shop_with_config, main_name="hidden-tag")
+    db.session.add(ProductToTagTable(shop_id=shop_with_config, product_id=product, tag_id=tag_id))
+    db.session.commit()
+
+    assert test_client.delete(f"/shops/{shop_with_config}/tags/{tag_id}").status_code == 204
+    db.session.expire_all()
+
+    # Top-level query filtered
+    assert db.session.query(TagTable).filter_by(id=tag_id).first() is None
+    # Relationship load from a queried parent is filtered too
+    row = db.session.query(ProductTable).filter_by(id=product).one()
+    assert tag_id not in [t.id for t in row.tags]
+    # Opt-out sees it
+    assert db.session.query(TagTable).filter_by(id=tag_id).execution_options(include_deleted=True).first() is not None
+
+    # Restoring the tag brings the product link back without any relinking
+    tag_row = db.session.query(TagTable).filter_by(id=tag_id).execution_options(include_deleted=True).one()
+    tag_row.deleted_at = None
+    db.session.commit()
+    db.session.expire_all()
+    row = db.session.query(ProductTable).filter_by(id=product).one()
+    assert tag_id in [t.id for t in row.tags]

--- a/tests/unit_tests/api/test_tag_attribute_restore.py
+++ b/tests/unit_tests/api/test_tag_attribute_restore.py
@@ -1,0 +1,194 @@
+"""Tests for restoring tags and attributes: by revision and from the trash."""
+
+from uuid import UUID
+
+from server.db import db
+from server.db.models import AttributeOptionTable, AttributeTable, ProductToTagTable, TagTable
+from server.utils.json import json_dumps
+from tests.unit_tests.api.test_shop_revision_feed import entity_revisions, tag_body
+from tests.unit_tests.factories.attribute import make_attribute, make_option
+from tests.unit_tests.factories.tag import make_tag
+
+
+def get_tag(tag_id):
+    db.session.expire_all()
+    return db.session.query(TagTable).filter_by(id=tag_id).execution_options(include_deleted=True).one()
+
+
+def get_attribute(attribute_id):
+    db.session.expire_all()
+    return db.session.query(AttributeTable).filter_by(id=attribute_id).execution_options(include_deleted=True).one()
+
+
+def live_option_keys(attribute_id):
+    db.session.expire_all()
+    options = db.session.query(AttributeOptionTable).filter_by(attribute_id=attribute_id).all()
+    return sorted(option.value_key for option in options)
+
+
+# --- Tags ---
+
+
+def test_restore_tag_revision_undoes_rename(shop, test_client):
+    resp = test_client.post(f"/shops/{shop}/tags/", content=json_dumps(tag_body(shop, "good-name")))
+    tag_id = resp.json()["id"]
+    body = tag_body(shop, "llm-mess")
+    assert test_client.put(f"/shops/{shop}/tags/{tag_id}", content=json_dumps(body)).status_code == 201
+
+    resp = test_client.post(f"/shops/{shop}/tags/{tag_id}/revisions/1/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["restored"] is True
+    assert report["entity_type"] == "tag"
+    assert report["restored_from_revision_no"] == 1
+
+    tag = get_tag(tag_id)
+    assert tag.name == "good-name"
+    assert tag.translation.main_name == "good-name"
+    assert entity_revisions("tag", UUID(tag_id))[-1].action == "restore"
+
+
+def test_restore_tag_from_trash_brings_back_product_links(shop_with_config, product, test_client):
+    tag_id = make_tag(shop_id=shop_with_config, main_name="linked-tag")
+    test_client.post(
+        f"/shops/{shop_with_config}/products-to-tags/",
+        json={"product_id": str(product), "tag_id": str(tag_id), "shop_id": str(shop_with_config)},
+    )
+    assert test_client.delete(f"/shops/{shop_with_config}/tags/{tag_id}").status_code == 204
+    assert get_tag(tag_id).deleted_at is not None
+
+    resp = test_client.post(f"/shops/{shop_with_config}/tags/{tag_id}/restore")
+    assert resp.status_code == 200, resp.json()
+    assert [r["kind"] for r in resp.json()["resurrected"]] == ["tag"]
+
+    assert get_tag(tag_id).deleted_at is None
+    links = db.session.query(ProductToTagTable).filter_by(product_id=product).all()
+    assert [link.tag_id for link in links] == [tag_id]
+
+
+def test_restore_purged_tag_requires_force(shop, test_client):
+    resp = test_client.post(f"/shops/{shop}/tags/", content=json_dumps(tag_body(shop, "purge-me")))
+    tag_id = resp.json()["id"]
+    assert test_client.delete(f"/shops/{shop}/tags/{tag_id}?force=true").status_code == 204
+
+    # Trash restore: gone
+    assert test_client.post(f"/shops/{shop}/tags/{tag_id}/restore").status_code == 404
+    # Revision restore without force: 410
+    assert test_client.post(f"/shops/{shop}/tags/{tag_id}/revisions/1/restore").status_code == 410
+
+    # With force the tag is recreated under its original id
+    resp = test_client.post(f"/shops/{shop}/tags/{tag_id}/revisions/1/restore?force=true")
+    assert resp.status_code == 200, resp.json()
+    assert any("recreated" in w for w in resp.json()["warnings"])
+    tag = get_tag(tag_id)
+    assert tag.name == "purge-me"
+    assert tag.translation.main_name == "purge-me"
+
+
+# --- Attributes ---
+
+
+def test_restore_attribute_revision_restores_option_set(shop, test_client):
+    resp = test_client.post(f"/shops/{shop}/attributes/", json={"name": "size", "unit": "EU"})
+    attr_id = resp.json()["id"]
+    for value_key in ("S", "M"):
+        assert (
+            test_client.post(
+                f"/shops/{shop}/attribute-options/", json={"attribute_id": attr_id, "value_key": value_key}
+            ).status_code
+            == 201
+        )
+    good_revision_no = entity_revisions("attribute", UUID(attr_id))[-1].revision_no
+
+    # The mess: rename the attribute, trash option M, add option XXL
+    resp = test_client.put(f"/shops/{shop}/attributes/{attr_id}", json={"name": "sizz", "unit": None})
+    assert resp.status_code == 200, resp.text
+    m_option = db.session.query(AttributeOptionTable).filter_by(value_key="M").one()
+    assert test_client.delete(f"/shops/{shop}/attribute-options/{m_option.id}").status_code == 204
+    assert (
+        test_client.post(
+            f"/shops/{shop}/attribute-options/", json={"attribute_id": attr_id, "value_key": "XXL"}
+        ).status_code
+        == 201
+    )
+    assert live_option_keys(attr_id) == ["S", "XXL"]
+
+    resp = test_client.post(f"/shops/{shop}/attributes/{attr_id}/revisions/{good_revision_no}/restore")
+    assert resp.status_code == 200, resp.json()
+    report = resp.json()
+    assert report["restored"] is True
+    # M was resurrected from the trash, XXL moved to the trash
+    assert any(r["kind"] == "attribute_option" and r["name"] == "M" for r in report["resurrected"])
+    assert any("XXL" in w and "trash" in w for w in report["warnings"])
+
+    attribute = get_attribute(attr_id)
+    assert attribute.name == "size"
+    assert attribute.unit == "EU"
+    assert live_option_keys(attr_id) == ["S", "M"] or live_option_keys(attr_id) == sorted(["S", "M"])
+    assert entity_revisions("attribute", UUID(attr_id))[-1].action == "restore"
+
+
+def test_restore_attribute_recreates_purged_option_with_same_id(shop, test_client):
+    resp = test_client.post(f"/shops/{shop}/attributes/", json={"name": "material"})
+    attr_id = resp.json()["id"]
+    resp = test_client.post(f"/shops/{shop}/attribute-options/", json={"attribute_id": attr_id, "value_key": "WOOL"})
+    option_id = resp.json()["id"]
+    snapshot_no = entity_revisions("attribute", UUID(attr_id))[-1].revision_no
+
+    # Hard-purge the option
+    assert test_client.delete(f"/shops/{shop}/attribute-options/{option_id}?force=true").status_code == 204
+    assert db.session.query(AttributeOptionTable).filter_by(id=option_id).first() is None
+
+    resp = test_client.post(f"/shops/{shop}/attributes/{attr_id}/revisions/{snapshot_no}/restore")
+    assert resp.status_code == 200, resp.json()
+    assert any("WOOL" in w and "recreated" in w for w in resp.json()["warnings"])
+
+    # Recreated under the original id, so old product snapshots referencing it resolve again
+    recreated = db.session.query(AttributeOptionTable).filter_by(id=option_id).one()
+    assert recreated.value_key == "WOOL"
+
+
+def test_restore_attribute_from_trash(shop_with_config, test_client):
+    attr_id = make_attribute(shop_with_config, name="trash-attr")
+    make_option(attr_id, "A")
+    assert test_client.delete(f"/shops/{shop_with_config}/attributes/{attr_id}").status_code == 204
+    assert get_attribute(attr_id).deleted_at is not None
+
+    resp = test_client.post(f"/shops/{shop_with_config}/attributes/{attr_id}/restore")
+    assert resp.status_code == 200, resp.json()
+    assert get_attribute(attr_id).deleted_at is None
+    assert live_option_keys(attr_id) == ["A"]
+
+
+def test_double_restore_is_idempotent(shop, test_client):
+    resp = test_client.post(f"/shops/{shop}/attributes/", json={"name": "twice"})
+    attr_id = resp.json()["id"]
+    assert (
+        test_client.post(
+            f"/shops/{shop}/attribute-options/", json={"attribute_id": attr_id, "value_key": "X"}
+        ).status_code
+        == 201
+    )
+    snapshot_no = entity_revisions("attribute", UUID(attr_id))[-1].revision_no
+
+    for _ in range(2):
+        resp = test_client.post(f"/shops/{shop}/attributes/{attr_id}/revisions/{snapshot_no}/restore")
+        assert resp.status_code == 200, resp.json()
+
+    assert live_option_keys(attr_id) == ["X"]
+    assert db.session.query(AttributeOptionTable).filter_by(attribute_id=attr_id).count() == 1
+
+
+# --- Trash listing ---
+
+
+def test_trash_lists_tags_and_attributes(shop_with_config, test_client):
+    tag_id = make_tag(shop_id=shop_with_config, main_name="binned-tag")
+    attr_id = make_attribute(shop_with_config, name="binned-attr")
+    assert test_client.delete(f"/shops/{shop_with_config}/tags/{tag_id}").status_code == 204
+    assert test_client.delete(f"/shops/{shop_with_config}/attributes/{attr_id}").status_code == 204
+
+    trash = test_client.get(f"/shops/{shop_with_config}/trash").json()
+    by_type = {(item["entity_type"], item["name"]) for item in trash}
+    assert ("tag", "binned-tag") in by_type
+    assert ("attribute", "binned-attr") in by_type

--- a/tests/unit_tests/mcp/test_mcp.py
+++ b/tests/unit_tests/mcp/test_mcp.py
@@ -53,6 +53,8 @@ EXPECTED_TOOL_NAMES = {
     "update_attribute",
     "delete_attribute",
     # revisions / trash
+    "list_shop_revisions",
+    "get_revision",
     "list_product_revisions",
     "get_product_revision",
     "restore_product_revision",

--- a/tests/unit_tests/mcp/test_mcp.py
+++ b/tests/unit_tests/mcp/test_mcp.py
@@ -60,6 +60,7 @@ EXPECTED_TOOL_NAMES = {
     "restore_product_revision",
     "restore_product",
     "restore_category",
+    "restore_category_revision",
     "restore_tag_revision",
     "restore_tag",
     "restore_attribute_revision",

--- a/tests/unit_tests/mcp/test_mcp.py
+++ b/tests/unit_tests/mcp/test_mcp.py
@@ -52,6 +52,12 @@ EXPECTED_TOOL_NAMES = {
     "create_attribute",
     "update_attribute",
     "delete_attribute",
+    # revisions / trash
+    "list_product_revisions",
+    "get_product_revision",
+    "restore_product_revision",
+    "restore_product",
+    "restore_category",
     # shops
     "list_my_shops",
 }

--- a/tests/unit_tests/mcp/test_mcp.py
+++ b/tests/unit_tests/mcp/test_mcp.py
@@ -60,6 +60,10 @@ EXPECTED_TOOL_NAMES = {
     "restore_product_revision",
     "restore_product",
     "restore_category",
+    "restore_tag_revision",
+    "restore_tag",
+    "restore_attribute_revision",
+    "restore_attribute",
     # shops
     "list_my_shops",
 }

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -4730,6 +4730,279 @@
         "title": "ProductWithDetailsAndPrices",
         "type": "object"
       },
+      "RestoreReport": {
+        "description": "What a restore actually did \u2014 agents should read this to see what didn't come back.",
+        "properties": {
+          "entity_id": {
+            "format": "uuid",
+            "title": "Entity Id",
+            "type": "string"
+          },
+          "entity_type": {
+            "title": "Entity Type",
+            "type": "string"
+          },
+          "new_revision_no": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "New Revision No"
+          },
+          "restored": {
+            "title": "Restored",
+            "type": "boolean"
+          },
+          "restored_from_revision_no": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Restored From Revision No"
+          },
+          "resurrected": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/ResurrectedEntity"
+            },
+            "title": "Resurrected",
+            "type": "array"
+          },
+          "skipped_fields": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Skipped Fields",
+            "type": "array"
+          },
+          "unresolved": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/UnresolvedReference"
+            },
+            "title": "Unresolved",
+            "type": "array"
+          },
+          "warnings": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Warnings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "restored",
+          "entity_type",
+          "entity_id"
+        ],
+        "title": "RestoreReport",
+        "type": "object"
+      },
+      "ResurrectedEntity": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "required": [
+          "kind",
+          "id"
+        ],
+        "title": "ResurrectedEntity",
+        "type": "object"
+      },
+      "RevisionDetail": {
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          },
+          "data": {
+            "additionalProperties": true,
+            "title": "Data",
+            "type": "object"
+          },
+          "entity_id": {
+            "format": "uuid",
+            "title": "Entity Id",
+            "type": "string"
+          },
+          "entity_type": {
+            "title": "Entity Type",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "revision_no": {
+            "title": "Revision No",
+            "type": "integer"
+          },
+          "schema_version": {
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "entity_type",
+          "entity_id",
+          "revision_no",
+          "action",
+          "schema_version",
+          "source",
+          "data"
+        ],
+        "title": "RevisionDetail",
+        "type": "object"
+      },
+      "RevisionSummary": {
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          },
+          "entity_id": {
+            "format": "uuid",
+            "title": "Entity Id",
+            "type": "string"
+          },
+          "entity_type": {
+            "title": "Entity Type",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "revision_no": {
+            "title": "Revision No",
+            "type": "integer"
+          },
+          "schema_version": {
+            "title": "Schema Version",
+            "type": "integer"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "entity_type",
+          "entity_id",
+          "revision_no",
+          "action",
+          "schema_version",
+          "source"
+        ],
+        "title": "RevisionSummary",
+        "type": "object"
+      },
       "ShippingCalculateRequest": {
         "properties": {
           "order_info": {
@@ -5653,6 +5926,96 @@
         "title": "Toggles",
         "type": "object"
       },
+      "TrashItem": {
+        "properties": {
+          "deleted_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deleted At"
+          },
+          "deleted_batch_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deleted Batch Id"
+          },
+          "entity_type": {
+            "title": "Entity Type",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "required": [
+          "entity_type",
+          "id"
+        ],
+        "title": "TrashItem",
+        "type": "object"
+      },
+      "UnresolvedReference": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "required": [
+          "kind"
+        ],
+        "title": "UnresolvedReference",
+        "type": "object"
+      },
       "ValidationError": {
         "properties": {
           "loc": {
@@ -5697,7 +6060,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.3.5"
+    "version": "0.4.0"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -9150,6 +9513,18 @@
               "title": "Option Id",
               "type": "string"
             }
+          },
+          {
+            "description": "Permanently purge instead of moving to trash. Irreversible.",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Permanently purge instead of moving to trash. Irreversible.",
+              "title": "Force",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -9818,7 +10193,7 @@
     },
     "/shops/{shop_id}/attributes/{attribute_id}": {
       "delete": {
-        "description": "Remove an attribute from a shop. This will fail if the attribute is currently in use by any products.",
+        "description": "Moves an attribute to the trash: it disappears from listings but existing product values keep their data, so restoring the attribute brings everything back. This action is reversible. Only `force=true` permanently purges the attribute (fails with 409 while products still use it); that is irreversible and requires user (Cognito) credentials \u2014 API keys get 403.",
         "operationId": "delete_attribute",
         "parameters": [
           {
@@ -9839,6 +10214,18 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Permanently purge instead of moving to trash. Irreversible.",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Permanently purge instead of moving to trash. Irreversible.",
+              "title": "Force",
+              "type": "boolean"
             }
           },
           {
@@ -9873,7 +10260,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Delete attribute",
+        "summary": "Delete attribute (moves to trash)",
         "tags": [
           "shops",
           "attributes",
@@ -10179,6 +10566,18 @@
               "format": "uuid",
               "title": "Option Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Permanently purge instead of moving to trash. Irreversible.",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Permanently purge instead of moving to trash. Irreversible.",
+              "title": "Force",
+              "type": "boolean"
             }
           }
         ],
@@ -10846,7 +11245,7 @@
     },
     "/shops/{shop_id}/categories/{category_id}": {
       "delete": {
-        "description": "Remove a category from the shop. Fails if any products are still assigned to it.",
+        "description": "Moves a category to the trash (restorable with `restore_category`). If products are still assigned to it the request fails with 409 and the product count; retry with `force=true` to also move all those products to the trash (restorable as one batch), or with `detach=true` to keep the products but clear their category. `force` and `detach` are mutually exclusive.",
         "operationId": "delete_category",
         "parameters": [
           {
@@ -10867,6 +11266,30 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Also move all products in this category to the trash.",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Also move all products in this category to the trash.",
+              "title": "Force",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Keep the products; clear their category reference instead.",
+            "in": "query",
+            "name": "detach",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Keep the products; clear their category reference instead.",
+              "title": "Detach",
+              "type": "boolean"
             }
           },
           {
@@ -10901,7 +11324,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Delete category",
+        "summary": "Delete category (moves to trash)",
         "tags": [
           "categories",
           "agent-exposed"
@@ -11286,6 +11709,165 @@
         "summary": "List products in a category with attribute filters",
         "tags": [
           "categories"
+        ]
+      }
+    },
+    "/shops/{shop_id}/categories/{category_id}/restore": {
+      "post": {
+        "description": "Brings a trashed (deleted) category back. With `restore_products=true` (default) it also restores every product that was moved to the trash together with the category by a `delete_category` with `force=true`.",
+        "operationId": "restore_category",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "category_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Category Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Also restore the products trashed together with this category.",
+            "in": "query",
+            "name": "restore_products",
+            "required": false,
+            "schema": {
+              "default": true,
+              "description": "Also restore the products trashed together with this category.",
+              "title": "Restore Products",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreReport"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore category from trash",
+        "tags": [
+          "shops",
+          "revisions",
+          "agent-exposed"
+        ]
+      }
+    },
+    "/shops/{shop_id}/categories/{category_id}/revisions": {
+      "get": {
+        "description": "Returns the revision history of a category, newest first.",
+        "operationId": "list_category_revisions_shops__shop_id__categories__category_id__revisions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "category_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Category Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RevisionSummary"
+                  },
+                  "title": "Response List Category Revisions Shops  Shop Id  Categories  Category Id  Revisions Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List category revisions",
+        "tags": [
+          "shops",
+          "revisions"
         ]
       }
     },
@@ -12656,7 +13238,7 @@
     },
     "/shops/{shop_id}/products/{product_id}": {
       "delete": {
-        "description": "Permanently remove a product from the shop.",
+        "description": "Moves the product to the trash. The product disappears from all listings but can be restored with `restore_product` or via its revisions \u2014 this action is reversible. Only `force=true` permanently purges the product; that is irreversible and requires user (Cognito) credentials \u2014 API keys get 403.",
         "operationId": "delete_product",
         "parameters": [
           {
@@ -12677,6 +13259,18 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Permanently purge instead of moving to trash. Irreversible.",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Permanently purge instead of moving to trash. Irreversible.",
+              "title": "Force",
+              "type": "boolean"
             }
           },
           {
@@ -12711,7 +13305,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Delete product",
+        "summary": "Delete product (moves to trash)",
         "tags": [
           "shops",
           "products",
@@ -12847,6 +13441,329 @@
         "tags": [
           "shops",
           "products",
+          "agent-exposed"
+        ]
+      }
+    },
+    "/shops/{shop_id}/products/{product_id}/restore": {
+      "post": {
+        "description": "Brings a trashed (deleted) product back, including its tags and attribute values. If the product's category is also in the trash it is restored as well.",
+        "operationId": "restore_product",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "product_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Product Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreReport"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore product from trash",
+        "tags": [
+          "shops",
+          "revisions",
+          "agent-exposed"
+        ]
+      }
+    },
+    "/shops/{shop_id}/products/{product_id}/revisions": {
+      "get": {
+        "description": "Returns the revision history of a product, newest first. Every change to the product (fields, translation, tags, attribute values, images) recorded one revision. Use `get_product_revision` to inspect a revision and `restore_product_revision` to roll back to it.",
+        "operationId": "list_product_revisions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "product_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Product Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RevisionSummary"
+                  },
+                  "title": "Response List Product Revisions",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List product revisions",
+        "tags": [
+          "shops",
+          "revisions",
+          "agent-exposed",
+          "agent-large"
+        ]
+      }
+    },
+    "/shops/{shop_id}/products/{product_id}/revisions/{revision_no}": {
+      "get": {
+        "description": "Returns one product revision including the full snapshot data (all fields, tags, attribute values and image references at that point in time).",
+        "operationId": "get_product_revision",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "product_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Product Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "revision_no",
+            "required": true,
+            "schema": {
+              "title": "Revision No",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevisionDetail"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get product revision",
+        "tags": [
+          "shops",
+          "revisions",
+          "agent-exposed"
+        ]
+      }
+    },
+    "/shops/{shop_id}/products/{product_id}/revisions/{revision_no}/restore": {
+      "post": {
+        "description": "Rolls the product back to the state captured in the given revision: fields, translation, category, tags, attribute values and image references. Soft-deleted categories/tags/attributes referenced by the snapshot are automatically restored from the trash; references that were permanently purged are matched by name where possible, otherwise reported in `unresolved`. The restore itself is recorded as a new revision, so it can be undone too. Read the returned report to see what could not be brought back.",
+        "operationId": "restore_product_revision",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "product_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Product Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "revision_no",
+            "required": true,
+            "schema": {
+              "title": "Revision No",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Recreate the product from the snapshot even if it was permanently purged (user credentials required).",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Recreate the product from the snapshot even if it was permanently purged (user credentials required).",
+              "title": "Force",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreReport"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore product to a revision",
+        "tags": [
+          "shops",
+          "revisions",
           "agent-exposed"
         ]
       }
@@ -13423,7 +14340,7 @@
     },
     "/shops/{shop_id}/tags/{tag_id}": {
       "delete": {
-        "description": "Remove a tag from a shop. Fails with 400 if products still reference this tag.",
+        "description": "Moves a tag to the trash: it disappears from listings and from the products carrying it, but its product links are kept so restoring the tag brings everything back. This action is reversible. Only `force=true` permanently purges the tag (and its product links); that is irreversible and requires user (Cognito) credentials \u2014 API keys get 403.",
         "operationId": "delete_tag",
         "parameters": [
           {
@@ -13444,6 +14361,18 @@
               "format": "uuid",
               "title": "Shop Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Permanently purge instead of moving to trash. Irreversible.",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Permanently purge instead of moving to trash. Irreversible.",
+              "title": "Force",
+              "type": "boolean"
             }
           },
           {
@@ -13478,7 +14407,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Delete tag",
+        "summary": "Delete tag (moves to trash)",
         "tags": [
           "shops",
           "products",
@@ -13631,6 +14560,71 @@
           "shops",
           "products",
           "agent-exposed"
+        ]
+      }
+    },
+    "/shops/{shop_id}/trash": {
+      "get": {
+        "description": "Returns all soft-deleted products and categories of the shop, so they can be inspected and restored.",
+        "operationId": "list_trash_shops__shop_id__trash_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TrashItem"
+                  },
+                  "title": "Response List Trash Shops  Shop Id  Trash Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List trashed products and categories",
+        "tags": [
+          "shops",
+          "revisions"
         ]
       }
     },

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -6060,7 +6060,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.4.1"
+    "version": "0.4.2"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -10677,6 +10677,171 @@
         ]
       }
     },
+    "/shops/{shop_id}/attributes/{attribute_id}/restore": {
+      "post": {
+        "description": "Brings a trashed (deleted) attribute back, including its options and all product values that used it. Options that were trashed individually before stay in the trash \u2014 restore an attribute revision to bring those back too.",
+        "operationId": "restore_attribute",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "attribute_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Attribute Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreReport"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore attribute from trash",
+        "tags": [
+          "shops",
+          "revisions",
+          "agent-exposed"
+        ]
+      }
+    },
+    "/shops/{shop_id}/attributes/{attribute_id}/revisions/{revision_no}/restore": {
+      "post": {
+        "description": "Rolls the attribute back to the state captured in the given revision: name, unit, translations and its option set. Trashed options in the snapshot are restored, purged ones are recreated under their original id, and live options that are not in the snapshot are moved to the trash (their product values survive). Use `list_shop_revisions` with `entity_type=attribute` to find revisions. If the attribute was permanently purged, `force=true` (user credentials required) recreates it. The restore is recorded as a new revision. Read the returned report for what was resurrected, recreated or trashed.",
+        "operationId": "restore_attribute_revision",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "attribute_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Attribute Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "revision_no",
+            "required": true,
+            "schema": {
+              "title": "Revision No",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Recreate the attribute from the snapshot even if it was permanently purged (user credentials required).",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Recreate the attribute from the snapshot even if it was permanently purged (user credentials required).",
+              "title": "Force",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreReport"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore attribute to a revision",
+        "tags": [
+          "shops",
+          "revisions",
+          "agent-exposed"
+        ]
+      }
+    },
     "/shops/{shop_id}/attributes/{attribute_id}/with-options": {
       "get": {
         "description": "Retrieve a specific attribute by its unique ID, including all of its defined options.",
@@ -14816,9 +14981,174 @@
         ]
       }
     },
+    "/shops/{shop_id}/tags/{tag_id}/restore": {
+      "post": {
+        "description": "Brings a trashed (deleted) tag back. Its product links were kept in the trash, so the tag reappears on all products that carried it.",
+        "operationId": "restore_tag",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "tag_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Tag Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreReport"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore tag from trash",
+        "tags": [
+          "shops",
+          "revisions",
+          "agent-exposed"
+        ]
+      }
+    },
+    "/shops/{shop_id}/tags/{tag_id}/revisions/{revision_no}/restore": {
+      "post": {
+        "description": "Rolls the tag back to the state captured in the given revision (name and translations). Use the `list_shop_revisions` feed with `entity_type=tag` to find revisions. If the tag was permanently purged, `force=true` (user credentials required) recreates it under its original id so existing product links in old snapshots resolve again. The restore is recorded as a new revision.",
+        "operationId": "restore_tag_revision",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "tag_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Tag Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "revision_no",
+            "required": true,
+            "schema": {
+              "title": "Revision No",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Recreate the tag from the snapshot even if it was permanently purged (user credentials required).",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Recreate the tag from the snapshot even if it was permanently purged (user credentials required).",
+              "title": "Force",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreReport"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore tag to a revision",
+        "tags": [
+          "shops",
+          "revisions",
+          "agent-exposed"
+        ]
+      }
+    },
     "/shops/{shop_id}/trash": {
       "get": {
-        "description": "Returns all soft-deleted products and categories of the shop, so they can be inspected and restored.",
+        "description": "Returns all soft-deleted products, categories, tags and attributes of the shop, so they can be inspected and restored.",
         "operationId": "list_trash_shops__shop_id__trash_get",
         "parameters": [
           {
@@ -14874,7 +15204,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "List trashed products and categories",
+        "summary": "List trashed products, categories, tags and attributes",
         "tags": [
           "shops",
           "revisions"

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -6084,7 +6084,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.4.3"
+    "version": "0.4.4"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -12057,6 +12057,99 @@
         "tags": [
           "shops",
           "revisions"
+        ]
+      }
+    },
+    "/shops/{shop_id}/categories/{category_id}/revisions/{revision_no}/restore": {
+      "post": {
+        "description": "Rolls the category back to the state captured in the given revision: fields, translations and image references. Products are not touched \u2014 use `restore_category` for a trashed category with its product batch, or per-product revision restores to reattach detached products. If the category was permanently purged, `force=true` (user credentials required) recreates it under its original id. The restore is recorded as a new revision.",
+        "operationId": "restore_category_revision",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "category_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Category Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "revision_no",
+            "required": true,
+            "schema": {
+              "title": "Revision No",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Recreate the category from the snapshot even if it was permanently purged (user credentials required).",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Recreate the category from the snapshot even if it was permanently purged (user credentials required).",
+              "title": "Force",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreReport"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Restore category to a revision",
+        "tags": [
+          "shops",
+          "revisions",
+          "agent-exposed"
         ]
       }
     },

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -3073,9 +3073,16 @@
       "ProductCreate": {
         "properties": {
           "category_id": {
-            "format": "uuid",
-            "title": "Category Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
           },
           "digital": {
             "anyOf": [
@@ -3327,7 +3334,6 @@
         },
         "required": [
           "shop_id",
-          "category_id",
           "max_one",
           "shippable",
           "featured",
@@ -3798,9 +3804,16 @@
       "ProductUpdate": {
         "properties": {
           "category_id": {
-            "format": "uuid",
-            "title": "Category Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
           },
           "digital": {
             "anyOf": [
@@ -4064,7 +4077,6 @@
         },
         "required": [
           "shop_id",
-          "category_id",
           "max_one",
           "shippable",
           "featured",
@@ -4117,9 +4129,16 @@
             "title": "Approved At"
           },
           "category_id": {
-            "format": "uuid",
-            "title": "Category Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
           },
           "digital": {
             "anyOf": [
@@ -4399,7 +4418,6 @@
         },
         "required": [
           "shop_id",
-          "category_id",
           "max_one",
           "shippable",
           "featured",
@@ -4432,9 +4450,16 @@
             "title": "Approved At"
           },
           "category_id": {
-            "format": "uuid",
-            "title": "Category Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
           },
           "digital": {
             "anyOf": [
@@ -4712,7 +4737,6 @@
         },
         "required": [
           "shop_id",
-          "category_id",
           "max_one",
           "shippable",
           "featured",
@@ -6060,7 +6084,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.4.2"
+    "version": "0.4.3"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -6060,7 +6060,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -13898,6 +13898,259 @@
         "tags": [
           "shops",
           "products"
+        ]
+      }
+    },
+    "/shops/{shop_id}/revisions": {
+      "get": {
+        "description": "Shop-wide change feed: every recorded revision of every product, category, tag and attribute, newest first. Supports filtering by `entity_type` (product | category | tag | attribute), `entity_id`, `action` (create | update | delete | restore | baseline), `source` (rest | mcp) and `created_by`, plus `skip`/`limit` pagination (the total is returned in the Content-Range header). Use `get_revision` to inspect a revision's full snapshot.",
+        "operationId": "list_shop_revisions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter: product | category | tag | attribute.",
+            "in": "query",
+            "name": "entity_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter: product | category | tag | attribute.",
+              "title": "Entity Type"
+            }
+          },
+          {
+            "description": "Filter on one specific entity.",
+            "in": "query",
+            "name": "entity_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter on one specific entity.",
+              "title": "Entity Id"
+            }
+          },
+          {
+            "description": "Filter: create | update | delete | restore | baseline.",
+            "in": "query",
+            "name": "action",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter: create | update | delete | restore | baseline.",
+              "title": "Action"
+            }
+          },
+          {
+            "description": "Filter: rest | mcp.",
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter: rest | mcp.",
+              "title": "Source"
+            }
+          },
+          {
+            "description": "Filter on actor, e.g. \"api_key:<uuid>\" or \"cognito:<sub>\".",
+            "in": "query",
+            "name": "created_by",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter on actor, e.g. \"api_key:<uuid>\" or \"cognito:<sub>\".",
+              "title": "Created By"
+            }
+          },
+          {
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RevisionSummary"
+                  },
+                  "title": "Response List Shop Revisions",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List all revisions in a shop",
+        "tags": [
+          "shops",
+          "revisions",
+          "agent-exposed",
+          "agent-large"
+        ]
+      }
+    },
+    "/shops/{shop_id}/revisions/{revision_id}": {
+      "get": {
+        "description": "Returns one revision (of any entity type) by its id, including the full snapshot data. Use it to inspect entries from the `list_shop_revisions` feed.",
+        "operationId": "get_revision",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "shop_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Shop Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Revision Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevisionDetail"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get one revision by id",
+        "tags": [
+          "shops",
+          "revisions",
+          "agent-exposed"
         ]
       }
     },


### PR DESCRIPTION
## Why

MCP agents (LLMs with per-shop API keys) can edit products, categories, tags and attributes. A faulty agent edit — or a scary one like deleting a category full of products — was previously irreversible: every delete was a hard delete, and deleting a category with products crashed with a raw FK `IntegrityError`. This PR adds a full undo story to the PIM.

Design decided in an interview: JSON aggregate snapshots, resurrect-via-soft-delete on restore, soft delete on all four entity families, warn+force for cascades with Cognito-only purge plus a detach option, retention configurable via settings, revision list/get/restore exposed to MCP. Locking was considered and deliberately **skipped for v1** (revisions + soft delete already make everything recoverable).

## Revisions

- New `revisions` table (`migrations/versions/schema/2026-07-01_a3f5c7d9e1b2`): one row per mutation with a **JSONB snapshot of the whole product aggregate** — scalar fields, translation, category ref, tags, attribute values (with denormalized names), image filenames.
- Written from **every** mutation path: product create/update/delete, attribute-value POST/PUT/DELETE, tag links, category images — in the **same transaction** as the mutation, with a `FOR UPDATE` row lock so revision numbering is race-free under concurrent agents.
- Tracks `created_by` (`cognito:<sub>` / `api_key:<uuid>`), `source` (`mcp`/`rest`, detected via the `mcp-session-id` header fastmcp forwards) and `action` (`create|update|delete|restore`).
- Retention: `REVISION_RETENTION` setting (default **25**, hard floor 10), pruned on write.
- Categories get create/update/delete/restore revisions too.

### Robust against DB model churn

The serializer iterates the model's mapped columns at runtime, so **new columns are snapshotted automatically with zero code change**. Restore applies only `snapshot_keys ∩ current_columns` and reports the difference in `skipped_fields` — it never crashes on old snapshots. A `schema_version` column + `UPCONVERTERS` registry (`server/services/restore.py`) covers future structural reshapes. A **churn round-trip test** (snapshot → restore → assert every mapped column equal) fails loudly if a future model change breaks restore.

## Soft deletes (trash)

- `deleted_at` on `products`, `categories`, `tags`, `attributes`, `attribute_options` via a `SoftDeleteMixin` (`migrations/.../2026-07-01_b4e6d8f0a2c3`); `deleted_batch_id` on products groups cascade deletes.
- A single `do_orm_execute` listener (bottom of `server/db/models.py`) adds `deleted_at IS NULL` to every ORM SELECT — covering CRUD, the ~19 direct-query sites and relationship loads — with per-statement opt-out `.execution_options(include_deleted=True)` used only by trash/restore/purge code. `CRUDBase.get` re-checks `deleted_at` because `Session.get()` can bypass the listener via the identity map.
- **Delete now means “move to trash”** for products, categories, tags, attributes and options. Trashed tags/attributes keep their product links/values, so restoring them brings everything back without relinking.
- **Hard purge** = `force=true` and requires **Cognito credentials — API keys get 403**. An agent can never permanently destroy data.

## Category delete: warn / force / detach

`DELETE /shops/{shop_id}/categories/{id}` with products still assigned:

1. no flag → **409** with `product_count` and a hint,
2. `force=true` → cascade soft-delete: every product is revisioned and trashed under one `deleted_batch_id`, restorable in one call,
3. `detach=true` → products stay live with `category_id = NULL` (each gets an update revision recording `detached_from_category`), then the category is trashed.

`force` and `detach` are mutually exclusive (422).

## Restore

- `POST /products/{id}/restore` — undelete from trash (tags/attribute values intact; also resurrects the product's trashed category).
- `POST /categories/{id}/restore?restore_products=true` — undelete a category plus the product batch trashed with it.
- `POST /products/{id}/revisions/{no}/restore` — roll back to any snapshot. Soft-deleted references are resurrected; purged ones are matched **by name** (attribute names / option value keys are unique per shop) or reported. Purged products can be recreated from the snapshot with `force=true` (Cognito-only).
- Every restore returns a **`RestoreReport`** (`resurrected`, `unresolved`, `skipped_fields`, `warnings`) so agents/UIs see exactly what came back — and the restore itself is a new revision, so it can be undone too.
- `GET /shops/{shop_id}/trash` lists trashed products and categories.

## Images

Snapshots record the S3 filenames; the image-delete endpoints keep only nulling the DB column while the S3 object stays (formalizing existing behavior), so any revision remains restorable. An orphan-purge job (delete only files unreferenced by any live row or revision) is a documented follow-up.

## MCP surface

New tools: `list_product_revisions`, `get_product_revision`, `restore_product_revision`, `restore_product`, `restore_category`. `delete_product` / `delete_category` / `delete_tag` / `delete_attribute` descriptions now tell agents deletes are restorable and only `force=true` is irreversible. `APP_VERSION` → **0.4.0**, OpenAPI snapshot regenerated, `EXPECTED_TOOL_NAMES` updated.

## Behavior changes to note

- Plain `DELETE` on products/categories/tags/attributes/options no longer hard-deletes (use `force=true` with user credentials for that).
- A trashed product still occupies its unique SKU/short_id until purged.
- Two ORM-level notes: the soft-delete listener is the one piece of “magic” (documented in `models.py`); `product_images.py` was found to be dead code (router never mounted) and left untouched — product image edits flow through `update_product`, which is revisioned.

## Tests

26 new tests: revision writing/listing across all mutation paths, restore incl. resurrection + name-fallback + unresolved reporting, idempotent double-restore, churn round-trip, unknown-snapshot-key skipping, schema-version guard, trash visibility/restore, purge auth rules (API key 403), API-key actor recorded, relationship-load filtering, category 409/force/detach/batch-restore, retention pruning + floor. Full suite: **206 passed** (the one failing test on `main`, `test_cleanup_of_accounts_and_orders`, is pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)