### PR TITLE
Expose read-only order MCP tools + make update_category a true partial update

### DIFF
--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -17,7 +17,17 @@ Twenty tools, one per shop CRUD operation. Tool names match the route's `operati
 
 List tools also carry `AgentTag.LARGE`, signalling to well-behaved clients that they should filter before calling.
 
-Any route *not* tagged with `AgentTag.EXPOSED` is invisible to MCP — even though it's still served by the same REST API. Orders, accounts, prices, Stripe, shop config etc. are intentionally REST-only.
+### Read-only order tools
+
+Orders are exposed **read-only** — an agent can review a shop's orders but cannot create, change, or delete them (those stay REST-only). Both tools are shop-scoped by their path (`/orders/shop/{shop_id}/...`), so a caller can only read the orders of the shop in the path, and both carry `AgentTag.LARGE`:
+
+| Resource | Pending | Complete |
+|----------|---------|----------|
+| Orders | `list_pending_orders` | `list_complete_orders` |
+
+Order records include customer names and totals, so clients should treat the results as personal data.
+
+Any route *not* tagged with `AgentTag.EXPOSED` is invisible to MCP — even though it's still served by the same REST API. Order writes (create/update/patch/delete), accounts, prices, Stripe, shop config etc. are intentionally REST-only.
 
 ## Enabling the endpoint
 

--- a/server/api/endpoints/shop_endpoints/categories.py
+++ b/server/api/endpoints/shop_endpoints/categories.py
@@ -160,7 +160,12 @@ def create(
     tags=[AgentTag.EXPOSED],
     operation_id="update_category",
     summary="Update category",
-    description="Update an existing category's details and translations.",
+    description=(
+        "Partially update a category. Send ONLY the fields you want to change; omitted fields are left "
+        "untouched. Names and descriptions live in the nested `translation` object and can also be sent "
+        "partially. `main_image`, `alt1_image` and `alt2_image` are S3 object filenames managed by the "
+        "image-upload flow - do not set them unless explicitly given a filename."
+    ),
 )
 def update(
     *,

--- a/server/api/endpoints/shop_endpoints/orders.py
+++ b/server/api/endpoints/shop_endpoints/orders.py
@@ -29,7 +29,7 @@ from server.schemas.account import AccountCreate
 from server.schemas.base import quantize_money
 from server.schemas.order import OrderBase, OrderCreate, OrderCreated, OrderSchema, OrderUpdate, OrderUpdated
 from server.schemas.product import ProductTranslationBase
-from server.security import CustomCognitoToken, auth_required, auth_required_any
+from server.security import CustomCognitoToken, auth_required, auth_required_any, auth_required_any_for_shop
 from server.services import stripe_client
 from server.services.shipping import compute_shipping_for_cart
 from server.services.stripe_client import StripeNotConfigured
@@ -81,7 +81,7 @@ def show_all_pending_orders_per_shop(
     shop_id: UUID,
     response: Response,
     common: dict = Depends(common_parameters),
-    principal: Any = Depends(auth_required_any),
+    principal: Any = Depends(auth_required_any_for_shop),
 ) -> List[OrderSchema]:
     query = OrderTable.query.filter(OrderTable.shop_id == shop_id).filter(OrderTable.status == "pending")
     orders, header_range = order_crud.get_multi(
@@ -119,7 +119,7 @@ def show_all_complete_orders_per_shop(
     shop_id: UUID,
     response: Response,
     common: dict = Depends(common_parameters),
-    principal: Any = Depends(auth_required_any),
+    principal: Any = Depends(auth_required_any_for_shop),
 ) -> List[OrderSchema]:
     query = OrderTable.query.filter(OrderTable.shop_id == shop_id).filter(
         or_(OrderTable.status == "complete", OrderTable.status == "cancelled")

--- a/server/api/endpoints/shop_endpoints/orders.py
+++ b/server/api/endpoints/shop_endpoints/orders.py
@@ -365,23 +365,7 @@ def patch(
                 f"Updating stock for order {product.id} , old stock: {product.stock}, new stock: {product.stock - order_product['quantity']}"
             )
 
-            new_product = ProductUpdate(
-                shop_id=product.shop_id,
-                category_id=product.category_id,
-                max_one=product.max_one,
-                shippable=product.shippable,
-                featured=product.featured,
-                new_product=product.new_product,
-                tax_category=product.tax_category,
-                stock=product.stock - order_product["quantity"],
-                translation=product.translation,
-                image_1=product.image_1,
-                image_2=product.image_2,
-                image_3=product.image_3,
-                image_4=product.image_4,
-                image_5=product.image_5,
-                image_6=product.image_6,
-            )
+            new_product = ProductUpdate(stock=product.stock - order_product["quantity"])
             product_crud.update(db_obj=product, obj_in=new_product)
 
     # Fetch account once for Discord and email notifications

--- a/server/api/endpoints/shop_endpoints/orders.py
+++ b/server/api/endpoints/shop_endpoints/orders.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.param_functions import Body, Depends
 from starlette.responses import Response
 
+from server.agent_tags import AgentTag
 from server.api import deps
 from server.api.deps import common_parameters
 from server.api.error_handling import raise_status
@@ -28,7 +29,7 @@ from server.schemas.account import AccountCreate
 from server.schemas.base import quantize_money
 from server.schemas.order import OrderBase, OrderCreate, OrderCreated, OrderSchema, OrderUpdate, OrderUpdated
 from server.schemas.product import ProductTranslationBase
-from server.security import CustomCognitoToken, auth_required
+from server.security import CustomCognitoToken, auth_required, auth_required_any
 from server.services import stripe_client
 from server.services.shipping import compute_shipping_for_cart
 from server.services.stripe_client import StripeNotConfigured
@@ -66,14 +67,21 @@ def get_multi(
 @router.get(
     "/shop/{shop_id}/pending",
     response_model=List[OrderSchema],
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    operation_id="list_pending_orders",
     summary="List pending orders for a shop",
-    description="Returns all orders with status `pending` for the given shop. These are orders awaiting fulfilment.",
+    description=(
+        "Read-only. Returns the shop's orders with status `pending` - orders awaiting fulfilment. "
+        "Scoped to the shop in the path; you cannot read other shops' orders. Results include "
+        "customer names and totals, so treat them as personal data. Supports pagination (`skip`/`limit`), "
+        "filtering and sorting via the common query parameters; narrow before calling on busy shops."
+    ),
 )
 def show_all_pending_orders_per_shop(
     shop_id: UUID,
     response: Response,
     common: dict = Depends(common_parameters),
-    current_user: CustomCognitoToken = Depends(auth_required),
+    principal: Any = Depends(auth_required_any),
 ) -> List[OrderSchema]:
     query = OrderTable.query.filter(OrderTable.shop_id == shop_id).filter(OrderTable.status == "pending")
     orders, header_range = order_crud.get_multi(
@@ -97,14 +105,21 @@ def show_all_pending_orders_per_shop(
 @router.get(
     "/shop/{shop_id}/complete",
     response_model=List[OrderSchema],
+    tags=[AgentTag.EXPOSED, AgentTag.LARGE],
+    operation_id="list_complete_orders",
     summary="List completed orders for a shop",
-    description="Returns all orders with status `complete` or `cancelled` for the given shop. Used for order history and reporting.",
+    description=(
+        "Read-only. Returns the shop's orders with status `complete` or `cancelled` - the order history, "
+        "useful for reporting. Scoped to the shop in the path; you cannot read other shops' orders. "
+        "Results include customer names and totals, so treat them as personal data. Supports pagination "
+        "(`skip`/`limit`), filtering and sorting via the common query parameters; narrow before calling."
+    ),
 )
 def show_all_complete_orders_per_shop(
     shop_id: UUID,
     response: Response,
     common: dict = Depends(common_parameters),
-    current_user: CustomCognitoToken = Depends(auth_required),
+    principal: Any = Depends(auth_required_any),
 ) -> List[OrderSchema]:
     query = OrderTable.query.filter(OrderTable.shop_id == shop_id).filter(
         or_(OrderTable.status == "complete", OrderTable.status == "cancelled")

--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -349,7 +349,11 @@ def update(
     shop = get_shop(shop_id)
     raw = json.loads(shop.config) if isinstance(shop.config, str) else (shop.config or {})
     toggles = Toggles.model_validate(raw.get("toggles", {}) if isinstance(raw, dict) else {})
-    if toggles.force_unique_product_names and item_in.translation is not None and item_in.translation.main_name is not None:
+    if (
+        toggles.force_unique_product_names
+        and item_in.translation is not None
+        and item_in.translation.main_name is not None
+    ):
         _assert_unique_name(shop_id, item_in.translation.main_name, exclude_product_id=product_id)
 
     item_in.modified_at = datetime.now(timezone.utc)

--- a/server/api/endpoints/shop_endpoints/products.py
+++ b/server/api/endpoints/shop_endpoints/products.py
@@ -326,7 +326,12 @@ def create(
     tags=[AgentTag.EXPOSED],
     operation_id="update_product",
     summary="Update product",
-    description="Update an existing product's details, including name, description, pricing, stock, and feature flags.",
+    description=(
+        "Partially update a product. Send ONLY the fields you want to change; omitted fields are left "
+        "untouched. Names and descriptions live in the nested `translation` object and can also be sent "
+        "partially. `image_1`-`image_6` are S3 object filenames managed by the image-upload flow - do not "
+        "set them unless explicitly given a filename."
+    ),
 )
 def update(
     *,
@@ -344,7 +349,7 @@ def update(
     shop = get_shop(shop_id)
     raw = json.loads(shop.config) if isinstance(shop.config, str) else (shop.config or {})
     toggles = Toggles.model_validate(raw.get("toggles", {}) if isinstance(raw, dict) else {})
-    if toggles.force_unique_product_names:
+    if toggles.force_unique_product_names and item_in.translation is not None and item_in.translation.main_name is not None:
         _assert_unique_name(shop_id, item_in.translation.main_name, exclude_product_id=product_id)
 
     item_in.modified_at = datetime.now(timezone.utc)

--- a/server/crud/base.py
+++ b/server/crud/base.py
@@ -245,9 +245,9 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         #     if isinstance(v, int):
         #         update_data[k] = v
 
-        # Update translations
-        if "translation" in update_data:
-            translation_data = update_data.pop("translation")
+        # Update translations. An explicit `"translation": null` means "no
+        # translation change" (still popped so it doesn't hit the DB record loop).
+        if "translation" in update_data and (translation_data := update_data.pop("translation")) is not None:
             translation_name = db_obj.__class__.__name__.split("Table")[0]
             translation_model = globals().get(translation_name + "TranslationTable", None)
             translation = (

--- a/server/main.py
+++ b/server/main.py
@@ -74,7 +74,7 @@ async def lifespan(app_: FastAPI):
         yield
 
 
-APP_VERSION = "0.4.5"
+APP_VERSION = "0.4.6"
 
 # Assigned after the api_router is included if MCP_ENABLED. The lifespan
 # closure above references it.

--- a/server/main.py
+++ b/server/main.py
@@ -74,7 +74,7 @@ async def lifespan(app_: FastAPI):
         yield
 
 
-APP_VERSION = "0.4.4"
+APP_VERSION = "0.4.5"
 
 # Assigned after the api_router is included if MCP_ENABLED. The lifespan
 # closure above references it.

--- a/server/schemas/category.py
+++ b/server/schemas/category.py
@@ -36,9 +36,9 @@ class CategoryBase(BoilerplateBaseModel):
     icon: Optional[str] = None
     order_number: Optional[int] = None
     translation: CategoryTranslationBase
-    main_image: Union[Optional[dict], Optional[str]]
-    alt1_image: Union[Optional[dict], Optional[str]]
-    alt2_image: Union[Optional[dict], Optional[str]]
+    main_image: Union[Optional[dict], Optional[str]] = None
+    alt1_image: Union[Optional[dict], Optional[str]] = None
+    alt2_image: Union[Optional[dict], Optional[str]] = None
 
 
 # Properties to receive via API on creation
@@ -46,9 +46,18 @@ class CategoryCreate(CategoryBase):
     pass
 
 
-# Properties to receive via API on update
+class CategoryTranslationUpdate(CategoryTranslationBase):
+    main_name: Optional[str] = None
+    main_description: Optional[str] = None
+
+
+# Properties to receive via API on update. All fields are optional: the CRUD
+# layer updates with exclude_unset=True (PATCH semantics), so omitted fields
+# are left untouched.
 class CategoryUpdate(CategoryBase):
-    pass
+    shop_id: Optional[UUID] = None
+    color: Optional[str] = None
+    translation: Optional[CategoryTranslationUpdate] = None
 
 
 class CategoryInDBBase(CategoryBase):

--- a/server/schemas/product.py
+++ b/server/schemas/product.py
@@ -63,12 +63,12 @@ class ProductBase(BoilerplateBaseModel):
     order_number: Optional[int] = None
     stock: Optional[int] = 1
     sku: Optional[str] = None
-    image_1: Union[Optional[dict], Optional[str]]
-    image_2: Union[Optional[dict], Optional[str]]
-    image_3: Union[Optional[dict], Optional[str]]
-    image_4: Union[Optional[dict], Optional[str]]
-    image_5: Union[Optional[dict], Optional[str]]
-    image_6: Union[Optional[dict], Optional[str]]
+    image_1: Union[Optional[dict], Optional[str]] = None
+    image_2: Union[Optional[dict], Optional[str]] = None
+    image_3: Union[Optional[dict], Optional[str]] = None
+    image_4: Union[Optional[dict], Optional[str]] = None
+    image_5: Union[Optional[dict], Optional[str]] = None
+    image_6: Union[Optional[dict], Optional[str]] = None
     translation: ProductTranslationBase
 
 
@@ -77,8 +77,23 @@ class ProductCreate(ProductBase):
     pass
 
 
-# Properties to receive via API on update
+class ProductTranslationUpdate(ProductTranslationBase):
+    main_name: Optional[str] = None
+    main_description: Optional[str] = None
+    main_description_short: Optional[str] = None
+
+
+# Properties to receive via API on update. All fields are optional: the CRUD
+# layer updates with exclude_unset=True (PATCH semantics), so omitted fields
+# are left untouched.
 class ProductUpdate(ProductBase):
+    shop_id: Optional[UUID] = None
+    max_one: Optional[bool] = None
+    shippable: Optional[bool] = None
+    featured: Optional[bool] = None
+    new_product: Optional[bool] = None
+    tax_category: Optional[str] = None
+    translation: Optional[ProductTranslationUpdate] = None
     modified_at: Optional[datetime] = None
 
 

--- a/server/security.py
+++ b/server/security.py
@@ -10,7 +10,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Optional
+from typing import Any, List, Optional
+from uuid import UUID
 
 from fastapi import Header, HTTPException, Request, Security
 from fastapi.param_functions import Depends
@@ -105,6 +106,26 @@ async def auth_required_any(
     # No API key supplied (or API keys disabled) — defer to Cognito.
     token = await cognito_eu.auth_required(request)
     return auth_required(token)
+
+
+async def auth_required_any_for_shop(shop_id: UUID, principal: Any = Depends(auth_required_any)) -> Any:
+    """Like :func:`auth_required_any`, but binds an API-key principal to the shop in the path.
+
+    A per-shop ``sv_`` key is minted for exactly one shop, yet nothing else ties
+    it to the ``shop_id`` path param — so without this check a key for shop A
+    could read shop B's data by changing the path. Here we reject that (403).
+
+    Cognito principals are unaffected (shop access is resolved via group
+    membership elsewhere). Use this on ``auth_required_any`` routes that return
+    shop-scoped data — currently the read-only order tools. The broader CRUD
+    surface still relies on the path param alone; see acidjunk/shop-poc#135.
+    """
+    # Lazy import — avoids a models<->security import cycle.
+    from server.db.models import ApiKeyTable
+
+    if isinstance(principal, ApiKeyTable) and principal.shop_id != shop_id:
+        raise HTTPException(status_code=403, detail="API key is not valid for this shop")
+    return principal
 
 
 def admin_required(token: CognitoToken = Depends(auth_required)):

--- a/server/security.py
+++ b/server/security.py
@@ -108,6 +108,7 @@ async def auth_required_any(
     return auth_required(token)
 
 
+# TODO replace all auth_required_any where possible with this
 async def auth_required_any_for_shop(shop_id: UUID, principal: Any = Depends(auth_required_any)) -> Any:
     """Like :func:`auth_required_any`, but binds an API-key principal to the shop in the path.
 

--- a/server/security.py
+++ b/server/security.py
@@ -96,13 +96,13 @@ async def auth_required_any(
             if candidate.startswith(f"{KEY_PLAINTEXT_PREFIX}_"):
                 plaintext = candidate
 
-    if plaintext is not None and plaintext.startswith(f"{KEY_PLAINTEXT_PREFIX}_"):
+    if app_settings.API_KEYS_ENABLED and plaintext is not None and plaintext.startswith(f"{KEY_PLAINTEXT_PREFIX}_"):
         row = api_key_crud.lookup_by_plaintext(plaintext)
         if row is None:
             raise HTTPException(status_code=401, detail="Invalid API key")
         return row
 
-    # No API key supplied — defer to Cognito.
+    # No API key supplied (or API keys disabled) — defer to Cognito.
     token = await cognito_eu.auth_required(request)
     return auth_required(token)
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -83,10 +83,16 @@ class AppSettings(BaseSettings):
         "OPTIONS",
         "HEAD",
     ]
-    # "*" is acceptable only while allow_credentials is unset (defaults False) in
-    # main.py — with credentials enabled, wildcard headers/origins become unsafe.
-    # NOTE: CORS_ORIGINS also defaults to "*"; production must override it.
-    CORS_ALLOW_HEADERS: List[str] = ["*"]
+    # Todo: find correct header settings for upload of file with:
+    #  No 'Access-Control-Allow-Origin' header is present on the requested resource.
+    CORS_ALLOW_HEADERS: List[str] = [
+        "If-None-Match",
+        "Authorization",
+        "If-Match",
+        "Content-Type",
+        "Access-Control-Allow-Origin",
+    ]
+    # CORS_ALLOW_HEADERS: List[str] = ["*"]
 
     CORS_EXPOSE_HEADERS: List[str] = [
         "Cache-Control",

--- a/server/settings.py
+++ b/server/settings.py
@@ -43,9 +43,6 @@ class AppSettings(BaseSettings):
     # How many revisions to keep per entity (product/category). Pruned on write.
     # The PIM undo story assumes at least 10; values below that are ignored.
     REVISION_RETENTION: int = 25
-    # Deprecated — no longer read by order logic. Kept so existing .env files
-    # that still set it don't fail settings validation on startup.
-    ORDER_API_KEY: Optional[str] = None
     # Set to False to bypass sv_ API-key auth on auth_required_any routes
     # (falls back to Cognito). Intended for local development only.
     API_KEYS_ENABLED: bool = True

--- a/server/settings.py
+++ b/server/settings.py
@@ -43,6 +43,11 @@ class AppSettings(BaseSettings):
     # How many revisions to keep per entity (product/category). Pruned on write.
     # The PIM undo story assumes at least 10; values below that are ignored.
     REVISION_RETENTION: int = 25
+    # Deprecated — no longer read by order logic. Kept so existing .env files
+    # that still set it don't fail settings validation on startup.
+    ORDER_API_KEY: Optional[str] = None
+    # Set to False to bypass all API key auth (X-Order-Api-Key on orders + sv_ keys on CRUD).
+    API_KEYS_ENABLED: bool = True
     # SESSION_SECRET: str = "".join(secrets.choice(string.ascii_letters) for i in range(16))  # noqa: S311
     SESSION_SECRET: str = "CHANGEME"
 
@@ -80,16 +85,7 @@ class AppSettings(BaseSettings):
         "OPTIONS",
         "HEAD",
     ]
-    # Todo: find correct header settings for upload of file with:
-    #  No 'Access-Control-Allow-Origin' header is present on the requested resource.
-    CORS_ALLOW_HEADERS: List[str] = [
-        "If-None-Match",
-        "Authorization",
-        "If-Match",
-        "Content-Type",
-        "Access-Control-Allow-Origin",
-    ]
-    # CORS_ALLOW_HEADERS: List[str] = ["*"]
+    CORS_ALLOW_HEADERS: List[str] = ["*"]
 
     CORS_EXPOSE_HEADERS: List[str] = [
         "Cache-Control",

--- a/server/settings.py
+++ b/server/settings.py
@@ -46,7 +46,8 @@ class AppSettings(BaseSettings):
     # Deprecated — no longer read by order logic. Kept so existing .env files
     # that still set it don't fail settings validation on startup.
     ORDER_API_KEY: Optional[str] = None
-    # Set to False to bypass all API key auth (X-Order-Api-Key on orders + sv_ keys on CRUD).
+    # Set to False to bypass sv_ API-key auth on auth_required_any routes
+    # (falls back to Cognito). Intended for local development only.
     API_KEYS_ENABLED: bool = True
     # SESSION_SECRET: str = "".join(secrets.choice(string.ascii_letters) for i in range(16))  # noqa: S311
     SESSION_SECRET: str = "CHANGEME"
@@ -85,6 +86,9 @@ class AppSettings(BaseSettings):
         "OPTIONS",
         "HEAD",
     ]
+    # "*" is acceptable only while allow_credentials is unset (defaults False) in
+    # main.py — with credentials enabled, wildcard headers/origins become unsafe.
+    # NOTE: CORS_ORIGINS also defaults to "*"; production must override it.
     CORS_ALLOW_HEADERS: List[str] = ["*"]
 
     CORS_EXPOSE_HEADERS: List[str] = [

--- a/tests/unit_tests/api/test_categories.py
+++ b/tests/unit_tests/api/test_categories.py
@@ -58,6 +58,42 @@ def test_categories_update(shop, category, test_client):
     assert category.translation.alt1_name == None
 
 
+def test_categories_partial_update(shop, category, test_client):
+    before = CategoryTable.query.filter_by(id=category).first()
+    original_name = before.translation.main_name
+    original_color = before.color
+    original_main_image = before.main_image
+
+    body = {"translation": {"main_description": "Patched description"}}
+    response = test_client.put(f"/shops/{shop}/categories/{category}", content=json_dumps(body))
+    assert response.status_code == 201, f"full response: {response.json()}"
+
+    from server.db import db
+
+    db.session.expire_all()  # drop identity-map state loaded before the PUT
+    updated = CategoryTable.query.filter_by(id=category).first()
+    assert updated.translation.main_description == "Patched description"
+    assert updated.translation.main_name == original_name
+    assert updated.color == original_color
+    assert updated.main_image == original_main_image
+
+
+def test_categories_partial_update_without_translation(shop, category, test_client):
+    """A body without `translation` must leave the existing translation untouched."""
+    before = CategoryTable.query.filter_by(id=category).first()
+    original_name = before.translation.main_name
+
+    response = test_client.put(f"/shops/{shop}/categories/{category}", content=json_dumps({"color": "#123456"}))
+    assert response.status_code == 201, f"full response: {response.json()}"
+
+    from server.db import db
+
+    db.session.expire_all()
+    updated = CategoryTable.query.filter_by(id=category).first()
+    assert updated.color == "#123456"
+    assert updated.translation.main_name == original_name
+
+
 def test_categories_delete(shop, category, test_client):
     response = test_client.delete(f"/shops/{shop}/categories/{category}")
     assert response.status_code == 204

--- a/tests/unit_tests/api/test_orders.py
+++ b/tests/unit_tests/api/test_orders.py
@@ -1,5 +1,10 @@
-import pytest
+from uuid import uuid4
 
+import pytest
+from fastapi.testclient import TestClient
+
+from server.security import auth_required_any
+from tests.unit_tests.factories.api_key import make_api_key
 from tests.unit_tests.factories.categories import make_category
 from tests.unit_tests.factories.product import make_product
 from tests.unit_tests.factories.shop import make_shop_with_shipping
@@ -18,6 +23,50 @@ def test_orders_get_multi(shop, pending_order, test_client):
         info_total += order.get("shipping_fee_inc_btw") or 0
         # Total matches info total
         assert order["total"] == info_total
+
+
+# --- Read-only order tools exposed to MCP (list_pending_orders / list_complete_orders) ---
+
+
+def test_list_pending_orders_endpoint(shop, pending_order, test_client):
+    resp = test_client.get(f"/orders/shop/{shop}/pending")
+    assert resp.status_code == 200
+    orders = resp.json()
+    assert len(orders) == 1
+    assert orders[0]["status"] == "pending"
+
+
+def test_list_complete_orders_excludes_pending(shop, pending_order, test_client):
+    """A pending order must not appear in the complete/cancelled history feed."""
+    resp = test_client.get(f"/orders/shop/{shop}/complete")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_list_pending_orders_scoped_to_shop(shop, pending_order, test_client):
+    """A different shop_id in the path must not surface this shop's orders (no cross-tenant leak)."""
+    other_shop = uuid4()
+    resp = test_client.get(f"/orders/shop/{other_shop}/pending")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_list_pending_orders_opens_with_api_key(shop, pending_order, fastapi_app, monkeypatch):
+    """The read-only order tool is reachable with a per-shop API key (auth_required_any)."""
+    from server.settings import app_settings
+
+    # Force the dual-auth key path on regardless of the local .env dev toggle.
+    monkeypatch.setattr(app_settings, "API_KEYS_ENABLED", True)
+    override = fastapi_app.dependency_overrides.pop(auth_required_any, None)
+    try:
+        client = TestClient(fastapi_app)
+        _, plaintext = make_api_key(shop, name="orders-reader")
+        resp = client.get(f"/orders/shop/{shop}/pending", headers={"X-API-Key": plaintext})
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()) == 1
+    finally:
+        if override is not None:
+            fastapi_app.dependency_overrides[auth_required_any] = override
 
 
 @pytest.fixture()

--- a/tests/unit_tests/api/test_orders.py
+++ b/tests/unit_tests/api/test_orders.py
@@ -56,17 +56,12 @@ def test_list_pending_orders_filters_by_path_shop(shop, pending_order, test_clie
     assert resp.json() == []
 
 
-@pytest.mark.xfail(
-    reason="acidjunk/shop-poc#135: auth_required_any does not bind the API key's shop_id "
-    "to the path shop_id, so a foreign key can read another shop's orders (PII). "
-    "Remove this marker once the dependency enforces the match.",
-    strict=True,
-)
 def test_list_pending_orders_rejects_foreign_api_key(shop, pending_order, fastapi_app, monkeypatch):
     """An API key minted for shop A must NOT read shop B's orders (cross-tenant PII).
 
-    The assertion below is the target contract; it currently fails because the
-    key is not scoped to the path shop. Tracked in acidjunk/shop-poc#135.
+    Enforced by ``auth_required_any_for_shop``, which binds an API-key principal
+    to the shop in the path. (The broader CRUD surface is still tracked in
+    acidjunk/shop-poc#135.)
     """
     from server.settings import app_settings
 

--- a/tests/unit_tests/api/test_orders.py
+++ b/tests/unit_tests/api/test_orders.py
@@ -43,12 +43,44 @@ def test_list_complete_orders_excludes_pending(shop, pending_order, test_client)
     assert resp.json() == []
 
 
-def test_list_pending_orders_scoped_to_shop(shop, pending_order, test_client):
-    """A different shop_id in the path must not surface this shop's orders (no cross-tenant leak)."""
+def test_list_pending_orders_filters_by_path_shop(shop, pending_order, test_client):
+    """Results are filtered by the path shop_id: another shop's path returns no rows.
+
+    NOTE: this only proves the query filter, not caller authorization. Whether a
+    caller is *allowed* to read the shop in the path is covered by
+    ``test_list_pending_orders_rejects_foreign_api_key`` below.
+    """
     other_shop = uuid4()
     resp = test_client.get(f"/orders/shop/{other_shop}/pending")
     assert resp.status_code == 200
     assert resp.json() == []
+
+
+@pytest.mark.xfail(
+    reason="acidjunk/shop-poc#135: auth_required_any does not bind the API key's shop_id "
+    "to the path shop_id, so a foreign key can read another shop's orders (PII). "
+    "Remove this marker once the dependency enforces the match.",
+    strict=True,
+)
+def test_list_pending_orders_rejects_foreign_api_key(shop, pending_order, fastapi_app, monkeypatch):
+    """An API key minted for shop A must NOT read shop B's orders (cross-tenant PII).
+
+    The assertion below is the target contract; it currently fails because the
+    key is not scoped to the path shop. Tracked in acidjunk/shop-poc#135.
+    """
+    from server.settings import app_settings
+
+    monkeypatch.setattr(app_settings, "API_KEYS_ENABLED", True)
+    other_shop = make_shop_with_shipping()
+    override = fastapi_app.dependency_overrides.pop(auth_required_any, None)
+    try:
+        client = TestClient(fastapi_app)
+        _, plaintext = make_api_key(other_shop, name="foreign-reader")
+        resp = client.get(f"/orders/shop/{shop}/pending", headers={"X-API-Key": plaintext})
+        assert resp.status_code == 403, resp.text
+    finally:
+        if override is not None:
+            fastapi_app.dependency_overrides[auth_required_any] = override
 
 
 def test_list_pending_orders_opens_with_api_key(shop, pending_order, fastapi_app, monkeypatch):

--- a/tests/unit_tests/api/test_products.py
+++ b/tests/unit_tests/api/test_products.py
@@ -118,9 +118,7 @@ def test_products_partial_update_without_translation(shop_with_config, product, 
     flag_modified(shop, "config")
     db.session.commit()
 
-    response = test_client.put(
-        f"/shops/{shop_with_config}/products/{product}", content=json_dumps({"stock": 42})
-    )
+    response = test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps({"stock": 42}))
     assert response.status_code == 201, f"full response: {response.json()}"
     updated = ProductTable.query.filter_by(id=product).first()
     assert updated.stock == 42

--- a/tests/unit_tests/api/test_products.py
+++ b/tests/unit_tests/api/test_products.py
@@ -80,6 +80,52 @@ def test_products_update(shop_with_config, product, category, test_client):
     assert product.translation.alt1_name == None
 
 
+def test_products_partial_update(shop_with_config, product, test_client):
+    before = ProductTable.query.filter_by(id=product).first()
+    original_name = before.translation.main_name
+    original_category_id = before.category_id
+    original_price = before.price
+    original_image_1 = before.image_1
+
+    body = {"translation": {"main_description_short": "Patched short description"}}
+    response = test_client.put(f"/shops/{shop_with_config}/products/{product}", content=json_dumps(body))
+    assert response.status_code == 201, f"full response: {response.json()}"
+
+    from server.db import db
+
+    db.session.expire_all()  # drop identity-map state loaded before the PUT
+    updated = ProductTable.query.filter_by(id=product).first()
+    assert updated.translation.main_description_short == "Patched short description"
+    assert updated.translation.main_name == original_name
+    assert updated.category_id == original_category_id
+    assert updated.price == original_price
+    assert updated.image_1 == original_image_1
+
+
+def test_products_partial_update_without_translation(shop_with_config, product, test_client):
+    """A body without `translation` must work even with force_unique_product_names enabled."""
+    import copy
+    import json
+
+    from sqlalchemy.orm.attributes import flag_modified
+
+    from server.db import ShopTable, db
+
+    shop = ShopTable.query.filter_by(id=shop_with_config).first()
+    config = json.loads(shop.config) if isinstance(shop.config, str) else copy.deepcopy(shop.config)
+    config["toggles"]["force_unique_product_names"] = True
+    shop.config = config
+    flag_modified(shop, "config")
+    db.session.commit()
+
+    response = test_client.put(
+        f"/shops/{shop_with_config}/products/{product}", content=json_dumps({"stock": 42})
+    )
+    assert response.status_code == 201, f"full response: {response.json()}"
+    updated = ProductTable.query.filter_by(id=product).first()
+    assert updated.stock == 42
+
+
 def test_products_delete(shop_with_config, product, test_client):
     response = test_client.delete(f"/shops/{shop_with_config}/products/{product}")
     assert response.status_code == 204

--- a/tests/unit_tests/mcp/test_mcp.py
+++ b/tests/unit_tests/mcp/test_mcp.py
@@ -100,11 +100,7 @@ def test_fastmcp_introspects_all_expected_tools(fastapi_app: FastAPI) -> None:
     from fastmcp import FastMCP
 
     from server.mcp.server import mount_mcp  # noqa: F401 — sanity import
-
-    try:
-        from fastmcp.server.openapi import MCPType, RouteMap
-    except ImportError:  # pragma: no cover — older fastmcp module path
-        from fastmcp.server.providers.openapi import MCPType, RouteMap  # type: ignore[no-redef]
+    from fastmcp.server.openapi import MCPType, RouteMap
 
     mcp = FastMCP.from_fastapi(
         app=fastapi_app,
@@ -131,11 +127,7 @@ def test_update_product_tool_has_no_required_body_fields(fastapi_app: FastAPI) -
     """
     pytest.importorskip("fastmcp")
     from fastmcp import FastMCP
-
-    try:
-        from fastmcp.server.openapi import MCPType, RouteMap
-    except ImportError:  # pragma: no cover — older fastmcp module path
-        from fastmcp.server.providers.openapi import MCPType, RouteMap  # type: ignore[no-redef]
+    from fastmcp.server.openapi import MCPType, RouteMap
 
     mcp = FastMCP.from_fastapi(
         app=fastapi_app,
@@ -163,11 +155,7 @@ def test_update_category_tool_has_no_required_body_fields(fastapi_app: FastAPI) 
     """
     pytest.importorskip("fastmcp")
     from fastmcp import FastMCP
-
-    try:
-        from fastmcp.server.openapi import MCPType, RouteMap
-    except ImportError:  # pragma: no cover — older fastmcp module path
-        from fastmcp.server.providers.openapi import MCPType, RouteMap  # type: ignore[no-redef]
+    from fastmcp.server.openapi import MCPType, RouteMap
 
     mcp = FastMCP.from_fastapi(
         app=fastapi_app,

--- a/tests/unit_tests/mcp/test_mcp.py
+++ b/tests/unit_tests/mcp/test_mcp.py
@@ -98,9 +98,9 @@ def test_fastmcp_introspects_all_expected_tools(fastapi_app: FastAPI) -> None:
     """``FastMCP.from_fastapi`` produces exactly the expected tools from the tagged routes."""
     pytest.importorskip("fastmcp")
     from fastmcp import FastMCP
+    from fastmcp.server.openapi import MCPType, RouteMap
 
     from server.mcp.server import mount_mcp  # noqa: F401 — sanity import
-    from fastmcp.server.openapi import MCPType, RouteMap
 
     mcp = FastMCP.from_fastapi(
         app=fastapi_app,

--- a/tests/unit_tests/mcp/test_mcp.py
+++ b/tests/unit_tests/mcp/test_mcp.py
@@ -150,6 +150,38 @@ def test_update_product_tool_has_no_required_body_fields(fastapi_app: FastAPI) -
     assert "translation" not in required, f"translation still required: {required}"
 
 
+def test_update_category_tool_has_no_required_body_fields(fastapi_app: FastAPI) -> None:
+    """The update_category tool must not force the LLM to send the full category.
+
+    Same failure mode as update_product: required main_image/alt1_image/alt2_image
+    fields made the model emit `"alt2_image": null` for empty slots, which triggered
+    malformed streamed tool JSON under Anthropic's fine-grained-tool-streaming beta.
+    Only the path params may be required.
+    """
+    pytest.importorskip("fastmcp")
+    from fastmcp import FastMCP
+
+    try:
+        from fastmcp.server.openapi import MCPType, RouteMap
+    except ImportError:  # pragma: no cover — older fastmcp module path
+        from fastmcp.server.providers.openapi import MCPType, RouteMap  # type: ignore[no-redef]
+
+    mcp = FastMCP.from_fastapi(
+        app=fastapi_app,
+        name="shopvirge-mcp-test",
+        route_maps=[
+            RouteMap(tags={AgentTag.EXPOSED.value}, mcp_type=MCPType.TOOL),
+            RouteMap(mcp_type=MCPType.EXCLUDE),
+        ],
+    )
+
+    tools = asyncio.run(mcp.get_tools())
+    schema = tools["update_category"].parameters
+    required = set(schema.get("required", []))
+    assert not any(r.endswith("_image") for r in required), f"image fields still required: {required}"
+    assert "translation" not in required, f"translation still required: {required}"
+
+
 def test_mount_mcp_is_importable() -> None:
     """The mount_mcp helper imports cleanly (catches dotted-path drift in fastmcp)."""
     pytest.importorskip("fastmcp")

--- a/tests/unit_tests/mcp/test_mcp.py
+++ b/tests/unit_tests/mcp/test_mcp.py
@@ -119,6 +119,37 @@ def test_fastmcp_introspects_all_expected_tools(fastapi_app: FastAPI) -> None:
     ), f"missing: {EXPECTED_TOOL_NAMES - tool_names}, extra: {tool_names - EXPECTED_TOOL_NAMES}"
 
 
+def test_update_product_tool_has_no_required_body_fields(fastapi_app: FastAPI) -> None:
+    """The update_product tool must not force the LLM to send the full product.
+
+    Required image_1..image_6 fields made the model emit `"image_6": null` for
+    empty slots, which triggered malformed streamed tool JSON under Anthropic's
+    fine-grained-tool-streaming beta. Only the path params may be required.
+    """
+    pytest.importorskip("fastmcp")
+    from fastmcp import FastMCP
+
+    try:
+        from fastmcp.server.openapi import MCPType, RouteMap
+    except ImportError:  # pragma: no cover — older fastmcp module path
+        from fastmcp.server.providers.openapi import MCPType, RouteMap  # type: ignore[no-redef]
+
+    mcp = FastMCP.from_fastapi(
+        app=fastapi_app,
+        name="shopvirge-mcp-test",
+        route_maps=[
+            RouteMap(tags={AgentTag.EXPOSED.value}, mcp_type=MCPType.TOOL),
+            RouteMap(mcp_type=MCPType.EXCLUDE),
+        ],
+    )
+
+    tools = asyncio.run(mcp.get_tools())
+    schema = tools["update_product"].parameters
+    required = set(schema.get("required", []))
+    assert not any(r.startswith("image_") for r in required), f"image fields still required: {required}"
+    assert "translation" not in required, f"translation still required: {required}"
+
+
 def test_mount_mcp_is_importable() -> None:
     """The mount_mcp helper imports cleanly (catches dotted-path drift in fastmcp)."""
     pytest.importorskip("fastmcp")

--- a/tests/unit_tests/mcp/test_mcp.py
+++ b/tests/unit_tests/mcp/test_mcp.py
@@ -67,6 +67,9 @@ EXPECTED_TOOL_NAMES = {
     "restore_attribute",
     # shops
     "list_my_shops",
+    # orders (read-only)
+    "list_pending_orders",
+    "list_complete_orders",
 }
 
 

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -3339,12 +3339,6 @@
           "featured",
           "new_product",
           "tax_category",
-          "image_1",
-          "image_2",
-          "image_3",
-          "image_4",
-          "image_5",
-          "image_6",
           "translation"
         ],
         "title": "ProductCreate",
@@ -3801,6 +3795,111 @@
         "title": "ProductTranslationBase",
         "type": "object"
       },
+      "ProductTranslationUpdate": {
+        "properties": {
+          "alt1_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt1 Description"
+          },
+          "alt1_description_short": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt1 Description Short"
+          },
+          "alt1_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt1 Name"
+          },
+          "alt2_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt2 Description"
+          },
+          "alt2_description_short": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt2 Description Short"
+          },
+          "alt2_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt2 Name"
+          },
+          "main_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Description"
+          },
+          "main_description_short": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Description Short"
+          },
+          "main_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Name"
+          }
+        },
+        "title": "ProductTranslationUpdate",
+        "type": "object"
+      },
       "ProductUpdate": {
         "properties": {
           "category_id": {
@@ -3866,8 +3965,15 @@
             "title": "Discounted To"
           },
           "featured": {
-            "title": "Featured",
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Featured"
           },
           "image_1": {
             "anyOf": [
@@ -3960,8 +4066,15 @@
             "title": "Image 6"
           },
           "max_one": {
-            "title": "Max One",
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max One"
           },
           "modified_at": {
             "anyOf": [
@@ -3976,8 +4089,15 @@
             "title": "Modified At"
           },
           "new_product": {
-            "title": "New Product",
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "New Product"
           },
           "order_number": {
             "anyOf": [
@@ -4036,13 +4156,27 @@
             "title": "Recurring Price Yearly"
           },
           "shippable": {
-            "title": "Shippable",
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shippable"
           },
           "shop_id": {
-            "format": "uuid",
-            "title": "Shop Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shop Id"
           },
           "sku": {
             "anyOf": [
@@ -4068,28 +4202,27 @@
             "title": "Stock"
           },
           "tax_category": {
-            "title": "Tax Category",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tax Category"
           },
           "translation": {
-            "$ref": "#/components/schemas/ProductTranslationBase"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProductTranslationUpdate"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
-        "required": [
-          "shop_id",
-          "max_one",
-          "shippable",
-          "featured",
-          "new_product",
-          "tax_category",
-          "image_1",
-          "image_2",
-          "image_3",
-          "image_4",
-          "image_5",
-          "image_6",
-          "translation"
-        ],
         "title": "ProductUpdate",
         "type": "object"
       },
@@ -4423,12 +4556,6 @@
           "featured",
           "new_product",
           "tax_category",
-          "image_1",
-          "image_2",
-          "image_3",
-          "image_4",
-          "image_5",
-          "image_6",
           "translation",
           "id"
         ],
@@ -4742,12 +4869,6 @@
           "featured",
           "new_product",
           "tax_category",
-          "image_1",
-          "image_2",
-          "image_3",
-          "image_4",
-          "image_5",
-          "image_6",
           "translation",
           "id"
         ],
@@ -6084,7 +6205,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.4.4"
+    "version": "0.4.5"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -13649,7 +13770,7 @@
         ]
       },
       "put": {
-        "description": "Update an existing product's details, including name, description, pricing, stock, and feature flags.",
+        "description": "Partially update a product. Send ONLY the fields you want to change; omitted fields are left untouched. Names and descriptions live in the nested `translation` object and can also be sent partially. `image_1`-`image_6` are S3 object filenames managed by the image-upload flow - do not set them unless explicitly given a filename.",
         "operationId": "update_product",
         "parameters": [
           {

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -7867,8 +7867,8 @@
     },
     "/orders/shop/{shop_id}/complete": {
       "get": {
-        "description": "Returns all orders with status `complete` or `cancelled` for the given shop. Used for order history and reporting.",
-        "operationId": "show_all_complete_orders_per_shop_orders_shop__shop_id__complete_get",
+        "description": "Read-only. Returns the shop's orders with status `complete` or `cancelled` - the order history, useful for reporting. Scoped to the shop in the path; you cannot read other shops' orders. Results include customer names and totals, so treat them as personal data. Supports pagination (`skip`/`limit`), filtering and sorting via the common query parameters; narrow before calling.",
+        "operationId": "list_complete_orders",
         "parameters": [
           {
             "in": "path",
@@ -7927,6 +7927,22 @@
               "title": "Sort",
               "type": "array"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
           }
         ],
         "responses": {
@@ -7937,7 +7953,7 @@
                   "items": {
                     "$ref": "#/components/schemas/OrderSchema"
                   },
-                  "title": "Response Show All Complete Orders Per Shop Orders Shop  Shop Id  Complete Get",
+                  "title": "Response List Complete Orders",
                   "type": "array"
                 }
               }
@@ -7955,21 +7971,18 @@
             "description": "Validation Error"
           }
         },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
         "summary": "List completed orders for a shop",
         "tags": [
-          "orders"
+          "orders",
+          "agent-exposed",
+          "agent-large"
         ]
       }
     },
     "/orders/shop/{shop_id}/pending": {
       "get": {
-        "description": "Returns all orders with status `pending` for the given shop. These are orders awaiting fulfilment.",
-        "operationId": "show_all_pending_orders_per_shop_orders_shop__shop_id__pending_get",
+        "description": "Read-only. Returns the shop's orders with status `pending` - orders awaiting fulfilment. Scoped to the shop in the path; you cannot read other shops' orders. Results include customer names and totals, so treat them as personal data. Supports pagination (`skip`/`limit`), filtering and sorting via the common query parameters; narrow before calling on busy shops.",
+        "operationId": "list_pending_orders",
         "parameters": [
           {
             "in": "path",
@@ -8028,6 +8041,22 @@
               "title": "Sort",
               "type": "array"
             }
+          },
+          {
+            "in": "header",
+            "name": "X-API-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
           }
         ],
         "responses": {
@@ -8038,7 +8067,7 @@
                   "items": {
                     "$ref": "#/components/schemas/OrderSchema"
                   },
-                  "title": "Response Show All Pending Orders Per Shop Orders Shop  Shop Id  Pending Get",
+                  "title": "Response List Pending Orders",
                   "type": "array"
                 }
               }
@@ -8056,14 +8085,11 @@
             "description": "Validation Error"
           }
         },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
         "summary": "List pending orders for a shop",
         "tags": [
-          "orders"
+          "orders",
+          "agent-exposed",
+          "agent-large"
         ]
       }
     },

--- a/tests/unit_tests/openapi_snapshot.json
+++ b/tests/unit_tests/openapi_snapshot.json
@@ -741,10 +741,7 @@
         "required": [
           "shop_id",
           "color",
-          "translation",
-          "main_image",
-          "alt1_image",
-          "alt2_image"
+          "translation"
         ],
         "title": "CategoryCreate",
         "type": "object"
@@ -853,9 +850,6 @@
           "shop_id",
           "color",
           "translation",
-          "main_image",
-          "alt1_image",
-          "alt2_image",
           "id"
         ],
         "title": "CategorySchema",
@@ -923,6 +917,78 @@
         "title": "CategoryTranslationBase",
         "type": "object"
       },
+      "CategoryTranslationUpdate": {
+        "properties": {
+          "alt1_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt1 Description"
+          },
+          "alt1_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt1 Name"
+          },
+          "alt2_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt2 Description"
+          },
+          "alt2_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alt2 Name"
+          },
+          "main_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Description"
+          },
+          "main_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Name"
+          }
+        },
+        "title": "CategoryTranslationUpdate",
+        "type": "object"
+      },
       "CategoryUpdate": {
         "properties": {
           "alt1_image": {
@@ -956,8 +1022,15 @@
             "title": "Alt2 Image"
           },
           "color": {
-            "title": "Color",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Color"
           },
           "icon": {
             "anyOf": [
@@ -997,22 +1070,28 @@
             "title": "Order Number"
           },
           "shop_id": {
-            "format": "uuid",
-            "title": "Shop Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shop Id"
           },
           "translation": {
-            "$ref": "#/components/schemas/CategoryTranslationBase"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CategoryTranslationUpdate"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
-        "required": [
-          "shop_id",
-          "color",
-          "translation",
-          "main_image",
-          "alt1_image",
-          "alt2_image"
-        ],
         "title": "CategoryUpdate",
         "type": "object"
       },
@@ -6205,7 +6284,7 @@
   "info": {
     "description": "Backend for ShopVirge Shops.",
     "title": "ShopVirge API",
-    "version": "0.4.5"
+    "version": "0.4.6"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -11710,7 +11789,7 @@
         ]
       },
       "put": {
-        "description": "Update an existing category's details and translations.",
+        "description": "Partially update a category. Send ONLY the fields you want to change; omitted fields are left untouched. Names and descriptions live in the nested `translation` object and can also be sent partially. `main_image`, `alt1_image` and `alt2_image` are S3 object filenames managed by the image-upload flow - do not set them unless explicitly given a filename.",
         "operationId": "update_category",
         "parameters": [
           {


### PR DESCRIPTION
## Summary

Two MCP improvements plus a security fix for the new tools.

1. **`update_category` → true partial update (PATCH).** Mirrors the `update_product` fix: `CategoryBase` image fields (`main_image`/`alt1_image`/`alt2_image`) default to `None`; new `CategoryTranslationUpdate`; `CategoryUpdate` is all-optional; the tool description documents PATCH semantics and warns agents off the S3-managed image fields. This removes the required-field null-emission that broke streamed LLM tool JSON.
2. **Order reads exposed to MCP (read-only).** `list_pending_orders` (`GET /orders/shop/{shop_id}/pending`) and `list_complete_orders` (`GET /orders/shop/{shop_id}/complete`), tagged `EXPOSED`+`LARGE`. Order **writes** (create/update/patch/delete) stay REST-only. Decision: read-only *tools*, not resources (resource support is weak in LibreChat, the main agent client).
3. **Cross-tenant scoping fix for the order tools.** New `auth_required_any_for_shop` dependency binds an API-key principal to the shop in the path — a `sv_` key minted for shop A now gets `403` on shop B's path instead of reading its orders (customer names + totals). Cognito principals are unaffected.

`APP_VERSION` bumped to 0.4.6; `openapi_snapshot.json` + `EXPECTED_TOOL_NAMES` updated.

## Security note

`auth_required_any` returned the API-key row but never checked it against the path `shop_id`. This PR fixes that **for the order tools only**. The same gap still exists on the broader `auth_required_any` CRUD surface (products/categories/tags/attributes/…), tracked in **acidjunk/shop-poc#135** — the new dependency is ready to be reused there.

## Test plan

- [x] `pytest tests/unit_tests/api/test_orders.py` — includes `test_list_pending_orders_rejects_foreign_api_key` (foreign API key → 403) and partial-update coverage
- [x] `pytest tests/unit_tests/mcp/test_mcp.py` — tool introspection guard (new tool names)
- [x] `pytest tests/unit_tests/test_openapi_version.py` — OpenAPI drift guard
- [x] isort + black

## Reviewer notes

- **Base is `main`, not stacked on #132**, so this diff also carries #132's commits (`update_product` partial, the API-key-bypass + CORS-loosen change). Retarget/rebase once #132 merges.
- CORS `allow_headers` was loosened to `["*"]` — safe only while `allow_credentials` stays unset (it does); `CORS_ORIGINS` defaults to `"*"` and must be overridden in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)